### PR TITLE
chore(release): prepare 2026.08.0-alpha7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha7-SNAPSHOT</version>
+    <version>2026.08.0-alpha7</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha7</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Prepares the `2026.08.0-alpha7` release.

- pom `<version>`: `2026.08.0-alpha7-SNAPSHOT` → `2026.08.0-alpha7`
- pom `<scm><tag>`: `HEAD` → `2026.08.0-alpha7`

**This release ships both `.deb`s.** The immutable-release fix (create a draft,
attach WAR + SBOM + both debs, then publish) is on `release/2026.08` and reaches
`main` with the promotion, so the alpha7 tag — cut on main's head — runs the
fixed workflows.

## Sequence after this merges
1. Promote `release/2026.08` → `main` (brings pom alpha7 **and** the fixed workflows)
2. Tag `2026.08.0-alpha7` on main's head, message **`Release 2026.08.0-alpha7`**
3. Publish runs: draft + WAR → deb build attaches both `.deb`s → release published with everything
4. Advance `release/2026.08` → `2026.08.0-alpha8-SNAPSHOT`; forward-merge to develop

`develop` stays `2026.09.0-SNAPSHOT`.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 2026.08.0-alpha7 release by setting `project.version` and `scm.tag` to `2026.08.0-alpha7`. Previously `project.version` was `2026.08.0-alpha7-SNAPSHOT` and `scm.tag` was `HEAD`; now both match the release tag so the immutable-release workflow ships both .deb packages with WAR and SBOM.

**Rollout**
- Promote `release/2026.08` to `main` to bring the workflow fix.
- Tag `2026.08.0-alpha7` on `main` (message: "Release 2026.08.0-alpha7"); the fixed workflow drafts, attaches WAR + SBOM + both `.deb`s, then publishes.
- Advance `release/2026.08` to `2026.08.0-alpha8-SNAPSHOT` and forward-merge to `develop` (remains `2026.09.0-SNAPSHOT`).

<sup>Written for commit 4aa0a36b0a415e07035538826084dcd17152bbc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

