### PR TITLE
ci(release): fix deb-packages guard to detect DRAFT releases

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -59,6 +59,12 @@ jobs:
   build-debs:
     name: Build and attach .deb packages
     runs-on: ubuntu-latest
+    # Pin the shell: container run steps otherwise default to /bin/sh, which
+    # differs from the runner's bash and broke earlier iterations. bash ships
+    # in the ubuntu:26.04 image, so set it once for the whole job.
+    defaults:
+      run:
+        shell: bash
     container:
       # Digest-pinned like every third-party artefact in this repository's
       # workflows: a re-pushed tag must never change what runs with release
@@ -273,8 +279,7 @@ jobs:
           # publish-release.yml) because the release is only published once all
           # assets, including these .debs, are in place.
           # grep -E keeps the exact anchored semantics of the original regex
-          # (digits required, matched at end); the step runs under sh/dash, so
-          # bash's [[ ... =~ ]] is unavailable and a shell glob would not anchor.
+          # (digits required, matched at end).
           prerelease=false
           if printf '%s' "$RELEASE_TAG" | grep -Eq -- '-(alpha|beta|rc)[1-9][0-9]*$'; then
             prerelease=true

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -123,28 +123,28 @@ jobs:
         run: |
           set -eu
           # gh release view (unlike the releases/tags REST endpoint, which 404s
-          # on drafts) can see a DRAFT release. Under the release flow the
-          # release is a draft carrying only the WAR at this point, so we must
-          # not treat "not published yet" as "published without debs".
-          #   draft, or no release yet -> proceed to build, attach, and publish
-          #   published with both packages -> nothing to do (immutable; re-upload would 422)
-          #   published but missing a package -> fail fast (immutable, unfixable)
-          isdraft=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo missing)
-          if [ "$isdraft" != "false" ]; then
-            echo "SKIP=false" >> "$GITHUB_ENV"
-          else
-            emr=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
-              --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-            drugref=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
-              --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-            if [ "$emr" -ge 1 ] && [ "$drugref" -ge 1 ]; then
+          # on drafts) can see a DRAFT release. One call computes the state via
+          # gh's built-in jq (system jq is not installed in the image):
+          #   draft / none  -> proceed to build, attach, and publish
+          #   done          -> published with BOTH packages; nothing to do
+          #                    (immutable, so a re-upload would 422)
+          #   missing       -> published but a package is absent; fail fast
+          #                    (immutable release can never be completed)
+          state=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json isDraft,assets --jq '
+            if .isDraft then "draft"
+            elif ([.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length) >= 1
+             and ([.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length) >= 1
+            then "done" else "missing" end' 2>/dev/null || echo none)
+          case "$state" in
+            draft|none)
+              echo "SKIP=false" >> "$GITHUB_ENV" ;;
+            done)
               echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
-              echo "SKIP=true" >> "$GITHUB_ENV"
-            else
+              echo "SKIP=true" >> "$GITHUB_ENV" ;;
+            missing)
               echo "::error::Release $RELEASE_TAG is already published but is missing a .deb asset. Immutable releases cannot accept new assets, so this cannot be completed; ship the .debs with the next release."
-              exit 1
-            fi
-          fi
+              exit 1 ;;
+          esac
 
       - name: Download and verify the release WAR
         if: env.SKIP != 'true'
@@ -242,10 +242,16 @@ jobs:
           # asset name (it rewrites the '~' in a Debian pre-release version
           # to '.'), so a name-equality lookup never matched and the check
           # failed on every alpha/rc tag. The digest is invariant.
-          # Resolve the release id first (gh release view sees drafts); the
-          # releases/tags/<tag> endpoint 404s on a draft, which is the state the
-          # release is in until this workflow publishes it below.
-          release_id=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json databaseId --jq '.databaseId')
+          # releases/tags/<tag> 404s on a draft (the release is a draft until
+          # this workflow publishes it). Resolve the numeric REST id from the
+          # releases LIST (which includes drafts and is guaranteed to be the
+          # REST id), mirroring publish-release.yml, then read digests by id.
+          release_id=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+            --jq ".[] | select(.tag_name == \"$RELEASE_TAG\") | .id" | head -n 1)
+          if [ -z "$release_id" ]; then
+            echo "::error::Release $RELEASE_TAG not found when verifying .deb digests."
+            exit 1
+          fi
           stored_digests="$(gh api "repos/$REPO/releases/$release_id" --jq '.assets[].digest')"
           for asset in release-assets/*.deb; do
             name="$(basename "$asset")"

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -121,32 +121,29 @@ jobs:
 
       - name: Skip if the release is already finalized
         run: |
-          set -euo pipefail
-          # A completed release is published (non-draft) AND already carries the
-          # two .deb assets. Immutable releases forbid re-uploading, so a re-run
-          # against a finished release would 422 — detect that and stop cleanly.
-          # Uses gh's built-in --jq (system jq is not installed in the image).
-          # GitHub normalises stored asset names (the Debian '~' becomes '.'),
-          # so match by package-name prefix, not the exact filename.
-          draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
-          emr=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
-            --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-          drugref=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
-            --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-          if [ "$draft" = "true" ] || [ -z "$draft" ]; then
-            # Draft (or no release yet): proceed to build, attach, and publish.
+          set -eu
+          # gh release view (unlike the releases/tags REST endpoint, which 404s
+          # on drafts) can see a DRAFT release. Under the release flow the
+          # release is a draft carrying only the WAR at this point, so we must
+          # not treat "not published yet" as "published without debs".
+          #   draft, or no release yet -> proceed to build, attach, and publish
+          #   published with both packages -> nothing to do (immutable; re-upload would 422)
+          #   published but missing a package -> fail fast (immutable, unfixable)
+          isdraft=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo missing)
+          if [ "$isdraft" != "false" ]; then
             echo "SKIP=false" >> "$GITHUB_ENV"
-          elif [ "${emr:-0}" -ge 1 ] && [ "${drugref:-0}" -ge 1 ]; then
-            # Fully finalized: published with its .debs. Nothing to do (and a
-            # re-upload would 422 against the immutable release).
-            echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
-            echo "SKIP=true" >> "$GITHUB_ENV"
           else
-            # Published but missing .debs: an immutable release cannot accept
-            # new assets, so this can never be completed. Fail fast and loud
-            # rather than dying later on an opaque HTTP 422 from the upload.
-            echo "::error::Release $RELEASE_TAG is already published but has no .deb assets. Immutable releases cannot accept new assets, so the .debs cannot be attached. This release is permanently WAR-only; ship the .debs with the next release."
-            exit 1
+            emr=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
+              --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
+            drugref=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
+              --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
+            if [ "$emr" -ge 1 ] && [ "$drugref" -ge 1 ]; then
+              echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
+              echo "SKIP=true" >> "$GITHUB_ENV"
+            else
+              echo "::error::Release $RELEASE_TAG is already published but is missing a .deb asset. Immutable releases cannot accept new assets, so this cannot be completed; ship the .debs with the next release."
+              exit 1
+            fi
           fi
 
       - name: Download and verify the release WAR

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -272,13 +272,13 @@ jobs:
           # immutable. The latest-pointer decision lives here (not in
           # publish-release.yml) because the release is only published once all
           # assets, including these .debs, are in place.
-          # POSIX case (the container step runs under sh/dash, not bash, so
-          # [[ ... =~ ]] is unavailable). The tag is already validated CalVer,
-          # so a -alphaN / -betaN / -rcN suffix is always the trailing segment.
+          # grep -E keeps the exact anchored semantics of the original regex
+          # (digits required, matched at end); the step runs under sh/dash, so
+          # bash's [[ ... =~ ]] is unavailable and a shell glob would not anchor.
           prerelease=false
-          case "$RELEASE_TAG" in
-            *-alpha[0-9]*|*-beta[0-9]*|*-rc[0-9]*) prerelease=true ;;
-          esac
+          if printf '%s' "$RELEASE_TAG" | grep -Eq -- '-(alpha|beta|rc)[1-9][0-9]*$'; then
+            prerelease=true
+          fi
 
           if [ "$prerelease" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -266,10 +266,13 @@ jobs:
           # immutable. The latest-pointer decision lives here (not in
           # publish-release.yml) because the release is only published once all
           # assets, including these .debs, are in place.
+          # POSIX case (the container step runs under sh/dash, not bash, so
+          # [[ ... =~ ]] is unavailable). The tag is already validated CalVer,
+          # so a -alphaN / -betaN / -rcN suffix is always the trailing segment.
           prerelease=false
-          if [[ "$RELEASE_TAG" =~ -(alpha|beta|rc)[1-9][0-9]*$ ]]; then
-            prerelease=true
-          fi
+          case "$RELEASE_TAG" in
+            *-alpha[0-9]*|*-beta[0-9]*|*-rc[0-9]*) prerelease=true ;;
+          esac
 
           if [ "$prerelease" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -242,7 +242,11 @@ jobs:
           # asset name (it rewrites the '~' in a Debian pre-release version
           # to '.'), so a name-equality lookup never matched and the check
           # failed on every alpha/rc tag. The digest is invariant.
-          stored_digests="$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.assets[].digest')"
+          # Resolve the release id first (gh release view sees drafts); the
+          # releases/tags/<tag> endpoint 404s on a draft, which is the state the
+          # release is in until this workflow publishes it below.
+          release_id=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json databaseId --jq '.databaseId')
+          stored_digests="$(gh api "repos/$REPO/releases/$release_id" --jq '.assets[].digest')"
           for asset in release-assets/*.deb; do
             name="$(basename "$asset")"
             expected="sha256:$(sha256sum "$asset" | awk '{print $1}')"


### PR DESCRIPTION
Follow-up to the immutable-release fix. The idempotency guard I added queried
`repos/.../releases/tags/<tag>`, which **404s for a draft release**. Under the
new flow the release is a draft (WAR only) when `deb-packages` runs, so the 404
JSON body flowed through `--jq` (`draft='null'`) and the guard wrongly took the
"published but missing debs" fail-fast branch — blocking the release from ever
attaching its `.deb`s. Caught live on the alpha7 run.

Fix: query with **`gh release view`**, which sees drafts. Also drop the
bash-only `set -o pipefail` (the step runs under `sh`). Logic now:
- draft, or no release yet → proceed to build/attach/publish
- published with both packages → skip (immutable; a re-upload would 422)
- published but missing a package → fail fast

alpha7 itself is being completed by dispatching this fixed workflow from the
branch (the alpha7 tag commit carries the buggy version and is immutable). This
PR lands the fix on the release line so it promotes to `main` for alpha8+.

Generated with Claude Code

## Summary by Sourcery

Update the Debian package release workflow to handle draft and immutable releases correctly while reliably verifying and publishing package assets.

Bug Fixes:
- Correct release idempotency checks to recognize draft releases and avoid blocking .deb package attachment.
- Fix release asset digest verification for draft releases.
- Preserve prerelease detection when running the workflow with POSIX-compatible shell commands.

Enhancements:
- Use an explicit release state to proceed for draft or missing releases, skip finalized releases with both packages, and fail fast for incomplete immutable releases.

CI:
- Configure the Debian package workflow to run with bash consistently across container steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deb-packages workflow to correctly detect DRAFT releases, verify .deb digests on drafts, and run with a deterministic shell. Previously the guard queried releases/tags/<tag>, misclassified drafts, and blocked .deb uploads; digest verification also failed on drafts.

- Guard derives state from gh release view: draft/none -> build/attach/publish; done -> skip; missing -> fail fast.
- Digest verification resolves the numeric release id from the releases list and reads digests via releases/<id>, which includes drafts and avoids id mismatches.
- Job pins the shell to bash; prerelease detection uses anchored grep -E '-(alpha|beta|rc)[1-9][0-9]*$' to preserve the original regex semantics.
- Outcomes: Draft or no release → proceed. Published with both `carlos-emr` and `carlos-emr-drugref` .deb assets → skip. Published but missing a .deb → fail fast.

<sup>Written for commit cf0914886654d8116fe648a1fd438852436e2d90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

