### PR TITLE
feat(deb): recommend a memory-sized Java heap in the install wizard

### DIFF
--- a/debian/carlos-emr.config
+++ b/debian/carlos-emr.config
@@ -34,37 +34,46 @@ else
         ''|localhost|localhost.*) : ;;
         *) db_set carlos-emr/server-name "${fqdn}" ;;
     esac
-fi
 
-# Recommend a heap sized for this machine instead of the static 2g template
-# default, the way the OSCAR 19 packaging did (it took 60% of MemTotal, capped
-# at 6g). This package's documented budget is: heap gets about half of physical
-# memory, the rest is left for MariaDB's buffer pool and ~1 GB for the OS
-# (carlos-emr.env, 60-carlos-emr.cnf). Half of RAM, rounded to the nearest
-# whole GB, clamped to 2g (below which CARLOS thrashes in GC) .. 8g (past
-# which a single-clinic heap stops paying — surplus RAM belongs to
-# innodb_buffer_pool_size).
-#
-# The seen-flag guard keeps this from clobbering an answer that already
-# exists: a preseeded install (debconf-set-selections marks the question
-# seen), a reconfigure, or an upgrade (also covered by the env-file seeding
-# above). If /proc/meminfo is unreadable — some containers — the case guard
-# falls through and the template's 2g default stands.
-db_fget carlos-emr/java-heap seen || true
-if [ "${RET}" != true ]; then
-    # `|| true`: a missing /proc/meminfo fails the command substitution, and
-    # under set -e a failed assignment would abort the whole question script.
-    mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
-    case "${mem_kb}" in
-        ''|*[!0-9]*) : ;;
-        *)
-            # (mem_kb + 1 GiB) / 2 GiB == round-to-nearest of (mem_kb / 2) GiB
-            heap_gb=$(( (mem_kb + 1048576) / 2097152 ))
-            if [ "${heap_gb}" -lt 2 ]; then heap_gb=2; fi
-            if [ "${heap_gb}" -gt 8 ]; then heap_gb=8; fi
-            db_set carlos-emr/java-heap "${heap_gb}g"
-            ;;
-    esac
+    # First install only: recommend a heap sized for this machine instead of
+    # the static 2g template default, the way the OSCAR 19 packaging did (it
+    # took 60% of MemTotal, capped at 6g). This package's documented budget
+    # is: heap gets about half of physical memory, the rest is left for
+    # MariaDB's buffer pool and ~1 GB for the OS (carlos-emr.env,
+    # 60-carlos-emr.cnf). Half of RAM, rounded to the nearest whole GB,
+    # clamped to 2g (below which CARLOS thrashes in GC) .. 8g (past which a
+    # single-clinic heap stops paying — surplus RAM belongs to
+    # innodb_buffer_pool_size).
+    #
+    # This sits in the no-env-file branch on purpose: an operator-tuned
+    # CARLOS_JAVA_XMX seeded above must never be replaced by the calculation,
+    # and the seen flag alone cannot guarantee that — a noninteractive
+    # install leaves questions unseen (debconf marks input seen only when a
+    # frontend actually shows it, unless DEBCONF_NONINTERACTIVE_SEEN=true),
+    # so an unattended upgrade would recompute over the deployed value. The
+    # seen-flag guard below narrows first install further: a preseeded answer
+    # (debconf-set-selections marks the question seen) also wins over the
+    # calculation. If /proc/meminfo is unreadable — some containers — the
+    # case guard falls through and the template's 2g default stands.
+    db_fget carlos-emr/java-heap seen || true
+    if [ "${RET}" != true ]; then
+        # `|| true`: a missing /proc/meminfo fails the command substitution,
+        # and under set -e a failed assignment would abort the whole script.
+        mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
+        case "${mem_kb}" in
+            ''|*[!0-9]*) : ;;
+            *)
+                # Target is MemTotal/2 expressed in GiB: mem_kb kB divided by
+                # (2 * 1048576) kB/GiB = mem_kb / 2097152. Rounding to the
+                # nearest integer adds half the divisor before the truncating
+                # division: (mem_kb + 1048576) / 2097152.
+                heap_gb=$(( (mem_kb + 1048576) / 2097152 ))
+                if [ "${heap_gb}" -lt 2 ]; then heap_gb=2; fi
+                if [ "${heap_gb}" -gt 8 ]; then heap_gb=8; fi
+                db_set carlos-emr/java-heap "${heap_gb}g"
+                ;;
+        esac
+    fi
 fi
 
 db_input high carlos-emr/server-name || true

--- a/debian/carlos-emr.config
+++ b/debian/carlos-emr.config
@@ -36,6 +36,37 @@ else
     esac
 fi
 
+# Recommend a heap sized for this machine instead of the static 2g template
+# default, the way the OSCAR 19 packaging did (it took 60% of MemTotal, capped
+# at 6g). This package's documented budget is: heap gets about half of physical
+# memory, the rest is left for MariaDB's buffer pool and ~1 GB for the OS
+# (carlos-emr.env, 60-carlos-emr.cnf). Half of RAM, rounded to the nearest
+# whole GB, clamped to 2g (below which CARLOS thrashes in GC) .. 8g (past
+# which a single-clinic heap stops paying — surplus RAM belongs to
+# innodb_buffer_pool_size).
+#
+# The seen-flag guard keeps this from clobbering an answer that already
+# exists: a preseeded install (debconf-set-selections marks the question
+# seen), a reconfigure, or an upgrade (also covered by the env-file seeding
+# above). If /proc/meminfo is unreadable — some containers — the case guard
+# falls through and the template's 2g default stands.
+db_fget carlos-emr/java-heap seen || true
+if [ "${RET}" != true ]; then
+    # `|| true`: a missing /proc/meminfo fails the command substitution, and
+    # under set -e a failed assignment would abort the whole question script.
+    mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || true)"
+    case "${mem_kb}" in
+        ''|*[!0-9]*) : ;;
+        *)
+            # (mem_kb + 1 GiB) / 2 GiB == round-to-nearest of (mem_kb / 2) GiB
+            heap_gb=$(( (mem_kb + 1048576) / 2097152 ))
+            if [ "${heap_gb}" -lt 2 ]; then heap_gb=2; fi
+            if [ "${heap_gb}" -gt 8 ]; then heap_gb=8; fi
+            db_set carlos-emr/java-heap "${heap_gb}g"
+            ;;
+    esac
+fi
+
 db_input high carlos-emr/server-name || true
 db_input high carlos-emr/bind-ip || true
 db_input high carlos-emr/province || true

--- a/debian/carlos-emr.templates
+++ b/debian/carlos-emr.templates
@@ -75,8 +75,9 @@ Description: Java heap size for the CARLOS application server:
  server give it roughly half of physical memory, leaving room for MariaDB's
  buffer pool and about 1 GB for the operating system.
  .
- The value offered has already been sized from this machine's memory (half of
- RAM, between 2g and 8g). Accept it unless the host is shared with other
+ On a fresh install the value offered is sized from this machine's memory
+ (half of RAM, between 2g and 8g); on reconfiguration or upgrade it is the
+ currently configured value. Accept it unless the host is shared with other
  services or the database runs elsewhere.
  .
  Use the JVM's own notation, for example 4g or 6144m.

--- a/debian/carlos-emr.templates
+++ b/debian/carlos-emr.templates
@@ -75,6 +75,10 @@ Description: Java heap size for the CARLOS application server:
  server give it roughly half of physical memory, leaving room for MariaDB's
  buffer pool and about 1 GB for the operating system.
  .
+ The value offered has already been sized from this machine's memory (half of
+ RAM, between 2g and 8g). Accept it unless the host is shared with other
+ services or the database runs elsewhere.
+ .
  Use the JVM's own notation, for example 4g or 6144m.
 
 Template: carlos-emr/reset-seed-admin

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+carlos-emr (2026.09.0~snapshot3) resolute; urgency=medium
+
+  * Install wizard: recommend a Java heap sized from the machine's memory
+    instead of a static 2g — half of physical RAM, rounded to the nearest GB,
+    clamped to 2g..8g — as the pre-filled answer to the java-heap question on
+    first install (successor to the OSCAR-19 packaging's 60%-of-RAM sizing).
+    Preseeded, reconfigured and upgraded installs keep their existing answer.
+
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Fri, 28 Aug 2026 14:00:00 +0000
+
 carlos-emr (2026.09.0~snapshot2) resolute; urgency=medium
 
   * Fix nine clinician-facing bugs reported by alpha testers on the .deb

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -107,11 +107,12 @@ The application server and database always listen on loopback only.
 
 ![Billing province question](images/install/03-province.png)
 
-**4. Java heap** — the installer pre-fills a recommendation sized from the
-machine's memory: half of physical RAM, between `2g` and `8g`. Accept it on a
-dedicated box; lower it only if the host is shared or the database runs
-elsewhere (CARLOS needs at least `2g`; the rest of RAM is left for MariaDB
-and ~1 GB for the OS).
+**4. Java heap** — on a fresh install the installer pre-fills a recommendation
+sized from the machine's memory: half of physical RAM, between `2g` and `8g`
+(on reconfiguration or upgrade it offers the currently configured value).
+Accept it on a dedicated box; lower it only if the host is shared or the
+database runs elsewhere (CARLOS needs at least `2g`; the rest of RAM is left
+for MariaDB and ~1 GB for the OS).
 
 ![Java heap question](images/install/04-java-heap.png)
 

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -107,8 +107,11 @@ The application server and database always listen on loopback only.
 
 ![Billing province question](images/install/03-province.png)
 
-**4. Java heap** — CARLOS needs at least `2g`; on a dedicated box give it about
-half of physical memory (leave room for MariaDB and ~1 GB for the OS).
+**4. Java heap** — the installer pre-fills a recommendation sized from the
+machine's memory: half of physical RAM, between `2g` and `8g`. Accept it on a
+dedicated box; lower it only if the host is shared or the database runs
+elsewhere (CARLOS needs at least `2g`; the rest of RAM is left for MariaDB
+and ~1 GB for the OS).
 
 ![Java heap question](images/install/04-java-heap.png)
 


### PR DESCRIPTION
## Description

The deb install wizard's `carlos-emr/java-heap` debconf question offered a static `2g` default while its own help text told the operator to give CARLOS about half of physical memory. The retired OSCAR-19 packaging (formerly `release/postinst`) actually computed the heap from the machine's memory (60% of `MemTotal`, capped at 6g); this restores that behavior against the current package's documented memory budget (heap + MariaDB buffer pool + ~1 GB for the OS, per `carlos-emr.env` and `60-carlos-emr.cnf`).

On first install, `debian/carlos-emr.config` now pre-fills the question with **half of physical RAM, rounded to the nearest whole GB, clamped to 2g..8g** — below 2g CARLOS thrashes in GC; past 8g surplus RAM is better spent on `innodb_buffer_pool_size`. Examples: 4 GB VM → `2g`, 8 GB → `4g`, 16 GB+ → `8g`.

Guard rails:
- A `db_fget … seen` guard keeps the recommendation from clobbering an answer that already exists: preseeded installs, `dpkg-reconfigure`, and upgrades (the latter also covered by the existing env-file seeding) all keep their current value.
- If `/proc/meminfo` is unreadable (some containers), the script silently keeps the `2g` template default — including a `|| true` on the `awk` command substitution so a missing meminfo can't abort the question script under `set -e`.
- The `postinst` / `carlos-emr-tomcat` `2g` fallbacks are deliberately unchanged.

Also updates the template description and `docs/install-deb.md` step 4 so the operator knows the offered value is already sized for the machine, and adds a `2026.09.0~snapshot3` changelog entry.

## Related Issues

None — follow-up to the deb packaging work in #3510 / #3546.

## Target Branch

The deb packaging being adjusted lives on the 2026.08 release line currently in alpha stabilization; the branch was cut from and targets `release/2026.08`.

## How Was This Tested?

- `sh -n debian/carlos-emr.config` passes; the added shell is POSIX-only (constructs already used elsewhere in the file), keeping it checkbashisms/lintian-clean.
- The sizing block was extracted verbatim from the script and driven with stubbed `db_fget`/`db_set` and a fake meminfo across 10 cases: 2/4/6/8/16/32/64 GB (→ 2g/2g/3g/4g/8g/8g/8g), missing meminfo, non-numeric meminfo, and an already-seen question (→ no `db_set`, default preserved). All pass. This test caught the `set -e`/missing-meminfo abort before it shipped.
- `dpkg-parsechangelog` parses the new changelog entry (version `2026.09.0~snapshot3`, correct weekday).

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests (maintainer-script logic exercised via the stubbed harness above; no Java code touched)
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017criXiM9th3sghRwLxfCta

---
_Generated by [Claude Code](https://claude.ai/code/session_017criXiM9th3sghRwLxfCta)_

## Summary by Sourcery

Size the Debian installer’s initial Java heap recommendation from the host’s physical memory while preserving existing configuration and safe fallbacks.

New Features:
- Pre-fill the Debian install wizard’s Java heap setting with a machine-sized recommendation based on physical memory, bounded between 2g and 8g.

Bug Fixes:
- Preserve existing Java heap answers during preseeding, reconfiguration, upgrades, and when system memory information is unavailable.

Enhancements:
- Update installer guidance to explain the automatically sized heap recommendation and its memory allocation policy.

Documentation:
- Document the machine-sized Java heap recommendation and behavior for fresh installs, reconfiguration, and upgrades.

Tests:
- Validate the maintainer-script sizing behavior across supported memory sizes, invalid or missing memory data, and previously answered questions.

Chores:
- Add the corresponding Debian changelog entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The deb install wizard now pre-fills the Java heap question with a machine-sized recommendation — half of physical RAM, rounded to the nearest GB, clamped to 2g..8g — instead of a static 2g default, matching the question's help text.

- The sizing only runs in the first-install (no env file) branch, so upgrades and reconfiguration can never overwrite an operator-tuned `CARLOS_JAVA_XMX`.
- Preseeded fresh installs keep their answer via a seen-flag guard; an unreadable `/proc/meminfo` silently keeps the `2g` default.
- Updates the template description and `docs/install-deb.md` so operators know the offered value is machine-sized.

<sup>Written for commit 70a4ddf9c545a678b792e6ba63283a5341a6db5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

