### PR TITLE
chore(release): prepare 2026.08.0-alpha8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha8-SNAPSHOT</version>
+    <version>2026.08.0-alpha8</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha8</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Prepares the `2026.08.0-alpha8` release.

- pom `<version>`: `2026.08.0-alpha8-SNAPSHOT` → `2026.08.0-alpha8`
- pom `<scm><tag>`: `HEAD` → `2026.08.0-alpha8`

The deb-packages pipeline fixes (#3534) are on `release/2026.08` and reach
`main` with the promotion, so tagging alpha8 on main's head publishes the
release **with both `.deb`s automatically** — no manual deb dispatch (unlike
alpha7, whose tag commit predated the fixes).

## Sequence after merge
1. Promote `release/2026.08` → `main` (carries pom alpha8 + the pipeline fixes)
2. Tag `2026.08.0-alpha8` on main, message `Release 2026.08.0-alpha8`
3. Publish runs end-to-end: draft + WAR → debs attached → published
4. Advance `release/2026.08` → `2026.08.0-alpha9-SNAPSHOT`; forward-merge to develop

`develop` stays `2026.09.0-SNAPSHOT`.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes the 2026.08.0-alpha8 release by setting `pom.xml` version to 2026.08.0-alpha8 and `scm.tag` to 2026.08.0-alpha8. Tagging on main now publishes both .deb packages automatically; alpha7 required manual deb dispatch.

- Promote `release/2026.08` to `main`, then tag `2026.08.0-alpha8` on `main` (message: “Release 2026.08.0-alpha8”).
- Allow the publish pipeline to run end-to-end and attach both .deb packages.
- Bump `release/2026.08` to `2026.08.0-alpha9-SNAPSHOT` and forward-merge to `develop` (which remains `2026.09.0-SNAPSHOT`).

<sup>Written for commit 8406d1a6713c53f9b747ead5cf3c9b78bf4fc01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

