### PR TITLE
ci: evict all vendored JitPack artifacts from restored Maven caches

### DIFF
--- a/.github/workflows/maven-project.yml
+++ b/.github/workflows/maven-project.yml
@@ -144,8 +144,13 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Purge stale local_repo artifacts from Maven cache
+        # Both formerly-JitPack groupIds are vendored in local_repo with bytes
+        # that differ from what JitPack ever served; a restored cache copy
+        # shadows local_repo (Maven prefers ~/.m2 and never re-verifies cached
+        # bytes), so evict them and let them re-copy from file://local_repo.
         run: |
-          rm -rf .m2-cache/repository/com/github/openosp/ultrabuk-htmltopdf-java
+          rm -rf .m2-cache/repository/com/github/openosp \
+                 .m2-cache/repository/com/github/librepdf
 
       - name: Build dev container (fallback)
         if: steps.pull-image.outputs.pulled != 'true'
@@ -292,8 +297,13 @@ jobs:
           "
 
       - name: Purge stale local_repo artifacts from Maven cache
+        # Both formerly-JitPack groupIds are vendored in local_repo with bytes
+        # that differ from what JitPack ever served; a restored cache copy
+        # shadows local_repo (Maven prefers ~/.m2 and never re-verifies cached
+        # bytes), so evict them and let them re-copy from file://local_repo.
         run: |
-          rm -rf .m2-cache/repository/com/github/openosp/ultrabuk-htmltopdf-java
+          rm -rf .m2-cache/repository/com/github/openosp \
+                 .m2-cache/repository/com/github/librepdf
 
       - name: Run tests
         run: |
@@ -437,8 +447,13 @@ jobs:
           "
 
       - name: Purge stale local_repo artifacts from Maven cache
+        # Both formerly-JitPack groupIds are vendored in local_repo with bytes
+        # that differ from what JitPack ever served; a restored cache copy
+        # shadows local_repo (Maven prefers ~/.m2 and never re-verifies cached
+        # bytes), so evict them and let them re-copy from file://local_repo.
         run: |
-          rm -rf .m2-cache/repository/com/github/openosp/ultrabuk-htmltopdf-java
+          rm -rf .m2-cache/repository/com/github/openosp \
+                 .m2-cache/repository/com/github/librepdf
 
       - name: Compile JSPs
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -151,6 +151,16 @@ jobs:
           mkdir -p .m2-cache
           mkdir -p .sonar-cache
 
+      - name: Purge stale local_repo artifacts from Maven cache
+        # Both formerly-JitPack groupIds are vendored in local_repo with bytes
+        # that differ from what JitPack ever served; a restored cache copy
+        # shadows local_repo (Maven prefers ~/.m2 and never re-verifies cached
+        # bytes), so evict them and let them re-copy from file://local_repo.
+        # Same guard as maven-project.yml / dependency-submission.yml.
+        run: |
+          rm -rf .m2-cache/repository/com/github/openosp \
+                 .m2-cache/repository/com/github/librepdf
+
       - name: Build dev container (fallback)
         if: steps.pull-image.outputs.pulled != 'true'
         run: |


### PR DESCRIPTION
## Description

Closes the remaining Maven cache-poisoning gaps behind the recurring `dependency-lock` integrity failures on the vendored ex-JitPack artifacts.

**Root cause (diagnosed on #3548):** `com.github.openosp:ultrabuk-htmltopdf-java` and `com.github.librepdf:openpdf` 3.x are vendored in `local_repo/` with bytes that differ from what JitPack ever served. Maven prefers whatever is already in the local repository over re-resolving from `local_repo`, and when a cached artifact's original remote id no longer exists it re-verifies *availability*, never *bytes* — so a pre-vendoring copy restored from a GitHub Actions cache shadows the vendored jar indefinitely, propagating itself through the restore-keys → re-save chain. Where the lock check runs, it fails (`Expected …@sha512:19I1LHAib… but found …@sha512:fiXBLMWh…`); where it's skipped, the build silently uses the stale bytes.

`dependency-submission.yml` already evicts both groupIds before validating. This PR brings the other cache-consuming workflows up to the same guard:

- **`maven-project.yml`** — the existing purge steps in `build`, `tests`, and `jspc` only evicted `ultrabuk-htmltopdf-java`; broadened to both vendored groupIds.
- **`sonarcloud.yml`** — had no purge at all; added the same step after the cache directories are prepared.

**Deliberately unchanged:** `publish-release.yml` builds in a fresh `.m2` with no cache restore, so the shipped WAR always embeds the vendored bytes; `deb-packages.yml` likewise restores no Maven cache.

**Not fixable in any file:** the currently-red `submit-maven` check on PRs comes from GitHub's **"Automatic dependency submission"** repo setting (`dynamic/dependency-graph/auto-submission`) — a settings-driven dynamic workflow with no YAML to carry this guard, red on every recent commit including the `release/2026.08` HEAD. Fix is admin-side: disable that redundant setting (the checked-in `dependency-submission.yml` submits the same graph, correctly), and/or purge the `Linux-jdk21-temurin-maven-*` Actions caches — post-vendoring nothing can re-fetch from JitPack, so cleaned caches stay clean.

## Related Issues

Related to the `submit-maven` failures discussed on #3548.

## Target Branch

Topic branch from `release/2026.08` targeting that same branch, at the maintainer's direction — the cache-poisoning failures currently bite this line's PR CI, and the sibling guards these files already carry (`dependency-submission.yml`, the ultrabuk-only purges) live on this branch. Maintainers forward-merge into newer lines; no version/SCM metadata is touched.

## How Was This Tested?

- Verified the vendored jar's SHA-512 (`19I1LHAib…`) matches `dependencies-lock.json` exactly — lock and `local_repo` are in sync; the divergent copy exists only in restored CI caches.
- Confirmed which workflows restore a Maven cache and which already purge: `dependency-submission.yml` (both groupIds ✓), `maven-project.yml` (ultrabuk only ✗ → fixed), `sonarcloud.yml` (none ✗ → fixed), `publish-release.yml`/`deb-packages.yml` (no cache restore, nothing to do).
- `yaml.safe_load` parses both edited files; the change is two `rm -rf` path additions and one copied step — no trigger, permission, or job-graph changes.

## Checklist

- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My commits follow Conventional Commits format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests (CI-only path additions)
- [x] I have read the contributing guide
- [x] I selected the target branch according to the release process (release-line CI correction at maintainer direction)
- [x] I preserved the target branch version/SCM metadata
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJTSSjiPVpmVz2mUZ467Tf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJTSSjiPVpmVz2mUZ467Tf)_

## Summary by Sourcery

Evict all vendored JitPack artifacts from CI Maven caches to ensure workflows use the repository’s verified vendored dependencies.

Bug Fixes:
- Prevent restored Maven caches from supplying stale copies of vendored JitPack artifacts by evicting both affected group IDs before builds and analysis run.

CI:
- Align Maven project and SonarCloud workflows with the existing dependency-submission cache cleanup guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evicts both vendored JitPack group IDs from restored Maven caches in `maven-project.yml` and `sonarcloud.yml` so cached copies no longer shadow the vendored artifacts and trip the dependency-lock integrity check.

- The old purge step in `maven-project.yml` only removed `com.github.openosp/ultrabuk-htmltopdf-java`; it now removes both `com.github.openosp` and `com.github.librepdf`.
- `sonarcloud.yml` previously had no purge and now adds the same eviction step.
- `publish-release.yml` and `deb-packages.yml` are unchanged because they don't restore a Maven cache.
- The still‑red `submit-maven` check has no workflow file; fixing it requires disabling the repo-level "Automatic dependency submission" setting or purging the poisoned `Linux-jdk21-temurin-maven-*` Actions caches.

<sup>Written for commit a255086e7e5dc28140cd67f82e5666accff01240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

