### PR TITLE
fix: null-check property key before FORMS_PROMOTEXT equals

### DIFF
--- a/src/main/java/io/github/carlos_emr/CarlosProperties.java
+++ b/src/main/java/io/github/carlos_emr/CarlosProperties.java
@@ -117,13 +117,13 @@ public class CarlosProperties extends Properties {
      * @return the validated property value, or null if not found
      */
     public String getProperty(String key) {
-        if (key.equals("FORMS_PROMOTEXT")) {
-            return "";
-        }
-
         if (key == null || key.trim().isEmpty()) {
             MiscUtils.getLogger().warn("Attempted to retrieve property with blank key.");
             throw new IllegalArgumentException("Property key cannot be blank.");
+        }
+
+        if (key.equals("FORMS_PROMOTEXT")) {
+            return "";
         }
 
         String value = super.getProperty(key);


### PR DESCRIPTION
## Summary

fix: null-check property key before FORMS_PROMOTEXT equals

## Changes

- Move null/blank guard before key.equals so getProperty(null) raises IllegalArgumentException not NPE.

Fixes #2930

## Summary by Sourcery

Bug Fixes:
- Validate null or blank property keys before checking special property names so invalid requests consistently raise IllegalArgumentException instead of NullPointerException.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a NullPointerException when `CarlosProperties#getProperty` is called with a null key by moving the blank-key guard before the `FORMS_PROMOTEXT` equality check. Previously `getProperty(null)` threw NPE; now it logs a warning and throws `IllegalArgumentException`. The `FORMS_PROMOTEXT` special case still returns an empty string.

- Migration: Update any callers that relied on catching NPE for null keys to catch `IllegalArgumentException` instead.

<sup>Written for commit 8212faf4ee6d9869525ff3458f48690b346e4cd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

