### PR TITLE
fix: remove unused RxDsMessageTo1 import

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/RxDsMessageTo1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/RxDsMessageTo1.java
@@ -37,8 +37,6 @@ import java.util.ResourceBundle;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
-
 
 @XmlRootElement
 public class RxDsMessageTo1 implements Serializable {


### PR DESCRIPTION
## Summary

- remove the stale `MiscUtils` import left after the debug log removal in #3073
- restore the Checkstyle build on `develop` and branches that merge it

## Testing

- `mvn -B -DskipTests checkstyle:checkstyle`

## Context

This is the upstream fix for the Checkstyle failure observed after merging `develop` into #3097.

## Summary by Sourcery

Restore Checkstyle validation by removing the stale import from `RxDsMessageTo1`.

Bug Fixes:
- Remove the unused `MiscUtils` import from `RxDsMessageTo1` to restore Checkstyle validation.

Build:
- Restore successful Checkstyle builds for affected branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unused `io.github.carlos_emr.carlos.utility.MiscUtils` import from `RxDsMessageTo1`, restoring the Checkstyle build. Previously Checkstyle failed on `develop` due to this unused import; now it passes with no runtime behavior change.

- Affects only static analysis; binaries and runtime behavior are unchanged.
- Verify: mvn -B -DskipTests checkstyle:checkstyle

<sup>Written for commit 19922898c14a04e293d01618145682f613503323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

