### PR TITLE
chore(release): advance 2026.08 to alpha8 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha7</version>
+    <version>2026.08.0-alpha8-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha7</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
`2026.08.0-alpha7` is tagged and published — the first release to ship with
both `.deb` packages attached (via the fixed draft→attach→publish pipeline).

- pom `<version>`: `2026.08.0-alpha7` → `2026.08.0-alpha8-SNAPSHOT`
- pom `<scm><tag>`: `2026.08.0-alpha7` → `HEAD`

`develop` stays `2026.09.0-SNAPSHOT`. From alpha8 on, tagging on main publishes
debs automatically — no manual deb-build dispatch needed.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the 2026.08 release line to 2026.08.0-alpha8-SNAPSHOT and set SCM tag to HEAD after publishing alpha7. Previously we manually dispatched .deb builds; now tags on main auto-publish .deb packages.

- Verify only `pom.xml` changes: version to 2026.08.0-alpha8-SNAPSHOT and `<scm><tag>` to HEAD.
- Do not trigger manual deb-build jobs; tagging on main publishes debs automatically.
- `develop` stays at 2026.09.0-SNAPSHOT.

<sup>Written for commit 3ec9294cb4e30c8511489f5b98f8f10aa7adda58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

