### PR TITLE
Merge release/2026.08 into develop (alpha6 follow-ups)

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -40,10 +40,16 @@ on:
         required: true
         type: string
 
-# Per-tag serialization: a retry racing the original run would upload the
-# same asset names concurrently.
+# ONE GLOBAL group (not per-tag): this workflow now publishes the release and
+# makes the latest-pointer decision, which reads the set of already-published
+# stable releases. Two releases finalizing concurrently could each query while
+# the other is still a draft and both claim --latest, letting the one that
+# publishes last win even if it is older. Global serialization removes that
+# race; it also still prevents a retry racing the original run (which would
+# upload the same asset names at once). Releases are rare and deliberate, so
+# serializing all deb builds costs nothing.
 concurrency:
-  group: deb-packages-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+  group: deb-packages
   cancel-in-progress: false
 
 permissions:
@@ -123,11 +129,20 @@ jobs:
           draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
           debs=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
             --jq '[.assets[].name | select(endswith(".deb"))] | length' 2>/dev/null || echo 0)
-          if [ "$draft" = "false" ] && [ "${debs:-0}" -ge 2 ]; then
+          if [ "$draft" = "true" ] || [ -z "$draft" ]; then
+            # Draft (or no release yet): proceed to build, attach, and publish.
+            echo "SKIP=false" >> "$GITHUB_ENV"
+          elif [ "${debs:-0}" -ge 2 ]; then
+            # Fully finalized: published with its .debs. Nothing to do (and a
+            # re-upload would 422 against the immutable release).
             echo "Release $RELEASE_TAG is already published with its .deb assets; nothing to do."
             echo "SKIP=true" >> "$GITHUB_ENV"
           else
-            echo "SKIP=false" >> "$GITHUB_ENV"
+            # Published but missing .debs: an immutable release cannot accept
+            # new assets, so this can never be completed. Fail fast and loud
+            # rather than dying later on an opaque HTTP 422 from the upload.
+            echo "::error::Release $RELEASE_TAG is already published but has no .deb assets. Immutable releases cannot accept new assets, so the .debs cannot be attached. This release is permanently WAR-only; ship the .debs with the next release."
+            exit 1
           fi
 
       - name: Download and verify the release WAR

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -1,20 +1,23 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2026 CARLOS Contributors
 #
-# Build and publish the Debian packages (carlos-emr, carlos-emr-drugref) as
-# assets of a CARLOS release.
+# Build the Debian packages (carlos-emr, carlos-emr-drugref), attach them to
+# the release, and PUBLISH the release as the final step.
 #
-# DESIGN — deliberately a SEPARATE workflow from publish-release.yml, running
-# after the release is published, rather than a job spliced into that
-# carefully-serialized pipeline:
+# DESIGN — a SEPARATE workflow from publish-release.yml, but it FINALIZES the
+# release: publish-release.yml leaves the release as a DRAFT carrying the WAR +
+# SBOM, and this workflow downloads that WAR, builds the .debs, attaches them,
+# and only then flips the release to published. The order matters because the
+# repository enables immutable releases — assets cannot be added once a release
+# is published, so every asset (WAR, SBOM, both .debs) must be in place while it
+# is still a draft.
 #
-#   * The deb ships the release's OWN published WAR, downloaded from the
-#     release and verified against its .sha256 — the same bytes the WAR
-#     attestation covers, with no second Maven compile that could drift.
-#     That is only possible after the WAR asset exists, i.e. post-publish.
-#   * A failure here can never wedge or roll back the release itself; the
-#     workflow_dispatch input exists to retry (or backfill an older release)
-#     without touching the release pipeline.
+#   * The deb ships the release's OWN WAR, downloaded from the draft and
+#     verified against its .sha256 and provenance attestation — the same bytes,
+#     with no second Maven compile that could drift.
+#   * If this workflow fails, the release simply stays a draft (nothing is
+#     half-published); the workflow_dispatch input re-runs it to finish the job
+#     (or to backfill an older release).
 #
 # The build runs inside an ubuntu:26.04 container so the toolchain and the
 # runtime dependency versions are exactly the target distribution's,
@@ -110,11 +113,29 @@ jobs:
             exit 1
           fi
 
-      - name: Download and verify the release WAR
+      - name: Skip if the release is already finalized
         run: |
           set -euo pipefail
-          # The deb ships the exact WAR the release published: the .sha256
-          # catches corrupt/partial downloads, and the attestation check
+          # A completed release is published (non-draft) AND already carries the
+          # two .deb assets. Immutable releases forbid re-uploading, so a re-run
+          # against a finished release would 422 — detect that and stop cleanly.
+          # Uses gh's built-in --jq (system jq is not installed in the image).
+          draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
+          debs=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
+            --jq '[.assets[].name | select(endswith(".deb"))] | length' 2>/dev/null || echo 0)
+          if [ "$draft" = "false" ] && [ "${debs:-0}" -ge 2 ]; then
+            echo "Release $RELEASE_TAG is already published with its .deb assets; nothing to do."
+            echo "SKIP=true" >> "$GITHUB_ENV"
+          else
+            echo "SKIP=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download and verify the release WAR
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          # The deb ships the exact WAR the release carries (still a draft):
+          # the .sha256 catches corrupt/partial downloads, and the attestation check
           # below is what makes the stronger claim true — a swapped WAR
           # (even one with a matching swapped .sha256) fails provenance
           # verification and never becomes a package payload.
@@ -132,6 +153,7 @@ jobs:
           echo "CARLOS_WAR=/tmp/release-war/carlos-$RELEASE_TAG.war" >> "$GITHUB_ENV"
 
       - name: Stamp the package version from the release tag
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           # CalVer tag -> Debian version. Pre-release suffixes swap '-' for
@@ -162,6 +184,7 @@ jobs:
           echo "DEB_VERSION=$deb_version" >> "$GITHUB_ENV"
 
       - name: Build the packages
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           # CARLOS_WAR skips the in-tree Maven compile; DrugRef builds from
@@ -178,6 +201,7 @@ jobs:
           ls -la
 
       - name: Lintian gate
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           # Errors fail the build. The overrides files in debian/ carry the
@@ -185,12 +209,14 @@ jobs:
           lintian --fail-on error ../carlos-emr_*.changes
 
       - name: Attest package provenance
+        if: env.SKIP != 'true'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             release-assets/*.deb
 
       - name: Upload and verify the release assets
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           gh release upload "$RELEASE_TAG" release-assets/* --repo "$REPO" --clobber
@@ -210,3 +236,39 @@ jobs:
             fi
           done
           echo "Published: $(cd release-assets && ls *.deb | tr '\n' ' ')"
+
+      - name: Publish the release
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          # Every asset (WAR, SBOM, both .debs) is now attached to the draft.
+          # Flip it to published — this is the point the release becomes
+          # immutable. The latest-pointer decision lives here (not in
+          # publish-release.yml) because the release is only published once all
+          # assets, including these .debs, are in place.
+          prerelease=false
+          if [[ "$RELEASE_TAG" =~ -(alpha|beta|rc)[1-9][0-9]*$ ]]; then
+            prerelease=true
+          fi
+          release_line=$(sed -E 's/^([0-9]{4}\.[0-9]{2})\..*$/\1/' <<< "$RELEASE_TAG")
+
+          if [ "$prerelease" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false
+          else
+            # A maintenance patch published from an OLDER release line must not
+            # steal the repo's "latest release" pointer from a newer train:
+            # mark latest only when this tag tops every published stable
+            # release under the CalVer numeric sort. Paginated so a fixed
+            # --limit cannot miss the newest stable release once the repo grows.
+            latest_flag=--latest
+            existing=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name')
+            top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
+              | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+            if [ "$top" != "$RELEASE_TAG" ]; then
+              latest_flag=--latest=false
+              echo "A newer stable release ($top) is already published — not marking $RELEASE_TAG as latest."
+            fi
+            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false "$latest_flag"
+          fi
+          echo "Published release $RELEASE_TAG with WAR, SBOM, and .deb assets."

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -126,16 +126,20 @@ jobs:
           # two .deb assets. Immutable releases forbid re-uploading, so a re-run
           # against a finished release would 422 — detect that and stop cleanly.
           # Uses gh's built-in --jq (system jq is not installed in the image).
+          # GitHub normalises stored asset names (the Debian '~' becomes '.'),
+          # so match by package-name prefix, not the exact filename.
           draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
-          debs=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
-            --jq '[.assets[].name | select(endswith(".deb"))] | length' 2>/dev/null || echo 0)
+          emr=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
+            --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
+          drugref=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
+            --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
           if [ "$draft" = "true" ] || [ -z "$draft" ]; then
             # Draft (or no release yet): proceed to build, attach, and publish.
             echo "SKIP=false" >> "$GITHUB_ENV"
-          elif [ "${debs:-0}" -ge 2 ]; then
+          elif [ "${emr:-0}" -ge 1 ] && [ "${drugref:-0}" -ge 1 ]; then
             # Fully finalized: published with its .debs. Nothing to do (and a
             # re-upload would 422 against the immutable release).
-            echo "Release $RELEASE_TAG is already published with its .deb assets; nothing to do."
+            echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
             echo "SKIP=true" >> "$GITHUB_ENV"
           else
             # Published but missing .debs: an immutable release cannot accept
@@ -265,7 +269,6 @@ jobs:
           if [[ "$RELEASE_TAG" =~ -(alpha|beta|rc)[1-9][0-9]*$ ]]; then
             prerelease=true
           fi
-          release_line=$(sed -E 's/^([0-9]{4}\.[0-9]{2})\..*$/\1/' <<< "$RELEASE_TAG")
 
           if [ "$prerelease" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,12 +11,12 @@ on:
         required: true
         type: string
 
-# One GLOBAL group (not per-tag): the publish step's latest-pointer decision
-# reads the set of already-published stable releases, so two stable tags
-# publishing concurrently could each miss the other (still a draft at query
-# time) and both claim --latest. Releases are rare and deliberate — strict
-# serialization costs nothing and removes the race; same-tag re-runs still
-# queue exactly as before.
+# One GLOBAL group (not per-tag): the release-notes "previous tag" lookup and
+# the draft bookkeeping read the set of existing releases, so serializing all
+# release runs keeps that state consistent. Releases are rare and deliberate —
+# strict serialization costs nothing; same-tag re-runs still queue as before.
+# (The final publish + latest-pointer decision now happens in deb-packages.yml,
+# after the .debs are attached.)
 concurrency:
   group: publish-release
   cancel-in-progress: false
@@ -197,7 +197,7 @@ jobs:
       ref: refs/tags/${{ needs.validate.outputs.tag }}
 
   package-and-publish:
-    name: Package and publish immutable release
+    name: Package release draft and dispatch deb build
     needs: [validate, full-check]
     if: always() && needs.validate.outputs.skip != 'true' && needs.full-check.result == 'success'
     runs-on: ubuntu-latest
@@ -206,12 +206,11 @@ jobs:
       attestations: write
       id-token: write
       # actions:write lets the final step dispatch the Debian-packages
-      # workflow. That explicit dispatch is REQUIRED, not a convenience:
-      # this job publishes the release with the workflow-scoped
-      # GITHUB_TOKEN, and GitHub suppresses workflow triggers for events
-      # created with that token — deb-packages.yml's `release: published`
-      # trigger never fires for releases this pipeline publishes.
-      # workflow_dispatch is exempt from the suppression.
+      # workflow, which attaches the .debs to the draft and publishes it.
+      # An explicit dispatch is REQUIRED: this job leaves the release as a
+      # draft (no release event to trigger on), and even once deb-packages
+      # publishes it, GitHub suppresses workflow triggers for events created
+      # with the workflow-scoped GITHUB_TOKEN. workflow_dispatch is exempt.
       actions: write
     env:
       GH_TOKEN: ${{ github.token }}
@@ -350,41 +349,19 @@ jobs:
             fi
           done
 
-      - name: Publish the immutable release
+      - name: Dispatch the Debian package build that finalizes the release
         run: |
           set -euo pipefail
-
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false
-          else
-            # A maintenance patch published from an OLDER release line (the
-            # documented supported-release flow) must not steal the repo's
-            # "latest release" pointer from a newer train: mark latest only
-            # when this tag tops every published stable release under the
-            # CalVer numeric sort (first-ever stable release wins trivially).
-            # Paginated: a fixed --limit would stop seeing the newest stable
-            # release once the repo accumulates more releases than the cap,
-            # letting an old-train patch wrongly grab the latest pointer.
-            latest_flag=--latest
-            existing=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
-              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name')
-            top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
-              | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-            if [ "$top" != "$RELEASE_TAG" ]; then
-              latest_flag=--latest=false
-              echo "A newer stable release ($top) is already published — not marking $RELEASE_TAG as latest."
-            fi
-            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false "$latest_flag"
-          fi
-
-      - name: Dispatch the Debian package build
-        run: |
-          set -euo pipefail
-          # See the actions:write comment above: the release-published event
-          # this job just caused is invisible to other workflows, so the deb
-          # build is dispatched by hand. Failure here must not unwind the
-          # published release — it reports loudly and the operator retries
-          # with the same dispatch (documented in deb-packages.yml).
+          # The release is still a DRAFT at this point: the WAR + SBOM are
+          # attached but it is NOT published. deb-packages.yml downloads the
+          # WAR from the draft, builds and attaches the .deb assets, and then
+          # publishes the release as its final step — so the immutable release,
+          # once locked, already carries every asset (the repo enables
+          # immutable releases, which forbid attaching assets after publish).
+          # It is dispatched by hand rather than relying on a trigger: this job
+          # has not published anything yet, so there is no release event to
+          # react to, and workflow_dispatch is also exempt from the
+          # GITHUB_TOKEN event suppression noted above.
           # Dispatched on the TAG's own ref: workflow_dispatch requires the
           # workflow file to exist on the dispatched ref, and deb-packages.yml
           # lives on the release lines (and their tags), not necessarily on
@@ -393,6 +370,6 @@ jobs:
           if ! gh workflow run deb-packages.yml --repo "$REPO" \
                  --ref "refs/tags/$RELEASE_TAG" \
                  -f "tag=$RELEASE_TAG"; then
-            echo "::error::Release $RELEASE_TAG is published but the Debian package build could not be dispatched. Run it manually: gh workflow run deb-packages.yml --ref refs/tags/$RELEASE_TAG -f tag=$RELEASE_TAG"
+            echo "::error::Draft release $RELEASE_TAG is ready but the Debian package build could not be dispatched, so the release was NOT published. Run it manually to finalize: gh workflow run deb-packages.yml --ref refs/tags/$RELEASE_TAG -f tag=$RELEASE_TAG"
             exit 1
           fi

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha6</version>
+    <version>2026.08.0-alpha7-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha6</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha6-SNAPSHOT</version>
+    <version>2026.08.0-alpha5</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha5</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha5</version>
+    <version>2026.08.0-alpha6</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha5</tag>
+        <tag>2026.08.0-alpha6</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/e2e/fax/README.md
+++ b/scripts/e2e/fax/README.md
@@ -37,3 +37,53 @@ A fax sent to the account's own `SRFAX_FAX_NUMBER` is delivered back to the
 same account's inbox, so send and receive can be validated with one account.
 The provider `Queue_Fax` returns a job id immediately; the inbound copy arrives
 minutes later and the scheduler (60s poll) imports it.
+
+## Database + staging access (for the tests that assert on the DB)
+
+Some tests read and assert against the live database and stage files into the
+service-owned document directory. On a hardened deployment those need
+privilege; pass a launcher via the environment (nothing is shell-parsed — argv
+only):
+
+| Variable             | Meaning                                                           |
+|----------------------|------------------------------------------------------------------|
+| `MARIADB`            | mariadb launcher, e.g. `sudo mariadb` (default `mariadb`)         |
+| `CARLOS_DB_NAME`     | application schema (default `oscar`)                              |
+| `CARLOS_DOCUMENT_DIR`| document dir for staged outbound PDFs                             |
+| `STAGE_AS`           | launcher to write into a dir the runner does not own, e.g. `sudo -u carlos` |
+| `DEDUP_WAIT_MS`      | how long `dedup-no-reimport.js` watches for a re-import (default 150000) |
+
+## The tests
+
+Run them in this order against a freshly provisioned deployment with
+`fixtures.sql` loaded:
+
+    sudo mariadb oscar < scripts/e2e/fax/fixtures.sql
+    set -a; . /secure/path/srfax.env; set +a
+    export MARIADB="sudo mariadb" STAGE_AS="sudo -u carlos"
+
+1. **`backbone-loopback.js`** — the shared send/receive backbone every clinical
+   outbound entry point funnels into: injects a WAITING outbound fax to the
+   account's own number, confirms the scheduler sends it via the real SRFax
+   `Queue_Fax` (WAITING → SENT + provider job id), then confirms the inbound
+   copy is downloaded, imported (RECEIVED), and routed to the UNCLAIMED inbox.
+   *Needs SRFax credentials.*
+
+2. **`inbox-lifecycle.js`** — picks up an imported inbound fax left UNCLAIMED by
+   the backbone test and drives the provider workflow through the real server
+   actions, asserting each DB transition: redirected-to-inbox → attached to a
+   patient (`documentUpdate`, `demog`) → attached to a provider
+   (`documentUpdate`, `flagproviders`) → provider files it (`fileLabAjax`,
+   status → `F`). *No SRFax credentials needed.*
+
+3. **`dedup-no-reimport.js`** — the live counterpart to
+   `FaxImporterDedupUnitTest`: every inbound fax is stamped with the account's
+   fax line (the dedup key), no two inbound faxes share a file name, and the
+   inbound count does not grow across more than two scheduler poll cycles (an
+   already-held fax is recognised and not re-imported). *No SRFax credentials.*
+
+4. **`prescription-drugref.js`** — proves the DrugRef2 lookup the prescription
+   module depends on is live: a common drug returns real reference results, a
+   nonsense term returns none, and a second common drug also resolves. The fax
+   transmission of the resulting prescription funnels into the same outbound
+   backbone proven by `backbone-loopback.js`. *No SRFax credentials.*

--- a/scripts/e2e/fax/backbone-loopback.js
+++ b/scripts/e2e/fax/backbone-loopback.js
@@ -12,6 +12,9 @@
 // matching how the deployment is administered; pass MARIADB="sudo mariadb" etc.
 'use strict';
 const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { cfg } = require('./lib');
 
 // MARIADB may be a multi-word launcher (e.g. "sudo mariadb"); split into argv
@@ -27,6 +30,24 @@ function sql(q) {
   return execFileSync(cmd, [...pre, '-N', DB, '-e', q], { encoding: 'utf8' }).trim();
 }
 function sh(cmd, args, opts) { return execFileSync(cmd, args, opts); }
+// Stage file content into a directory the current user may not own. On a
+// hardened deployment the document dir is 0750 and owned by the service
+// account, so staging the outbound PDF needs a privilege wrapper. STAGE_AS is
+// an optional launcher (e.g. "sudo -u carlos"); empty by default so nothing
+// changes when the runner already owns the dir. Content is written to a
+// world-readable temp file first, then installed as the target user — piping
+// through "sudo -u other install /dev/stdin" cannot inherit our pipe fd.
+function stage(content, dest, mode = '0644') {
+  const wrap = (process.env.STAGE_AS || '').split(/\s+/).filter(Boolean);
+  const tmp = path.join(os.tmpdir(), 'carlos-e2e-' + path.basename(dest));
+  fs.writeFileSync(tmp, content, { mode: 0o644 });
+  try {
+    const argv = [...wrap, 'install', '-m', mode, tmp, dest];
+    execFileSync(argv[0], argv.slice(1));
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+}
 
 async function main() {
   const c = cfg();
@@ -42,7 +63,7 @@ async function main() {
     + '5 0 obj<</Length 60>>stream\nBT /F1 18 Tf 72 700 Td (CARLOS E2E loopback) Tj ET\n'
     + 'endstream endobj\ntrailer<</Root 1 0 R/Size 6>>\n%%EOF';
   const fname = 'e2e-backbone-loopback.pdf';
-  sh('install', ['-m', '0644', '/dev/stdin', `${DOCDIR}/${fname}`], { input: pdf });
+  stage(pdf, `${DOCDIR}/${fname}`);
 
   const demo = sql(`SELECT demographic_no FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest' ORDER BY demographic_no LIMIT 1`);
   if (!demo) throw new Error('fixture demographic Loopback/Faxtest not found — load fixtures.sql first');

--- a/scripts/e2e/fax/backbone-loopback.js
+++ b/scripts/e2e/fax/backbone-loopback.js
@@ -39,13 +39,22 @@ function sh(cmd, args, opts) { return execFileSync(cmd, args, opts); }
 // through "sudo -u other install /dev/stdin" cannot inherit our pipe fd.
 function stage(content, dest, mode = '0644') {
   const wrap = (process.env.STAGE_AS || '').split(/\s+/).filter(Boolean);
-  const tmp = path.join(os.tmpdir(), 'carlos-e2e-' + path.basename(dest));
-  fs.writeFileSync(tmp, content, { mode: 0o644 });
+  // mkdtempSync creates a fresh directory with an unguessable name owned by
+  // us, so no pre-existing file or symlink can redirect the write, and only we
+  // (and root) can create entries inside it. It is then made traversable so a
+  // STAGE_AS target user (e.g. carlos) can read the staged file; others still
+  // cannot write into the dir, so no symlink can be planted. The exclusive
+  // 'wx' write flag refuses any collision as a final guard.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-e2e-'));
+  fs.chmodSync(dir, 0o755);
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- dir is a private mkdtemp dir; dest basename is a constant in this script
+  const tmp = path.join(dir, path.basename(dest));
   try {
+    fs.writeFileSync(tmp, content, { mode: 0o644, flag: 'wx' });
     const argv = [...wrap, 'install', '-m', mode, tmp, dest];
     execFileSync(argv[0], argv.slice(1));
   } finally {
-    fs.unlinkSync(tmp);
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 

--- a/scripts/e2e/fax/dedup-no-reimport.js
+++ b/scripts/e2e/fax/dedup-no-reimport.js
@@ -6,9 +6,12 @@
 //      a faxline equal to the configured account number's last 10 digits. This
 //      is the account key FaxImporter.isAlreadyImported() scopes dedup by.
 //   2. no duplicate rows — no two inbound faxes share the same file name.
-//   3. no re-import       — over more than two scheduler poll cycles the count
-//      of inbound faxes does not grow: faxes already held are recognised and
-//      skipped rather than downloaded and imported again.
+//   3. no duplicate import — over more than two scheduler poll cycles the count
+//      of inbound faxes does not grow. A successfully downloaded fax is marked
+//      read on the provider, so normal polling should not re-import it; this
+//      confirms no duplicate rows appear in steady state. The account-scoped
+//      isAlreadyImported() logic that guards a genuine re-offer is covered
+//      directly and exhaustively by FaxImporterDedupUnitTest.
 //
 // This is the live counterpart to FaxImporterDedupUnitTest. It sends no faxes
 // of its own, so it needs no SRFax credentials. Never run in CI (it waits on
@@ -41,12 +44,19 @@ async function main() {
   const before = inCount();
   must(before > 0, 'no inbound faxes present — run backbone-loopback.js first');
 
-  // 1. faxline stamping on every inbound row.
+  // 1. faxline stamping. Every inbound row must carry a usable (>= 10 digit)
+  //    account key — that is what FaxImporter.isAlreadyImported() scopes dedup
+  //    by. We do NOT require every row to equal one account: a deployment may
+  //    have several fax configurations, each stamping its own line. Instead we
+  //    assert none are unstamped/malformed, and that the account we selected
+  //    above is represented among the inbound rows.
   const unstamped = parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN' AND (faxline IS NULL OR faxline='')`), 10) || 0;
   must(unstamped === 0, `${unstamped} inbound fax(es) have no faxline stamped (dedup account key missing)`);
-  const wrong = parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN' AND RIGHT(REGEXP_REPLACE(faxline,'[^0-9]',''),10) <> '${acctTail}'`), 10) || 0;
-  must(wrong === 0, `${wrong} inbound fax(es) have a faxline whose last 10 digits != account ${acctTail}`);
-  console.log(`STEP 1 faxline-stamping: PASS (all ${before} inbound faxes stamped with account tail ${acctTail})`);
+  const malformed = parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN' AND CHAR_LENGTH(REGEXP_REPLACE(faxline,'[^0-9]','')) < 10`), 10) || 0;
+  must(malformed === 0, `${malformed} inbound fax(es) have a faxline with fewer than 10 digits (not a usable account key)`);
+  const forAccount = parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN' AND RIGHT(REGEXP_REPLACE(faxline,'[^0-9]',''),10) = '${acctTail}'`), 10) || 0;
+  must(forAccount > 0, `no inbound fax is stamped for the selected account ${acctTail}`);
+  console.log(`STEP 1 faxline-stamping: PASS (all ${before} inbound faxes carry a usable account key; ${forAccount} for account ${acctTail})`);
 
   // 2. no duplicate file names among inbound faxes.
   const dups = sql(`SELECT COALESCE(filename,'') fn, COUNT(*) n FROM faxes WHERE direction='IN' GROUP BY filename HAVING n > 1`);
@@ -62,8 +72,8 @@ async function main() {
     must(now <= before, `inbound fax count grew from ${before} to ${now} — an already-held fax was re-imported`);
   }
   const after = inCount();
-  must(after === before, `inbound fax count changed from ${before} to ${after}`);
-  console.log(`STEP 3 no-re-import: PASS (inbound count stable at ${after} across the window)`);
+  must(after === before, `inbound fax count changed from ${before} to ${after} — a duplicate import appeared`);
+  console.log(`STEP 3 no-duplicate-import: PASS (inbound count stable at ${after} across the window)`);
 
   console.log('DEDUP NO-REIMPORT: PASS');
 }

--- a/scripts/e2e/fax/dedup-no-reimport.js
+++ b/scripts/e2e/fax/dedup-no-reimport.js
@@ -31,6 +31,11 @@ const digitsTail = (v) => (v || '').replace(/\D/g, '').slice(-10);
 
 // Two poll cycles at the scheduler's 60s cadence, plus margin.
 const WAIT_MS = parseInt(process.env.DEDUP_WAIT_MS || '150000', 10);
+// The window must span more than two 60s poll cycles for the no-growth check to
+// mean anything; reject a NaN/short value rather than pass trivially.
+if (!Number.isInteger(WAIT_MS) || WAIT_MS < 130000) {
+  throw new Error('DEDUP_WAIT_MS must be an integer >= 130000 (more than two 60s scheduler cycles)');
+}
 
 async function main() {
   cfg({ srfax: false }); // validates BASE_URL/login env even though we drive the DB

--- a/scripts/e2e/fax/dedup-no-reimport.js
+++ b/scripts/e2e/fax/dedup-no-reimport.js
@@ -30,7 +30,7 @@ const must = (cond, msg) => { if (!cond) throw new Error(msg); };
 const digitsTail = (v) => (v || '').replace(/\D/g, '').slice(-10);
 
 // Two poll cycles at the scheduler's 60s cadence, plus margin.
-const WAIT_MS = parseInt(process.env.DEDUP_WAIT_MS || '150000', 10);
+const WAIT_MS = Number(process.env.DEDUP_WAIT_MS || '150000');
 // The window must span more than two 60s poll cycles for the no-growth check to
 // mean anything; reject a NaN/short value rather than pass trivially.
 if (!Number.isInteger(WAIT_MS) || WAIT_MS < 130000) {

--- a/scripts/e2e/fax/dedup-no-reimport.js
+++ b/scripts/e2e/fax/dedup-no-reimport.js
@@ -1,0 +1,71 @@
+// Inbound-fax de-duplication test: proves the account-scoped dedup hardening
+// holds against a live deployment. After the scheduler has imported inbound
+// faxes (run backbone-loopback.js first), it verifies:
+//
+//   1. faxline stamping  — every imported inbound (direction='IN') fax carries
+//      a faxline equal to the configured account number's last 10 digits. This
+//      is the account key FaxImporter.isAlreadyImported() scopes dedup by.
+//   2. no duplicate rows — no two inbound faxes share the same file name.
+//   3. no re-import       — over more than two scheduler poll cycles the count
+//      of inbound faxes does not grow: faxes already held are recognised and
+//      skipped rather than downloaded and imported again.
+//
+// This is the live counterpart to FaxImporterDedupUnitTest. It sends no faxes
+// of its own, so it needs no SRFax credentials. Never run in CI (it waits on
+// the real scheduler and inspects a live database).
+'use strict';
+const { execFileSync } = require('child_process');
+const { cfg } = require('./lib');
+
+const MARIADB = (process.env.MARIADB || 'mariadb').split(/\s+/);
+const DB = process.env.CARLOS_DB_NAME || 'oscar';
+function sql(q) {
+  const [cmd, ...pre] = MARIADB;
+  return execFileSync(cmd, [...pre, '-N', DB, '-e', q], { encoding: 'utf8' }).trim();
+}
+const must = (cond, msg) => { if (!cond) throw new Error(msg); };
+const digitsTail = (v) => (v || '').replace(/\D/g, '').slice(-10);
+
+// Two poll cycles at the scheduler's 60s cadence, plus margin.
+const WAIT_MS = parseInt(process.env.DEDUP_WAIT_MS || '150000', 10);
+
+async function main() {
+  cfg({ srfax: false }); // validates BASE_URL/login env even though we drive the DB
+
+  const account = sql(`SELECT faxNumber FROM fax_config WHERE faxNumber IS NOT NULL ORDER BY id DESC LIMIT 1`)
+    || sql(`SELECT faxline FROM faxes WHERE direction='IN' ORDER BY id DESC LIMIT 1`);
+  must(account, 'could not determine the configured fax account number');
+  const acctTail = digitsTail(account);
+
+  const inCount = () => parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN'`), 10) || 0;
+  const before = inCount();
+  must(before > 0, 'no inbound faxes present — run backbone-loopback.js first');
+
+  // 1. faxline stamping on every inbound row.
+  const unstamped = parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN' AND (faxline IS NULL OR faxline='')`), 10) || 0;
+  must(unstamped === 0, `${unstamped} inbound fax(es) have no faxline stamped (dedup account key missing)`);
+  const wrong = parseInt(sql(`SELECT COUNT(*) FROM faxes WHERE direction='IN' AND RIGHT(REGEXP_REPLACE(faxline,'[^0-9]',''),10) <> '${acctTail}'`), 10) || 0;
+  must(wrong === 0, `${wrong} inbound fax(es) have a faxline whose last 10 digits != account ${acctTail}`);
+  console.log(`STEP 1 faxline-stamping: PASS (all ${before} inbound faxes stamped with account tail ${acctTail})`);
+
+  // 2. no duplicate file names among inbound faxes.
+  const dups = sql(`SELECT COALESCE(filename,'') fn, COUNT(*) n FROM faxes WHERE direction='IN' GROUP BY filename HAVING n > 1`);
+  must(dups === '', `duplicate inbound fax file names found:\n${dups}`);
+  console.log('STEP 2 no-duplicate-rows: PASS (every inbound fax file name is unique)');
+
+  // 3. no re-import across more than two scheduler poll cycles.
+  console.log(`STEP 3 waiting ${Math.round(WAIT_MS / 1000)}s (> two 60s scheduler cycles) to confirm no re-import...`);
+  const start = Date.now();
+  while (Date.now() - start < WAIT_MS) {
+    execFileSync('sleep', ['15']);
+    const now = inCount();
+    must(now <= before, `inbound fax count grew from ${before} to ${now} — an already-held fax was re-imported`);
+  }
+  const after = inCount();
+  must(after === before, `inbound fax count changed from ${before} to ${after}`);
+  console.log(`STEP 3 no-re-import: PASS (inbound count stable at ${after} across the window)`);
+
+  console.log('DEDUP NO-REIMPORT: PASS');
+}
+
+main().catch((e) => { console.error('DEDUP NO-REIMPORT: FAIL —', e.message); process.exit(1); });

--- a/scripts/e2e/fax/inbox-lifecycle.js
+++ b/scripts/e2e/fax/inbox-lifecycle.js
@@ -30,6 +30,8 @@ function sql(q) {
   return execFileSync(cmd, [...pre, '-N', DB, '-e', q], { encoding: 'utf8' }).trim();
 }
 const must = (cond, msg) => { if (!cond) throw new Error(msg); };
+// Escape a value for embedding inside a single-quoted SQL string literal.
+const sqlLit = (v) => String(v).replace(/'/g, "''");
 
 async function main() {
   const c = cfg({ srfax: false });
@@ -38,7 +40,7 @@ async function main() {
   // nothing is hardcoded to a particular install.
   const demo = sql(`SELECT demographic_no FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest' ORDER BY demographic_no LIMIT 1`);
   must(demo, 'fixture demographic Loopback/Faxtest not found — load fixtures.sql first');
-  const provider = sql(`SELECT provider_no FROM security WHERE user_name='${c.user}' ORDER BY security_no LIMIT 1`);
+  const provider = sql(`SELECT provider_no FROM security WHERE user_name='${sqlLit(c.user)}' ORDER BY security_no LIMIT 1`);
   must(provider, `no provider mapped to login ${c.user} in the security table`);
 
   // Find an imported inbound fax still sitting UNCLAIMED in the inbox.

--- a/scripts/e2e/fax/inbox-lifecycle.js
+++ b/scripts/e2e/fax/inbox-lifecycle.js
@@ -1,0 +1,94 @@
+// Inbound fax inbox lifecycle test: takes an inbound fax that the scheduler
+// has imported and left UNCLAIMED (see backbone-loopback.js, which must run
+// first to produce one), then drives the real provider workflow through the
+// live server actions and asserts each database transition:
+//
+//   1. redirected to the inbox   — providerLabRouting(DOC) provider_no=0 status=N
+//   2. attached to a patient     — documentUpdate(demog) -> ctl_document module_id
+//                                  set to the demographic + a chart note created
+//   3. attached to a provider    — documentUpdate(flagproviders) -> a
+//                                  providerLabRouting row for that provider
+//   4. provider interacts (files)— fileLabAjax(DOC) -> that row's status -> 'F'
+//
+// The two server actions (documentManager/ManageDocument!documentUpdate and
+// oscarMDS/FileLabs!fileLabAjax) are the exact endpoints the inbox UI calls;
+// they are posted from within an authenticated page so the session cookies and
+// the scraped CSRFGuard token travel with them. Assertions are made against the
+// database via the mariadb CLI, matching backbone-loopback.js.
+//
+// Talks to a live deployment (no SRFax traffic of its own). Never run in CI.
+// Prereqs: fixtures.sql loaded; backbone-loopback.js has imported >=1 inbound
+// fax; the login user has _edoc and _lab write privileges (carlosdoc does).
+'use strict';
+const { execFileSync } = require('child_process');
+const { launch, login, cfg } = require('./lib');
+
+const MARIADB = (process.env.MARIADB || 'mariadb').split(/\s+/);
+const DB = process.env.CARLOS_DB_NAME || 'oscar';
+function sql(q) {
+  const [cmd, ...pre] = MARIADB;
+  return execFileSync(cmd, [...pre, '-N', DB, '-e', q], { encoding: 'utf8' }).trim();
+}
+const must = (cond, msg) => { if (!cond) throw new Error(msg); };
+
+async function main() {
+  const c = cfg({ srfax: false });
+
+  // Resolve the fixture patient and the login's provider from the database so
+  // nothing is hardcoded to a particular install.
+  const demo = sql(`SELECT demographic_no FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest' ORDER BY demographic_no LIMIT 1`);
+  must(demo, 'fixture demographic Loopback/Faxtest not found — load fixtures.sql first');
+  const provider = sql(`SELECT provider_no FROM security WHERE user_name='${c.user}' ORDER BY security_no LIMIT 1`);
+  must(provider, `no provider mapped to login ${c.user} in the security table`);
+
+  // Find an imported inbound fax still sitting UNCLAIMED in the inbox.
+  const doc = sql(`SELECT r.lab_no FROM providerLabRouting r JOIN document d ON d.document_no=r.lab_no `
+    + `WHERE r.lab_type='DOC' AND r.provider_no='0' AND r.status='N' AND d.doctype='Received Fax' `
+    + `ORDER BY r.lab_no DESC LIMIT 1`);
+  must(doc, 'no UNCLAIMED inbound fax in the inbox — run backbone-loopback.js first');
+  console.log(`unclaimed inbound fax document=${doc}; target patient=${demo} provider=${provider}`);
+  console.log('STEP 1 redirected-to-inbox: PASS (providerLabRouting DOC provider_no=0 status=N)');
+
+  const b = await launch();
+  const ctx = await b.newContext({ ignoreHTTPSErrors: true });
+  try {
+    const p = await login(ctx, c);
+    // Land on an app page so a CSRFGuard token is present to scrape.
+    // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- validated base + constant path
+    await p.goto(c.base + '/web/inboxhub/Inboxhub', { waitUntil: 'domcontentloaded' });
+    await p.waitForTimeout(800);
+    const { postForm } = require('./lib');
+
+    // STEP 2 + 3: file the document to the patient and route it to the provider.
+    const r1 = await postForm(p, c.base + '/documentManager/ManageDocument', {
+      method: 'documentUpdate', documentId: doc, doc_no: doc, docType: 'Received Fax',
+      documentDescription: 'E2E inbound fax', observationDate: '', demog: demo, flagproviders: provider,
+    });
+    must(r1.status === 200, `documentUpdate returned HTTP ${r1.status} (expected 200)`);
+
+    const linked = sql(`SELECT COUNT(*) FROM ctl_document WHERE document_no=${doc} AND module='demographic' AND module_id=${demo}`);
+    must(parseInt(linked, 10) > 0, `document ${doc} was not linked to demographic ${demo}`);
+    const noted = sql(`SELECT COUNT(*) FROM casemgmt_note WHERE demographic_no='${demo}' AND note LIKE '%E2E inbound fax%'`);
+    must(parseInt(noted, 10) > 0, 'no chart note was created on the patient for the filed fax');
+    console.log(`STEP 2 attached-to-patient: PASS (ctl_document -> demographic ${demo}, chart note created)`);
+
+    const routed = sql(`SELECT COUNT(*) FROM providerLabRouting WHERE lab_no=${doc} AND lab_type='DOC' AND provider_no='${provider}'`);
+    must(parseInt(routed, 10) > 0, `document ${doc} was not routed to provider ${provider}`);
+    console.log(`STEP 3 attached-to-provider: PASS (providerLabRouting -> provider ${provider})`);
+
+    // STEP 4: the provider files (acknowledges) the item in their inbox.
+    const r2 = await postForm(p, c.base + '/oscarMDS/FileLabs', {
+      method: 'fileLabAjax', flaggedLabId: doc, labType: 'DOC',
+    });
+    must(r2.status === 200, `fileLabAjax returned HTTP ${r2.status} (expected 200)`);
+    const filed = sql(`SELECT status FROM providerLabRouting WHERE lab_no=${doc} AND lab_type='DOC' AND provider_no='${provider}' ORDER BY id DESC LIMIT 1`);
+    must(filed === 'F', `provider routing status is '${filed}', expected 'F' (filed)`);
+    console.log(`STEP 4 provider-files-in-inbox: PASS (routing status -> F)`);
+
+    console.log('INBOX LIFECYCLE: PASS');
+  } finally {
+    await b.close();
+  }
+}
+
+main().catch((e) => { console.error('INBOX LIFECYCLE: FAIL —', e.message); process.exit(1); });

--- a/scripts/e2e/fax/lib.js
+++ b/scripts/e2e/fax/lib.js
@@ -29,18 +29,21 @@ function validateBaseUrl(raw) {
   return u.toString().replace(/\/$/, '');
 }
 
-const cfg = () => ({
+// Assemble config from the environment. Pass { srfax: false } for tests that
+// drive an already-imported fax and never call the SRFax API, so they do not
+// require SRFax account credentials just to run.
+const cfg = ({ srfax = true } = {}) => ({
   base: validateBaseUrl(env('BASE_URL')),
   user: env('TEST_USER'),
   pass: env('TEST_PASSWORD'),
   pin: env('TEST_PIN'),
   chrome: process.env.CHROME_PATH || undefined,
-  srfax: {
+  srfax: srfax ? {
     accessId: env('SRFAX_ACCESS_ID'),
     pass: env('SRFAX_PASS'),
     email: env('SRFAX_USER'),
     faxNumber: env('SRFAX_FAX_NUMBER'),
-  },
+  } : undefined,
 });
 
 async function launch() {
@@ -109,4 +112,34 @@ async function waitForInboundFax(p, c, { sinceCount = 0, timeoutMs = 480000 } = 
   return -1;
 }
 
-module.exports = { env, cfg, launch, login, ensureSrfaxConfigured, waitForInboundFax };
+// Scrape the CSRFGuard token from a rendered page. Every authenticated app
+// page carries it as a hidden <input name="CSRF-TOKEN">; POSTs without it are
+// rejected 403 by CarlosCsrfGuardFilter. Navigate to an app page first.
+async function csrfToken(p) {
+  const t = await p.evaluate(() => {
+    const el = document.querySelector('input[name="CSRF-TOKEN"]');
+    return el ? el.value : null;
+  });
+  if (!t) throw new Error('CSRF-TOKEN not found on page — navigate to an app page before posting');
+  return t;
+}
+
+// POST a form-encoded request from WITHIN the page context so it carries the
+// session cookies and same-origin credentials, with the scraped CSRF token
+// appended. url must be absolute (c.base + path) — a relative path would drop
+// the /carlos context. Returns { status, url }.
+async function postForm(p, url, params) {
+  const token = await csrfToken(p);
+  return p.evaluate(async ({ url, params, token }) => {
+    const body = new URLSearchParams({ ...params, 'CSRF-TOKEN': token }).toString();
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+      credentials: 'same-origin',
+    });
+    return { status: res.status, url: res.url };
+  }, { url, params, token });
+}
+
+module.exports = { env, cfg, launch, login, ensureSrfaxConfigured, waitForInboundFax, csrfToken, postForm };

--- a/scripts/e2e/fax/lib.js
+++ b/scripts/e2e/fax/lib.js
@@ -130,6 +130,7 @@ async function csrfToken(p) {
 // the /carlos context. Returns { status, url }.
 async function postForm(p, url, params) {
   const token = await csrfToken(p);
+  // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection -- url is the validated base + a constant path and params are test-controlled; no untrusted input reaches evaluate
   return p.evaluate(async ({ url, params, token }) => {
     const body = new URLSearchParams({ ...params, 'CSRF-TOKEN': token }).toString();
     const res = await fetch(url, {

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -47,7 +47,11 @@ async function searchDrug(p, base, demo, term) {
     const hits = [...document.querySelectorAll('a,tr,li')]
       .map((e) => (e.textContent || '').trim())
       .filter((s) => s.length < 120 && s.toLowerCase().includes(needle));
-    return { count: hits.length, sample: hits.slice(0, 3), failedOrEmpty: /unavailable|no results|not found|failed/i.test(text) || text.length < 400 };
+    // "failed" is a genuine service problem (DrugRef unavailable / error page),
+    // kept separate from a valid empty result so the negative case can require
+    // the lookup to have COMPLETED and merely returned nothing.
+    const failed = /unavailable|error contacting|could not|exception|service is unavailable/i.test(text);
+    return { count: hits.length, sample: hits.slice(0, 3), failed };
   }, term);
 }
 
@@ -67,17 +71,18 @@ async function main() {
 
     // 1. positive lookup
     const pos = await searchDrug(p, c.base, demo, 'amoxicillin');
-    must(pos.count > 0 && !pos.failedOrEmpty, `DrugRef returned no results for "amoxicillin" (count=${pos.count}) — is carlos-emr-drugref up?`);
+    must(pos.count > 0 && !pos.failed, `DrugRef returned no results for "amoxicillin" (count=${pos.count}) — is carlos-emr-drugref up?`);
     console.log(`STEP 1 drugref-positive: PASS (amoxicillin -> ${pos.count} row(s), e.g. ${JSON.stringify(pos.sample[0] || '')})`);
 
     // 2. negative lookup
     const neg = await searchDrug(p, c.base, demo, 'zzzznotarealdrugxyz');
+    must(!neg.failed, 'the negative DrugRef lookup hit a service failure, not a valid empty result');
     must(neg.count === 0, `DrugRef returned ${neg.count} result(s) for a nonsense term — lookup is not a real query`);
-    console.log('STEP 2 drugref-negative: PASS (nonsense term -> no results)');
+    console.log('STEP 2 drugref-negative: PASS (nonsense term -> lookup completed, no results)');
 
     // 3. second positive, to guard against a single fluke/cached hit
     const pos2 = await searchDrug(p, c.base, demo, 'metformin');
-    must(pos2.count > 0 && !pos2.failedOrEmpty, `DrugRef returned no results for "metformin" (count=${pos2.count})`);
+    must(pos2.count > 0 && !pos2.failed, `DrugRef returned no results for "metformin" (count=${pos2.count})`);
     console.log(`STEP 3 drugref-second-drug: PASS (metformin -> ${pos2.count} row(s))`);
 
     console.log('PRESCRIPTION DRUGREF: PASS');

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -50,7 +50,7 @@ async function searchDrug(p, base, demo, term) {
     // "failed" is a genuine service problem (DrugRef unavailable / error page),
     // kept separate from a valid empty result so the negative case can require
     // the lookup to have COMPLETED and merely returned nothing.
-const failed = /unavailable|error contacting|could not|exception|service is unavailable|failed|interrupted/i.test(text);
+    const failed = /unavailable|error contacting|could not|exception|service is unavailable|failed|interrupted/i.test(text);
     return { count: hits.length, sample: hits.slice(0, 3), failed };
   }, term);
 }

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -1,0 +1,88 @@
+// Prescription DrugRef lookup test: proves the DrugRef2 drug-reference
+// integration that the prescription module depends on is live and answering
+// real queries — the lookup a provider does before writing (and faxing) a
+// prescription. It drives the real Rx search action (rx/searchDrug ->
+// RxSearchDrug2Action -> RxDrugRef.list_drug*), which queries DrugRef over
+// XML-RPC, and asserts:
+//
+//   1. a common drug name returns real reference results (generic/brand rows);
+//   2. a nonsense string returns no results — so we know the lookup is a real
+//      query against the dataset, not a stub that always "matches";
+//   3. (optional) a second common drug also resolves, guarding against a
+//      single cached/fluke hit.
+//
+// Scope note: this covers the DrugRef lookup that gates prescribing. The fax
+// TRANSMISSION of the resulting prescription funnels into the same outbound
+// backbone (WAITING faxes row -> scheduler -> SRFax Queue_Fax -> SENT) that
+// backbone-loopback.js already proves end to end; it is not re-driven here
+// because the full write-script -> PDF -> fax-to-pharmacy UI is a brittle
+// multi-step flow unsuitable for a stable automated check.
+//
+// Talks to a live deployment; sends no faxes, needs no SRFax credentials.
+// Never run in CI. Prereqs: fixtures.sql loaded (provides the patient), the
+// carlos-emr-drugref package installed and its dataset loaded.
+'use strict';
+const { execFileSync } = require('child_process');
+const { launch, login, cfg } = require('./lib');
+
+const MARIADB = (process.env.MARIADB || 'mariadb').split(/\s+/);
+const DB = process.env.CARLOS_DB_NAME || 'oscar';
+function sql(q) {
+  const [cmd, ...pre] = MARIADB;
+  return execFileSync(cmd, [...pre, '-N', DB, '-e', q], { encoding: 'utf8' }).trim();
+}
+const must = (cond, msg) => { if (!cond) throw new Error(msg); };
+
+// Run one rx/searchDrug query in the authenticated Rx session and report how
+// many reference rows came back and whether the term appears in them.
+async function searchDrug(p, base, demo, term) {
+  // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- validated base + constant path, term is URL-encoded
+  await p.goto(base + '/rx/searchDrug?demographicNo=' + demo + '&searchString=' + encodeURIComponent(term),
+    { waitUntil: 'domcontentloaded' });
+  await p.waitForTimeout(600);
+  return p.evaluate((t) => {
+    const text = document.body.innerText || '';
+    // Result rows in ChooseDrug.jsp carry an "(Info)" affordance per drug.
+    const hits = [...document.querySelectorAll('a,tr,li')]
+      .map((e) => (e.textContent || '').trim())
+      .filter((s) => new RegExp(t, 'i').test(s) && s.length < 120);
+    return { count: hits.length, sample: hits.slice(0, 3), failedOrEmpty: /unavailable|no results|not found|failed/i.test(text) || text.length < 400 };
+  }, term);
+}
+
+async function main() {
+  const c = cfg({ srfax: false });
+  const demo = sql(`SELECT demographic_no FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest' ORDER BY demographic_no LIMIT 1`);
+  must(demo, 'fixture demographic Loopback/Faxtest not found — load fixtures.sql first');
+
+  const b = await launch();
+  const ctx = await b.newContext({ ignoreHTTPSErrors: true });
+  try {
+    const p = await login(ctx, c);
+    // Open the patient's Rx session so drug search has a demographic context.
+    // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- validated base + constant path
+    await p.goto(c.base + '/rx/choosePatient?demographicNo=' + demo, { waitUntil: 'domcontentloaded' }).catch(() => {});
+    await p.waitForTimeout(400);
+
+    // 1. positive lookup
+    const pos = await searchDrug(p, c.base, demo, 'amoxicillin');
+    must(pos.count > 0 && !pos.failedOrEmpty, `DrugRef returned no results for "amoxicillin" (count=${pos.count}) — is carlos-emr-drugref up?`);
+    console.log(`STEP 1 drugref-positive: PASS (amoxicillin -> ${pos.count} row(s), e.g. ${JSON.stringify(pos.sample[0] || '')})`);
+
+    // 2. negative lookup
+    const neg = await searchDrug(p, c.base, demo, 'zzzznotarealdrugxyz');
+    must(neg.count === 0, `DrugRef returned ${neg.count} result(s) for a nonsense term — lookup is not a real query`);
+    console.log('STEP 2 drugref-negative: PASS (nonsense term -> no results)');
+
+    // 3. second positive, to guard against a single fluke/cached hit
+    const pos2 = await searchDrug(p, c.base, demo, 'metformin');
+    must(pos2.count > 0 && !pos2.failedOrEmpty, `DrugRef returned no results for "metformin" (count=${pos2.count})`);
+    console.log(`STEP 3 drugref-second-drug: PASS (metformin -> ${pos2.count} row(s))`);
+
+    console.log('PRESCRIPTION DRUGREF: PASS');
+  } finally {
+    await b.close();
+  }
+}
+
+main().catch((e) => { console.error('PRESCRIPTION DRUGREF: FAIL —', e.message); process.exit(1); });

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -43,9 +43,10 @@ async function searchDrug(p, base, demo, term) {
   return p.evaluate((t) => {
     const text = document.body.innerText || '';
     // Result rows in ChooseDrug.jsp carry an "(Info)" affordance per drug.
+    const needle = t.toLowerCase();
     const hits = [...document.querySelectorAll('a,tr,li')]
       .map((e) => (e.textContent || '').trim())
-      .filter((s) => new RegExp(t, 'i').test(s) && s.length < 120);
+      .filter((s) => s.length < 120 && s.toLowerCase().includes(needle));
     return { count: hits.length, sample: hits.slice(0, 3), failedOrEmpty: /unavailable|no results|not found|failed/i.test(text) || text.length < 400 };
   }, term);
 }

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -50,7 +50,7 @@ async function searchDrug(p, base, demo, term) {
     // "failed" is a genuine service problem (DrugRef unavailable / error page),
     // kept separate from a valid empty result so the negative case can require
     // the lookup to have COMPLETED and merely returned nothing.
-    const failed = /unavailable|error contacting|could not|exception|service is unavailable/i.test(text);
+const failed = /unavailable|error contacting|could not|exception|service is unavailable|failed|interrupted/i.test(text);
     return { count: hits.length, sample: hits.slice(0, 3), failed };
   }, term);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import io.github.carlos_emr.carlos.commn.model.FaxJob;
 import org.springframework.stereotype.Repository;
@@ -169,10 +170,9 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
      * match; order is unspecified.
      */
     @Override
-    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
-        Query query = entityManager.createQuery(
-                "select job from FaxJob job where job.file_name = ?1");
+        TypedQuery<FaxJob> query = entityManager.createQuery(
+                "select job from FaxJob job where job.file_name = ?1", FaxJob.class);
 
         query.setParameter(1, fileName);
 

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -918,22 +918,18 @@ public class FaxImporter {
             if (FaxJob.Direction.OUT.equals(prior.getDirection())) {
                 continue;
             }
-            // Account scoping on the receiving fax line: a prior row that
-            // names a DIFFERENT account is not ours (two accounts/backends
-            // can reuse the same numeric provider job id). A blank/null
-            // fax_line is a legacy row from before imports stamped it — treat
-            // it as ours so an upgrade never re-imports an already-held fax.
-            // NOTE: fax_line is the best account key on the row today; a
-            // number genuinely shared by two backends cannot be told apart
-            // without a per-config identity on the fax record.
-            // A prior row that names a DIFFERENT account is not ours. A
-            // blank/null prior fax_line is a legacy row (imports did not
-            // stamp it before this release) — treat it as ours so an upgrade
-            // never re-imports an already-held fax. Comparison is on the last
-            // 10 digits so a provider-supplied 11-digit line (e.g. a
+            // Account scoping on the receiving fax line: two accounts or
+            // backends can reuse the same numeric provider job id, so a prior
+            // row that names a DIFFERENT account is not ours. Comparison is on
+            // the last 10 digits so a provider-supplied 11-digit line (e.g. a
             // middleware backend) still matches a 10-digit configured number.
-            // If THIS account has no fax line to scope by, a row bearing some
-            // OTHER account's line cannot be confirmed ours, so it is skipped.
+            // A blank/null prior fax_line is a legacy row (imports did not
+            // stamp it before this release) — treat it as ours so an upgrade
+            // never re-imports an already-held fax. If THIS account has no
+            // fax line to scope by, a row bearing some other account's line
+            // cannot be confirmed ours, so it is skipped. fax_line is the best
+            // account key on the row today; a number genuinely shared by two
+            // backends cannot be told apart without a per-config identity.
             String priorLine = prior.getFax_line();
             if (priorLine != null && !priorLine.trim().isEmpty()
                     && !sameFaxLine(priorLine, accountFaxLine)) {
@@ -972,7 +968,13 @@ public class FaxImporter {
             return "";
         }
         String digits = v.replaceAll("\\D", "");
-        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+        // A usable fax line needs at least 10 digits; anything shorter is a
+        // malformed/partial value and is treated as no line (never matches),
+        // so it can neither falsely scope to nor away from a real account.
+        if (digits.length() < 10) {
+            return "";
+        }
+        return digits.substring(digits.length() - 10);
     }
 
 

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -469,6 +469,17 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return false when the prior row's fax line is short/malformed (< 10 digits)")
+        void shouldReturnFalse_whenPriorFaxLineIsShortMalformed() {
+            // A prior row carrying a truncated/garbage fax_line has no usable account key; it must
+            // not be treated as a match against this account (else a genuine new fax is suppressed),
+            // and a short value must never coincidentally match another short value.
+            FaxJob shortLine = priorRow(FaxJob.STATUS.RECEIVED, null);
+            shortLine.setFax_line("8476");
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(shortLine), ACCOUNT_FAX_NUMBER)).isFalse();
+        }
+
+        @Test
         @DisplayName("should return true for a legacy row with a blank fax line (pre-stamping upgrade)")
         void shouldReturnTrue_forLegacyRowWithBlankFaxLine() {
             // Rows imported before this release have no fax_line; an upgrade must still treat them


### PR DESCRIPTION
Forward-merge `release/2026.08` into `develop` after the `2026.08.0-alpha6`
release, keeping the branches aligned.

Brings to develop:
- **deb immutable-release fix** (#3529): attach the `.deb`s to the draft
  release, then publish — so future releases ship their Debian packages.
- **SRFax e2e tests** (#3528): `inbox-lifecycle`, `dedup-no-reimport`,
  `prescription-drugref`, plus the `STAGE_AS` staging wrapper and
  `csrfToken`/`postForm` helpers.

`pom` is kept at develop's `2026.09.0-SNAPSHOT` (`scm.tag` HEAD); only the
release-line's non-version content is merged.

Generated with Claude Code

## Summary by Sourcery

Finalize immutable releases with complete Debian packaging and broaden live fax and prescription integration coverage.

New Features:
- Add live SRFax and DrugRef end-to-end coverage for inbox lifecycle, inbound de-duplication, and prescription drug lookup workflows.

Bug Fixes:
- Ensure Debian packages are attached before immutable releases are published, preventing releases from becoming permanently incomplete.
- Prevent malformed short fax-line values from causing incorrect inbound fax de-duplication matches.

Enhancements:
- Improve fax data-access type safety and provide reusable authenticated form-posting and privileged file-staging support for live E2E tests.

Documentation:
- Document live fax E2E prerequisites, staging configuration, database access, and test execution order.

Tests:
- Add live tests for inbound fax lifecycle transitions, duplicate prevention, and DrugRef positive and negative lookups.
- Add regression coverage for malformed fax-line de-duplication values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward-merges `release/2026.08` into `develop`, fixing immutable-release packaging and expanding live SRFax/DrugRef coverage. Previously we published before attaching `.deb`s; now we publish only after `carlos-emr` and `carlos-emr-drugref` `.deb`s are attached, with idempotent skip when both are present and a fail-fast error if a release was published without `.deb`s.

- Draft-first flow: `publish-release` builds WAR/SBOM and creates a draft; `deb-packages` downloads the draft WAR, builds/attests/uploads both `.deb`s, then publishes and sets the latest pointer. Adds a global concurrency group to serialize finalization, and moves the latest-pointer decision here to avoid races.
- E2E (live, not CI): adds inbox lifecycle, inbound dedup no-reimport (validates `DEDUP_WAIT_MS`), and DrugRef search tests with `STAGE_AS`, `csrfToken`, and `postForm` helpers; tightens staging safety and distinguishes DrugRef service failure from valid empty results.
- Java: inbound-fax de-dup treats fax-line values with fewer than 10 digits as “no line,” preventing coincidental matches; adds a regression test. `FaxJobDaoImpl.findByFileName` now uses a `TypedQuery<FaxJob>`.
- `pom`: `develop` remains `2026.09.0-SNAPSHOT`; only non-version content merges.

**Rollout**
- To finalize a release: run `publish-release` to create the draft, then let `deb-packages` attach both `.deb`s and publish. If `deb-packages` fails, re-run `deb-packages` for the same tag to complete publishing.
- Already-published WAR-only releases cannot accept `.deb`s due to immutable releases; ship `.deb`s with the next release.

<sup>Written for commit 43a03276f027559bd7ce593f75439ecdf9308b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

