### PR TITLE
Promote release/2026.08 to main for 2026.08.0-alpha8

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -59,6 +59,12 @@ jobs:
   build-debs:
     name: Build and attach .deb packages
     runs-on: ubuntu-latest
+    # Pin the shell: container run steps otherwise default to /bin/sh, which
+    # differs from the runner's bash and broke earlier iterations. bash ships
+    # in the ubuntu:26.04 image, so set it once for the whole job.
+    defaults:
+      run:
+        shell: bash
     container:
       # Digest-pinned like every third-party artefact in this repository's
       # workflows: a re-pushed tag must never change what runs with release
@@ -273,8 +279,7 @@ jobs:
           # publish-release.yml) because the release is only published once all
           # assets, including these .debs, are in place.
           # grep -E keeps the exact anchored semantics of the original regex
-          # (digits required, matched at end); the step runs under sh/dash, so
-          # bash's [[ ... =~ ]] is unavailable and a shell glob would not anchor.
+          # (digits required, matched at end).
           prerelease=false
           if printf '%s' "$RELEASE_TAG" | grep -Eq -- '-(alpha|beta|rc)[1-9][0-9]*$'; then
             prerelease=true

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -123,28 +123,28 @@ jobs:
         run: |
           set -eu
           # gh release view (unlike the releases/tags REST endpoint, which 404s
-          # on drafts) can see a DRAFT release. Under the release flow the
-          # release is a draft carrying only the WAR at this point, so we must
-          # not treat "not published yet" as "published without debs".
-          #   draft, or no release yet -> proceed to build, attach, and publish
-          #   published with both packages -> nothing to do (immutable; re-upload would 422)
-          #   published but missing a package -> fail fast (immutable, unfixable)
-          isdraft=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo missing)
-          if [ "$isdraft" != "false" ]; then
-            echo "SKIP=false" >> "$GITHUB_ENV"
-          else
-            emr=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
-              --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-            drugref=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
-              --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-            if [ "$emr" -ge 1 ] && [ "$drugref" -ge 1 ]; then
+          # on drafts) can see a DRAFT release. One call computes the state via
+          # gh's built-in jq (system jq is not installed in the image):
+          #   draft / none  -> proceed to build, attach, and publish
+          #   done          -> published with BOTH packages; nothing to do
+          #                    (immutable, so a re-upload would 422)
+          #   missing       -> published but a package is absent; fail fast
+          #                    (immutable release can never be completed)
+          state=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json isDraft,assets --jq '
+            if .isDraft then "draft"
+            elif ([.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length) >= 1
+             and ([.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length) >= 1
+            then "done" else "missing" end' 2>/dev/null || echo none)
+          case "$state" in
+            draft|none)
+              echo "SKIP=false" >> "$GITHUB_ENV" ;;
+            done)
               echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
-              echo "SKIP=true" >> "$GITHUB_ENV"
-            else
+              echo "SKIP=true" >> "$GITHUB_ENV" ;;
+            missing)
               echo "::error::Release $RELEASE_TAG is already published but is missing a .deb asset. Immutable releases cannot accept new assets, so this cannot be completed; ship the .debs with the next release."
-              exit 1
-            fi
-          fi
+              exit 1 ;;
+          esac
 
       - name: Download and verify the release WAR
         if: env.SKIP != 'true'
@@ -242,10 +242,16 @@ jobs:
           # asset name (it rewrites the '~' in a Debian pre-release version
           # to '.'), so a name-equality lookup never matched and the check
           # failed on every alpha/rc tag. The digest is invariant.
-          # Resolve the release id first (gh release view sees drafts); the
-          # releases/tags/<tag> endpoint 404s on a draft, which is the state the
-          # release is in until this workflow publishes it below.
-          release_id=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json databaseId --jq '.databaseId')
+          # releases/tags/<tag> 404s on a draft (the release is a draft until
+          # this workflow publishes it). Resolve the numeric REST id from the
+          # releases LIST (which includes drafts and is guaranteed to be the
+          # REST id), mirroring publish-release.yml, then read digests by id.
+          release_id=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+            --jq ".[] | select(.tag_name == \"$RELEASE_TAG\") | .id" | head -n 1)
+          if [ -z "$release_id" ]; then
+            echo "::error::Release $RELEASE_TAG not found when verifying .deb digests."
+            exit 1
+          fi
           stored_digests="$(gh api "repos/$REPO/releases/$release_id" --jq '.assets[].digest')"
           for asset in release-assets/*.deb; do
             name="$(basename "$asset")"

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -121,32 +121,29 @@ jobs:
 
       - name: Skip if the release is already finalized
         run: |
-          set -euo pipefail
-          # A completed release is published (non-draft) AND already carries the
-          # two .deb assets. Immutable releases forbid re-uploading, so a re-run
-          # against a finished release would 422 — detect that and stop cleanly.
-          # Uses gh's built-in --jq (system jq is not installed in the image).
-          # GitHub normalises stored asset names (the Debian '~' becomes '.'),
-          # so match by package-name prefix, not the exact filename.
-          draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
-          emr=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
-            --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-          drugref=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
-            --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
-          if [ "$draft" = "true" ] || [ -z "$draft" ]; then
-            # Draft (or no release yet): proceed to build, attach, and publish.
+          set -eu
+          # gh release view (unlike the releases/tags REST endpoint, which 404s
+          # on drafts) can see a DRAFT release. Under the release flow the
+          # release is a draft carrying only the WAR at this point, so we must
+          # not treat "not published yet" as "published without debs".
+          #   draft, or no release yet -> proceed to build, attach, and publish
+          #   published with both packages -> nothing to do (immutable; re-upload would 422)
+          #   published but missing a package -> fail fast (immutable, unfixable)
+          isdraft=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo missing)
+          if [ "$isdraft" != "false" ]; then
             echo "SKIP=false" >> "$GITHUB_ENV"
-          elif [ "${emr:-0}" -ge 1 ] && [ "${drugref:-0}" -ge 1 ]; then
-            # Fully finalized: published with its .debs. Nothing to do (and a
-            # re-upload would 422 against the immutable release).
-            echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
-            echo "SKIP=true" >> "$GITHUB_ENV"
           else
-            # Published but missing .debs: an immutable release cannot accept
-            # new assets, so this can never be completed. Fail fast and loud
-            # rather than dying later on an opaque HTTP 422 from the upload.
-            echo "::error::Release $RELEASE_TAG is already published but has no .deb assets. Immutable releases cannot accept new assets, so the .debs cannot be attached. This release is permanently WAR-only; ship the .debs with the next release."
-            exit 1
+            emr=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
+              --jq '[.assets[].name | select(startswith("carlos-emr_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
+            drugref=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
+              --jq '[.assets[].name | select(startswith("carlos-emr-drugref_") and endswith(".deb"))] | length' 2>/dev/null || echo 0)
+            if [ "$emr" -ge 1 ] && [ "$drugref" -ge 1 ]; then
+              echo "Release $RELEASE_TAG is already published with both carlos-emr and carlos-emr-drugref .deb assets; nothing to do."
+              echo "SKIP=true" >> "$GITHUB_ENV"
+            else
+              echo "::error::Release $RELEASE_TAG is already published but is missing a .deb asset. Immutable releases cannot accept new assets, so this cannot be completed; ship the .debs with the next release."
+              exit 1
+            fi
           fi
 
       - name: Download and verify the release WAR

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -272,13 +272,13 @@ jobs:
           # immutable. The latest-pointer decision lives here (not in
           # publish-release.yml) because the release is only published once all
           # assets, including these .debs, are in place.
-          # POSIX case (the container step runs under sh/dash, not bash, so
-          # [[ ... =~ ]] is unavailable). The tag is already validated CalVer,
-          # so a -alphaN / -betaN / -rcN suffix is always the trailing segment.
+          # grep -E keeps the exact anchored semantics of the original regex
+          # (digits required, matched at end); the step runs under sh/dash, so
+          # bash's [[ ... =~ ]] is unavailable and a shell glob would not anchor.
           prerelease=false
-          case "$RELEASE_TAG" in
-            *-alpha[0-9]*|*-beta[0-9]*|*-rc[0-9]*) prerelease=true ;;
-          esac
+          if printf '%s' "$RELEASE_TAG" | grep -Eq -- '-(alpha|beta|rc)[1-9][0-9]*$'; then
+            prerelease=true
+          fi
 
           if [ "$prerelease" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -266,10 +266,13 @@ jobs:
           # immutable. The latest-pointer decision lives here (not in
           # publish-release.yml) because the release is only published once all
           # assets, including these .debs, are in place.
+          # POSIX case (the container step runs under sh/dash, not bash, so
+          # [[ ... =~ ]] is unavailable). The tag is already validated CalVer,
+          # so a -alphaN / -betaN / -rcN suffix is always the trailing segment.
           prerelease=false
-          if [[ "$RELEASE_TAG" =~ -(alpha|beta|rc)[1-9][0-9]*$ ]]; then
-            prerelease=true
-          fi
+          case "$RELEASE_TAG" in
+            *-alpha[0-9]*|*-beta[0-9]*|*-rc[0-9]*) prerelease=true ;;
+          esac
 
           if [ "$prerelease" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -242,7 +242,11 @@ jobs:
           # asset name (it rewrites the '~' in a Debian pre-release version
           # to '.'), so a name-equality lookup never matched and the check
           # failed on every alpha/rc tag. The digest is invariant.
-          stored_digests="$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.assets[].digest')"
+          # Resolve the release id first (gh release view sees drafts); the
+          # releases/tags/<tag> endpoint 404s on a draft, which is the state the
+          # release is in until this workflow publishes it below.
+          release_id=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json databaseId --jq '.databaseId')
+          stored_digests="$(gh api "repos/$REPO/releases/$release_id" --jq '.assets[].digest')"
           for asset in release-assets/*.deb; do
             name="$(basename "$asset")"
             expected="sha256:$(sha256sum "$asset" | awk '{print $1}')"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha8-SNAPSHOT</version>
+    <version>2026.08.0-alpha8</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha8</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha7</version>
+    <version>2026.08.0-alpha8-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha7</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Promotes `release/2026.08` to `main` so the `2026.08.0-alpha8` tag sits on
main's head. Tree identical to `release/2026.08`; pom + scm.tag =
`2026.08.0-alpha8`.

Critically, this brings the **deb-packages pipeline fixes (#3534)** to `main`
(draft-safe guard + digest verify via `gh release view`/releases list; job
shell pinned to bash). So tagging `2026.08.0-alpha8` here runs the fully-fixed
pipeline: **tag → draft + WAR → debs attached → published, in one pass** (no
manual dispatch like alpha7 needed).

## After merge
    git tag -a 2026.08.0-alpha8 -m "Release 2026.08.0-alpha8" <main-head>
    git push origin 2026.08.0-alpha8

Then advance `release/2026.08` → `2026.08.0-alpha9-SNAPSHOT` + forward-merge to
develop.

Generated with Claude Code

## Summary by Sourcery

Prepare the 2026.08.0-alpha8 release on main with a reliable end-to-end Debian package publication workflow.

Bug Fixes:
- Fix Debian package workflow handling of draft releases and verification of release asset digests.
- Prevent failed reruns from attempting uploads to already finalized immutable releases.

Enhancements:
- Pin Debian package job execution to Bash and update prerelease detection for reliable pipeline execution.

Build:
- Advance the project version and SCM release tag to 2026.08.0-alpha8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `release/2026.08` to `main` and prepares `2026.08.0-alpha8`. Tagging on `main` now runs the fixed deb-packages pipeline end-to-end: draft release → WAR + .deb attached → publish, no manual dispatch.
Previously the job misread draft releases and digest checks and hit shell incompatibilities; it now uses `gh release view` for draft-aware guards, resolves the numeric release ID for digest verification, pins the job shell to bash, and restores anchored prerelease detection. `pom.xml` and `scm.tag` are set to `2026.08.0-alpha8`.

- Rollout
  - Tag and push: git tag -a 2026.08.0-alpha8 -m "Release 2026.08.0-alpha8" <main-head> && git push origin 2026.08.0-alpha8
  - Then bump `release/2026.08` to `2026.08.0-alpha9-SNAPSHOT` and forward-merge to `develop`.

<sup>Written for commit 60eec83e1df92e0b7d11690ddb0b184866653f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

