### PR TITLE
ci/test(fax): review follow-ups on the deb fix + e2e tests

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -126,16 +126,20 @@ jobs:
           # two .deb assets. Immutable releases forbid re-uploading, so a re-run
           # against a finished release would 422 — detect that and stop cleanly.
           # Uses gh's built-in --jq (system jq is not installed in the image).
+          # GitHub normalises stored asset names (the Debian '~' becomes '.'),
+          # so match by package-name prefix, not the exact filename.
           draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
-          debs=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
-            --jq '[.assets[].name | select(endswith(".deb"))] | length' 2>/dev/null || echo 0)
+          emr=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
+            --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
+          drugref=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
+            --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
           if [ "$draft" = "true" ] || [ -z "$draft" ]; then
             # Draft (or no release yet): proceed to build, attach, and publish.
             echo "SKIP=false" >> "$GITHUB_ENV"
-          elif [ "${debs:-0}" -ge 2 ]; then
+          elif [ "${emr:-0}" -ge 1 ] && [ "${drugref:-0}" -ge 1 ]; then
             # Fully finalized: published with its .debs. Nothing to do (and a
             # re-upload would 422 against the immutable release).
-            echo "Release $RELEASE_TAG is already published with its .deb assets; nothing to do."
+            echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
             echo "SKIP=true" >> "$GITHUB_ENV"
           else
             # Published but missing .debs: an immutable release cannot accept
@@ -265,7 +269,6 @@ jobs:
           if [[ "$RELEASE_TAG" =~ -(alpha|beta|rc)[1-9][0-9]*$ ]]; then
             prerelease=true
           fi
-          release_line=$(sed -E 's/^([0-9]{4}\.[0-9]{2})\..*$/\1/' <<< "$RELEASE_TAG")
 
           if [ "$prerelease" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false

--- a/scripts/e2e/fax/dedup-no-reimport.js
+++ b/scripts/e2e/fax/dedup-no-reimport.js
@@ -31,6 +31,11 @@ const digitsTail = (v) => (v || '').replace(/\D/g, '').slice(-10);
 
 // Two poll cycles at the scheduler's 60s cadence, plus margin.
 const WAIT_MS = parseInt(process.env.DEDUP_WAIT_MS || '150000', 10);
+// The window must span more than two 60s poll cycles for the no-growth check to
+// mean anything; reject a NaN/short value rather than pass trivially.
+if (!Number.isInteger(WAIT_MS) || WAIT_MS < 130000) {
+  throw new Error('DEDUP_WAIT_MS must be an integer >= 130000 (more than two 60s scheduler cycles)');
+}
 
 async function main() {
   cfg({ srfax: false }); // validates BASE_URL/login env even though we drive the DB

--- a/scripts/e2e/fax/dedup-no-reimport.js
+++ b/scripts/e2e/fax/dedup-no-reimport.js
@@ -30,7 +30,7 @@ const must = (cond, msg) => { if (!cond) throw new Error(msg); };
 const digitsTail = (v) => (v || '').replace(/\D/g, '').slice(-10);
 
 // Two poll cycles at the scheduler's 60s cadence, plus margin.
-const WAIT_MS = parseInt(process.env.DEDUP_WAIT_MS || '150000', 10);
+const WAIT_MS = Number(process.env.DEDUP_WAIT_MS || '150000');
 // The window must span more than two 60s poll cycles for the no-growth check to
 // mean anything; reject a NaN/short value rather than pass trivially.
 if (!Number.isInteger(WAIT_MS) || WAIT_MS < 130000) {

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -47,7 +47,11 @@ async function searchDrug(p, base, demo, term) {
     const hits = [...document.querySelectorAll('a,tr,li')]
       .map((e) => (e.textContent || '').trim())
       .filter((s) => s.length < 120 && s.toLowerCase().includes(needle));
-    return { count: hits.length, sample: hits.slice(0, 3), failedOrEmpty: /unavailable|no results|not found|failed/i.test(text) || text.length < 400 };
+    // "failed" is a genuine service problem (DrugRef unavailable / error page),
+    // kept separate from a valid empty result so the negative case can require
+    // the lookup to have COMPLETED and merely returned nothing.
+    const failed = /unavailable|error contacting|could not|exception|service is unavailable/i.test(text);
+    return { count: hits.length, sample: hits.slice(0, 3), failed };
   }, term);
 }
 
@@ -67,17 +71,18 @@ async function main() {
 
     // 1. positive lookup
     const pos = await searchDrug(p, c.base, demo, 'amoxicillin');
-    must(pos.count > 0 && !pos.failedOrEmpty, `DrugRef returned no results for "amoxicillin" (count=${pos.count}) — is carlos-emr-drugref up?`);
+    must(pos.count > 0 && !pos.failed, `DrugRef returned no results for "amoxicillin" (count=${pos.count}) — is carlos-emr-drugref up?`);
     console.log(`STEP 1 drugref-positive: PASS (amoxicillin -> ${pos.count} row(s), e.g. ${JSON.stringify(pos.sample[0] || '')})`);
 
     // 2. negative lookup
     const neg = await searchDrug(p, c.base, demo, 'zzzznotarealdrugxyz');
+    must(!neg.failed, 'the negative DrugRef lookup hit a service failure, not a valid empty result');
     must(neg.count === 0, `DrugRef returned ${neg.count} result(s) for a nonsense term — lookup is not a real query`);
-    console.log('STEP 2 drugref-negative: PASS (nonsense term -> no results)');
+    console.log('STEP 2 drugref-negative: PASS (nonsense term -> lookup completed, no results)');
 
     // 3. second positive, to guard against a single fluke/cached hit
     const pos2 = await searchDrug(p, c.base, demo, 'metformin');
-    must(pos2.count > 0 && !pos2.failedOrEmpty, `DrugRef returned no results for "metformin" (count=${pos2.count})`);
+    must(pos2.count > 0 && !pos2.failed, `DrugRef returned no results for "metformin" (count=${pos2.count})`);
     console.log(`STEP 3 drugref-second-drug: PASS (metformin -> ${pos2.count} row(s))`);
 
     console.log('PRESCRIPTION DRUGREF: PASS');

--- a/scripts/e2e/fax/prescription-drugref.js
+++ b/scripts/e2e/fax/prescription-drugref.js
@@ -50,7 +50,7 @@ async function searchDrug(p, base, demo, term) {
     // "failed" is a genuine service problem (DrugRef unavailable / error page),
     // kept separate from a valid empty result so the negative case can require
     // the lookup to have COMPLETED and merely returned nothing.
-    const failed = /unavailable|error contacting|could not|exception|service is unavailable/i.test(text);
+const failed = /unavailable|error contacting|could not|exception|service is unavailable|failed|interrupted/i.test(text);
     return { count: hits.length, sample: hits.slice(0, 3), failed };
   }, term);
 }


### PR DESCRIPTION
Addresses the review comments raised on the forward-merge PR #3530 (they
re-flag code that merged via #3528/#3529, so the fixes land here on the source
branch).

- **deb-packages.yml** — the finalized-skip guard now requires **both** the
  `carlos-emr` and `carlos-emr-drugref` `.deb` assets (by package-name prefix),
  not just "≥2 .debs", so an unrelated/partial asset set can't make it skip.
  *(coderabbit, Major)*
- **deb-packages.yml** — drop the unused `release_line` assignment in the
  publish step (ShellCheck SC2034). *(copilot, coderabbit)*
- **dedup-no-reimport.js** — validate `DEDUP_WAIT_MS` is an integer ≥ 130000
  (> two 60s poll cycles) so a NaN/short value can't pass the window trivially.
  *(coderabbit)*
- **prescription-drugref.js** — separate a genuine service failure from a valid
  empty result; the negative lookup must have completed without failure and
  returned zero, so a DrugRef error page can't satisfy it. *(coderabbit)*

The codex P2 ("hold the release lock until the dispatched build finishes") is a
rare, cosmetic edge (release-notes start-tag for two same-line releases within
the ~10-min build window); the critical latest-pointer race is already handled
by deb-packages' global concurrency, so it is intentionally not addressed here.

Both changed tests re-run green on the clean alpha6 install.

Generated with Claude Code

## Summary by Sourcery

Harden Debian release handling and fax end-to-end test validation against incomplete assets, invalid timing, and false-positive DrugRef results.

Bug Fixes:
- Prevent finalized Debian releases with incomplete or unrelated assets from being incorrectly skipped.
- Require the fax deduplication test to use a valid wait window spanning more than two scheduler cycles.
- Ensure DrugRef negative lookups distinguish valid empty results from service failures.

Enhancements:
- Remove the unused Debian release-line assignment from the publish workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the Debian release finalized-skip guard and hardens two fax e2e tests to prevent false positives; also adds a potential CI fix for a PR-finding issue.

- Debian releases: skip only when both `carlos-emr` and `carlos-emr-drugref` .deb assets exist (matched by package-name prefix). Previously skipped on “any two .debs.” Incomplete releases now build/publish instead of skipping. Also removes an unused release_line assignment.
- Fax e2e (dedup-no-reimport): require `DEDUP_WAIT_MS` to be an integer ≥ 130000; the test fails fast if unset/NaN/too short. Action: set `DEDUP_WAIT_MS` ≥ 130000 in CI/local runs.
- Fax e2e (prescription-drugref): separate service failure from a valid empty result; the negative lookup must complete successfully and return zero. Positive checks use the new failure flag.

<sup>Written for commit f2bc0a24e20403c02a888576c628d2ffe4db0fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

