### PR TITLE
fix: deb-deployment follow-ups from full front-door validation (WAF eForm/note saves, nullable-column 500s, signature defaults)

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -19,6 +19,8 @@ COPY ./.devcontainer/db/scripts/demo-name-sanitization.sql /scripts/demo-name-sa
 COPY ./.devcontainer/db/scripts/demo-name-sanitization-on.sql /scripts/demo-name-sanitization-on.sql
 COPY ./.devcontainer/db/scripts/demo-specialists.sql /scripts/demo-specialists.sql
 COPY ./.devcontainer/db/scripts/demo-provider-links.sql /scripts/demo-provider-links.sql
+COPY ./.devcontainer/db/scripts/demo-program-links.sql /scripts/demo-program-links.sql
+COPY ./.devcontainer/db/scripts/demo-issue-codes.sql /scripts/demo-issue-codes.sql
 COPY ./database /database
 COPY ./.devcontainer/development/config/shared/my.cnf /etc/mysql/my.cnf
 

--- a/.devcontainer/db/scripts/demo-issue-codes.sql
+++ b/.devcontainer/db/scripts/demo-issue-codes.sql
@@ -1,0 +1,23 @@
+-- ---------------------------------------------------------------------------
+-- CARLOS demo/development data — demo-only issue codes
+--
+-- The issue catalog is Flyway-owned (71 rows in V1.0.2) and excluded from
+-- the additive demo transform, but the dev snapshot's catalog carries ONE
+-- extra row the migrations do not: issue_id 73 'ExternalNote', the system
+-- issue NoteDisplayLocal.isExternalNote() keys on. The snapshot's
+-- casemgmt_issue rows (which DO load additively) reference it, and an
+-- unresolved issue pointing at a missing catalog row breaks the whole
+-- eChart issues module for that patient ("Could not retrieve data for
+-- unresolvedIssues", failed note locks, 500 on the encounter reload).
+--
+-- Seed exactly that row, guarded so it never duplicates an ExternalNote a
+-- future migration might add under another id, and IGNOREd so a foreign
+-- occupant of id 73 fails soft rather than aborting the demo load. In the
+-- devcontainer flow development.sql truncate-reloads the catalog with this
+-- row included, so this file is a no-op there.
+-- ---------------------------------------------------------------------------
+
+INSERT IGNORE INTO issue (issue_id, code, description, role, update_date, priority, type, sortOrderId)
+SELECT 73, 'ExternalNote', 'External Note', 'nurse', '2024-01-29 23:18:48', NULL, 'system', 0
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM issue WHERE code = 'ExternalNote');

--- a/.devcontainer/db/scripts/demo-program-links.sql
+++ b/.devcontainer/db/scripts/demo-program-links.sql
@@ -1,0 +1,32 @@
+-- ---------------------------------------------------------------------------
+-- CARLOS demo/development data — provider ↔ program links
+--
+-- program_provider is Flyway-seeded (V1.0.2 enrols carlosdoc in the 33
+-- legacy community programs, occupying auto-increment ids 1-33) and the raw
+-- dev-snapshot statement inserts its rows WITH explicit ids in that same
+-- range — under the additive load's INSERT IGNORE every snapshot row
+-- collides on the primary key and is silently dropped. The snapshot rows
+-- are the ones that matter: they enrol the demo providers in program 10034
+-- ("OSCAR", the Bed program every demo patient is admitted to), and without
+-- them each patient's eChart answers "Access Denied … not in your program
+-- domain". So the raw statement is excluded from the additive transform and
+-- replaced by this guarded version, which lets AUTO_INCREMENT assign the ids.
+--
+-- The EXISTS guards keep re-runs no-ops and skip cleanly when either
+-- endpoint is missing (program 10034 arrives with the additive snapshot;
+-- the demo load runs with FOREIGN_KEY_CHECKS=0, so the JOINs take over the
+-- FKs' job). In the devcontainer flow development.sql truncate-reloads the
+-- table with these same rows first, so this file is a no-op there.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO program_provider (program_id, provider_no, role_id, team_id)
+SELECT pr.id, p.provider_no, m.role_id, NULL
+FROM (SELECT '999998' AS provider_no, 2 AS role_id
+      UNION ALL SELECT '1', 2
+      UNION ALL SELECT '2', 2
+      UNION ALL SELECT '3', 2
+      UNION ALL SELECT '5', 3) m
+JOIN provider p ON p.provider_no = m.provider_no
+JOIN program pr ON pr.id = 10034
+WHERE NOT EXISTS (SELECT 1 FROM program_provider x
+                  WHERE x.program_id = pr.id AND x.provider_no = p.provider_no);

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -114,5 +114,5 @@ $SQL oscar < /database/mysql/updates/update-2026-06-29-rtl-attachment-route-fix.
 # signature workflows (consultation stamps, signature pad) like a stock
 # install does.
 echo 'Enabling digital signatures on the demo facility...'
-$SQL oscar -e "UPDATE Facility SET enableDigitalSignatures = 1;"
+$SQL oscar -e "UPDATE Facility SET enableDigitalSignatures = 1 WHERE id = 1;"
 echo 'Database initialization complete!'

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -100,4 +100,19 @@ $SQL oscar < /database/mysql/updates/update-2012-07-12.sql
 echo 'Modernizing Rich Text Letter eForm to 2026.3.0...'
 $SQL oscar < /database/mysql/updates/update-2026-03-22-rtl-2026.3.0-modernize.sql
 $SQL oscar < /database/mysql/updates/update-2026-03-12-rtl-enable-direct.sql
+# Must run AFTER the modernize update above: it string-replaces the dead
+# public-JSP attachment paths (attachEform.jsp / displayAttachedFiles.jsp)
+# that 2026.3.0 still carries with the gated Struts routes, and switches
+# fid/demographic_no lookup to the hidden inputs the saved-instance render
+# provides. Without it the seeded RTL's Attach flow 404s on every install -
+# the eform-rtl-attachment-* Playwright checks pin this.
+echo 'Rewiring Rich Text Letter attachment routes...'
+$SQL oscar < /database/mysql/updates/update-2026-06-29-rtl-attachment-route-fix.sql
+# development.sql truncate-reloads Facility with the old snapshot's
+# enableDigitalSignatures=0, undoing the V1.0.17 migration applied above.
+# Re-assert the product default so the demo environment exercises the
+# signature workflows (consultation stamps, signature pad) like a stock
+# install does.
+echo 'Enabling digital signatures on the demo facility...'
+$SQL oscar -e "UPDATE Facility SET enableDigitalSignatures = 1;"
 echo 'Database initialization complete!'

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -88,6 +88,13 @@ echo 'Restoring current Administration privileges...'
 $SQL oscar < /scripts/development_privileges.sql
 echo 'Seeding fake referral specialists and provider links...'
 $SQL oscar < /scripts/demo-provider-links.sql
+# Guarded no-ops here (development.sql truncate-reloads both tables with
+# these rows), kept for parity with the deb's carlos-ctl demo-data flow,
+# where the additive transform excludes the raw statements and these files
+# are the only source of the program-10034 enrolments and the ExternalNote
+# issue row. See scripts/demo-additive-exclude.txt (SPECIAL section).
+$SQL oscar < /scripts/demo-program-links.sql
+$SQL oscar < /scripts/demo-issue-codes.sql
 $SQL oscar < /scripts/demo-specialists.sql
 # Name sanitization v2: FAKE- prefixes across all person-name tables plus
 # replacement of known real names. The -on supplement covers Ontario-only

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -13,6 +13,38 @@
 #   - Validates the dependency lock file
 #   - Submits dependency graph to GitHub
 #
+# ---------------------------------------------------------------------------
+# Recovering a red "submit-maven" check (built-in Automatic Dependency
+# Submission) — NOT this workflow, but the failure people hit:
+#
+# GitHub's *managed* "Automatic Dependency Submission" feature (repo Settings >
+# Code security > Automatic dependency submission; job name "submit-maven")
+# runs its own `mvn` and CANNOT be customized, so it lacks the ~/.m2 eviction
+# the Validate-lock-file step below performs. Symptom: it fails with
+#   [ERROR] ... com.github.openosp:ultrabuk-htmltopdf-java ... wrong integrity
+# (or com.github.librepdf.openpdf:*), "Dependencies differ".
+#
+# Cause: those coordinates were once served by JitPack, whose on-demand rebuilds
+# return different bytes per fetch. They are now vendored in local_repo with the
+# exact bytes in dependencies-lock.json (JitPack is fully removed from the pom's
+# <repositories>), but any Actions cache saved BEFORE the vendoring still holds
+# the old jar, Maven prefers ~/.m2 over every repository, and prefix restore-keys
+# keep propagating the stale copy into each new cache generation. The lock file
+# itself is correct — do NOT "fix" it by running `make lock` against the stale
+# bytes; that would bless the wrong artifact.
+#
+# Fix (one-time, self-healing thereafter): delete the poisoned Maven caches, then
+# re-run the job so a clean run re-saves the deterministic-key cache from
+# local_repo.
+#   gh cache list  | grep -iE 'Linux-maven|Linux-.*-maven'   # find them
+#   gh cache delete <id>                                     # delete each stale one
+#   gh run rerun <failed-run-id>
+# Nothing can re-poison it now that JitPack is gone, so this is a one-time
+# cleanup — a bump of a vendored coordinate would land under a new cache key and
+# re-resolve clean. Better still: disable the redundant managed feature; THIS
+# workflow already submits the graph and validates the lock with the eviction.
+# ---------------------------------------------------------------------------
+#
 # License:
 # This GitHub Workflow file is part of the Carlos EMR project and is subject
 # to the licensing terms outlined in the repository's LICENSE file.

--- a/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
+++ b/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
@@ -21,4 +21,12 @@
 -- the operator re-disables once post-upgrade if desired. The postinst twin for
 -- the carlos.properties consultation_signature_enabled flag makes the same
 -- accepted tradeoff for its exact old-stock line.
+--
+-- One more dimension of that override, for the release note: on a converted
+-- pre-Flyway datadir adopted at baseline 1.0.2 (so this migration then runs),
+-- "id = 1" is whatever the legacy datadir's first Facility row is. That is the
+-- Default Facility on essentially every install, but a legacy multi-facility
+-- site whose PRIMARY clinic occupies id 1 with a deliberate off-choice would
+-- have it flipped. Same accepted "a boolean can't distinguish chosen-off"
+-- tradeoff, just widened from "the seeded default row" to "whatever row is id 1".
 UPDATE Facility SET enableDigitalSignatures = 1 WHERE id = 1;

--- a/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
+++ b/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
@@ -1,9 +1,14 @@
 -- Digital signatures (consultation stamps and signature-pad capture on
 -- consultations and prescriptions) are gated per facility by
--- Facility.enableDigitalSignatures, and the seeded Default Facility shipped
--- with it OFF - so on a stock install the signature UI silently never
--- appears until an operator finds Administration > Facility > Enable
--- Digital Signatures. Signatures are a supported, tested workflow; make
--- them the default. Runs once: a site that prefers them off can disable
--- the setting afterwards and it will not be flipped back.
-UPDATE Facility SET enableDigitalSignatures = 1;
+-- Facility.enableDigitalSignatures, and the genesis-seeded facility (id 1,
+-- "Default Facility") shipped with it OFF - so on a stock install the
+-- signature UI silently never appears until an operator finds
+-- Administration > Facility > Enable Digital Signatures. Signatures are a
+-- supported, tested workflow; make them the default.
+--
+-- Scoped to the seeded facility only: facilities created later through the
+-- admin UI carry an explicit operator choice for this checkbox and must not
+-- have it overridden on multi-facility installs. Runs once: a site that
+-- prefers signatures off can disable the setting afterwards and it will not
+-- be flipped back.
+UPDATE Facility SET enableDigitalSignatures = 1 WHERE id = 1;

--- a/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
+++ b/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
@@ -1,0 +1,9 @@
+-- Digital signatures (consultation stamps and signature-pad capture on
+-- consultations and prescriptions) are gated per facility by
+-- Facility.enableDigitalSignatures, and the seeded Default Facility shipped
+-- with it OFF - so on a stock install the signature UI silently never
+-- appears until an operator finds Administration > Facility > Enable
+-- Digital Signatures. Signatures are a supported, tested workflow; make
+-- them the default. Runs once: a site that prefers them off can disable
+-- the setting afterwards and it will not be flipped back.
+UPDATE Facility SET enableDigitalSignatures = 1;

--- a/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
+++ b/database/mysql/migration/common/V1.0.17__enable_digital_signatures_by_default.sql
@@ -11,4 +11,14 @@
 -- have it overridden on multi-facility installs. Runs once: a site that
 -- prefers signatures off can disable the setting afterwards and it will not
 -- be flipped back.
+--
+-- DELIBERATE, ONE-TIME OVERRIDE, worth a release note: a boolean flag cannot
+-- distinguish "still the seeded default (off)" from "operator explicitly turned
+-- it off via Administration > Facility". This is the standard changing-a-default
+-- migration and treats both the same, so an upgrade that ships this migration
+-- WILL re-enable signatures on the Default Facility even where an operator had
+-- deliberately disabled them. That is intended (the whole point is default-on);
+-- the operator re-disables once post-upgrade if desired. The postinst twin for
+-- the carlos.properties consultation_signature_enabled flag makes the same
+-- accepted tradeoff for its exact old-stock line.
 UPDATE Facility SET enableDigitalSignatures = 1 WHERE id = 1;

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -3,6 +3,7 @@
 /build/
 /carlos-emr/
 /carlos-emr-drugref/
+/carlos-emr-eform-renderer/
 /tmp/
 /files
 /*.substvars

--- a/debian/assets/carlos_ctl/dbops.py
+++ b/debian/assets/carlos_ctl/dbops.py
@@ -782,6 +782,14 @@ def cmd_demo_data(argv) -> int:
     # piece failed to read.
     pieces = [
         os.path.join(DEMO_DIR, "demo-provider-links.sql"),
+        # Both guarded replacements for statements the additive transform
+        # excludes (see scripts/demo-additive-exclude.txt SPECIAL section):
+        # the program-10034 enrolments the snapshot loses to PK collision,
+        # and the demo-only 'ExternalNote' issue-catalog row the snapshot's
+        # casemgmt_issue rows reference. Must run after the additive
+        # snapshot (program 10034 and the demo providers arrive with it).
+        os.path.join(DEMO_DIR, "demo-program-links.sql"),
+        os.path.join(DEMO_DIR, "demo-issue-codes.sql"),
         os.path.join(DEMO_DIR, "demo-specialists.sql"),
         # Rich Text Letter eform, for parity with the devcontainer's dev
         # seeding. Purely additive: the Flyway baseline seeds zero eform rows

--- a/debian/assets/carlos_ctl/dbops.py
+++ b/debian/assets/carlos_ctl/dbops.py
@@ -789,6 +789,13 @@ def cmd_demo_data(argv) -> int:
         os.path.join(DEMO_DIR, "update-2012-07-12.sql"),
         os.path.join(DEMO_DIR, "update-2026-03-22-rtl-2026.3.0-modernize.sql"),
         os.path.join(DEMO_DIR, "update-2026-03-12-rtl-enable-direct.sql"),
+        # Must run after the modernize update: it string-replaces the dead
+        # public-JSP attachment paths (attachEform.jsp/displayAttachedFiles.jsp)
+        # that 2026.3.0 still carries with the gated Struts routes. Without it
+        # the seeded RTL's Attach flow 404s (populate_db.sh applies the same
+        # file in the devcontainer flow; the eform-rtl-attachment-* Playwright
+        # checks pin this).
+        os.path.join(DEMO_DIR, "update-2026-06-29-rtl-attachment-route-fix.sql"),
         os.path.join(DEMO_DIR, "demo-name-sanitization.sql"),
     ]
     if s.province == "on":

--- a/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -45,15 +45,23 @@
 
 # eChart CPP progress-note / history-item save: the note body arrives in
 # ARGS:value as clinical prose (apostrophes, "or", "s/p", drug names, angle
-# brackets) that trips the SQLi/XSS keyword rules. Only ARGS:value is unhooked,
-# and only on POST to this route. Stored-XSS defence for the note body is the
+# brackets) that trips the SQLi/XSS keyword rules. ARGS:reloadUrl carries an
+# app-generated internal redirect URL whose OWN nested query string
+# (…&method=…&issue_code=…&cmd=divR1I1) makes the Windows-RCE rule 932110 match
+# the literal "&cmd", 403-ing every encounter-note save through the front door.
+# reloadUrl is constructed by the eChart JS from server state, not typed by the
+# user, so unhooking the three noisy attack tag groups on it — only on POST to
+# this route — is safe. Stored-XSS defence for the note body remains the
 # application's CI-enforced context-aware output encoding.
 SecRule REQUEST_URI "@beginsWith /carlos/CaseManagementEntry" \
     "id:1010,phase:1,pass,nolog,chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:value,\
-        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:value"
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:value,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:reloadUrl,\
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:reloadUrl,\
+        ctl:ruleRemoveTargetByTag=attack-rce;ARGS:reloadUrl"
 
 # Signature pad upload: ARGS:signatureImage is a 50-200 KB base64 data-URI
 # (canvas.toDataURL) whose random base64 matches SQLi/XSS/RCE keyword rules.

--- a/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -36,12 +36,24 @@
 # CARLOS is a legacy JSP EMR that posts clinical free text and base64 image
 # blobs from a handful of routes. At CRS paranoia level 1 with anomaly
 # threshold 5 (see crs-overrides.conf) a single CRITICAL signature match blocks
-# the whole request with 403. Each exclusion below is chained to POST (so the
-# entire GET surface — including anything probe-shaped — stays fully inspected),
-# scoped to ONE route, and unhooks only the named free-text argument from only
-# the noisy attack tag groups. Every other argument on these routes (ids,
-# demographic numbers, keys) stays fully inspected, as do RCE/LFI/traversal/
-# protocol rules on the excluded arguments.
+# the whole request with 403. Every exclusion below is chained to POST (so the
+# entire GET surface — including anything probe-shaped — stays fully inspected)
+# and scoped to ONE route.
+#
+# Most are per-argument: they unhook only the named argument from only the noisy
+# attack tag groups, leaving every other argument on the route — and every other
+# rule on the excluded argument — fully inspected. TWO go slightly wider, each
+# annotated at its rule with the reason and the tracked follow-up:
+#   - id 1010 additionally removes the attack-RCE tag on ARGS:reloadUrl (an
+#     app-generated redirect URL whose nested "&cmd=" trips the Windows-RCE
+#     rule); RCE/LFI/traversal still apply to every OTHER argument.
+#   - id 1040 removes CRS rules 941130/941170 by id for the whole
+#     /eform/addEForm POST (the un-enumerable signature data-URI fields), so
+#     those two attribute-XSS signatures no longer score ANY field on that one
+#     route. See its comment and carlos-emr/carlos#3552.
+# When adding an exclusion, prefer the per-argument tag form; reach for a
+# whole-rule ruleRemoveById only when the argument name cannot be enumerated,
+# and document the residual scope inline as 1040 does.
 
 # eChart CPP progress-note / history-item save: the note body arrives in
 # ARGS:value as clinical prose (apostrophes, "or", "s/p", drug names, angle

--- a/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -44,16 +44,21 @@
 # attack tag groups, leaving every other argument on the route — and every other
 # rule on the excluded argument — fully inspected. TWO go slightly wider, each
 # annotated at its rule with the reason and the tracked follow-up:
-#   - id 1010 additionally removes the attack-RCE tag on ARGS:reloadUrl (an
-#     app-generated redirect URL whose nested "&cmd=" trips the Windows-RCE
-#     rule); RCE/LFI/traversal still apply to every OTHER argument.
+#   - id 1010 additionally removes ONE rule (932110, Windows-RCE) on
+#     ARGS:reloadUrl — narrowly, by id, not by the whole attack-rce tag, which
+#     also carries the Unix/PowerShell rules and the REQUEST-944 Java-RCE family
+#     and would leave RCE detection on that value uncompensated. Every other
+#     RCE/LFI/traversal rule still scores reloadUrl and every other argument.
 #   - id 1040 removes CRS rules 941130/941170 by id for the whole
 #     /eform/addEForm POST (the un-enumerable signature data-URI fields), so
 #     those two attribute-XSS signatures no longer score ANY field on that one
 #     route. See its comment and carlos-emr/carlos#3552.
-# When adding an exclusion, prefer the per-argument tag form; reach for a
-# whole-rule ruleRemoveById only when the argument name cannot be enumerated,
-# and document the residual scope inline as 1040 does.
+# The route match is path-anchored (@rx ^…(?:[;?]|$) on REQUEST_URI, not a bare
+# @beginsWith): the request-wide id 1040 in particular must not be carried onto
+# a DIFFERENT action reached by Tomcat path/matrix-param confusion
+# (…/addEForm/..;/otherAction). When adding an exclusion, prefer the
+# per-argument tag form; reach for a whole-rule ruleRemoveById only when the
+# argument name cannot be enumerated, and document the residual scope inline.
 
 # eChart CPP progress-note / history-item save: the note body arrives in
 # ARGS:value as clinical prose (apostrophes, "or", "s/p", drug names, angle
@@ -61,11 +66,16 @@
 # app-generated internal redirect URL whose OWN nested query string
 # (…&method=…&issue_code=…&cmd=divR1I1) makes the Windows-RCE rule 932110 match
 # the literal "&cmd", 403-ing every encounter-note save through the front door.
-# reloadUrl is constructed by the eChart JS from server state, not typed by the
-# user, so unhooking the three noisy attack tag groups on it — only on POST to
-# this route — is safe. Stored-XSS defence for the note body remains the
-# application's CI-enforced context-aware output encoding.
-SecRule REQUEST_URI "@beginsWith /carlos/CaseManagementEntry" \
+# reloadUrl IS an attacker-controllable POST parameter, so the safety does not
+# rest on "the client won't send anything bad": its value is server-side
+# validated on the only sink that consumes it (the listCPPNotes redirect goes
+# through RedirectValidationUtils; the rest is parsed for issue_code, reflected
+# nowhere). So unhook only the noisy signatures that actually false-positive —
+# SQLi/XSS keyword tags on the two args, and ONLY rule 932110 on reloadUrl (not
+# the whole attack-rce tag, which would also drop Unix/PowerShell/Java RCE) —
+# and only on POST to this route. Stored-XSS defence for the note body remains
+# the application's CI-enforced context-aware output encoding.
+SecRule REQUEST_URI "@rx ^/carlos/CaseManagementEntry(?:[;?]|$)" \
     "id:1010,phase:1,pass,nolog,chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -73,13 +83,13 @@ SecRule REQUEST_URI "@beginsWith /carlos/CaseManagementEntry" \
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS:value,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:reloadUrl,\
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS:reloadUrl,\
-        ctl:ruleRemoveTargetByTag=attack-rce;ARGS:reloadUrl"
+        ctl:ruleRemoveTargetById=932110;ARGS:reloadUrl"
 
 # Signature pad upload: ARGS:signatureImage is a 50-200 KB base64 data-URI
 # (canvas.toDataURL) whose random base64 matches SQLi/XSS/RCE keyword rules.
 # The endpoint (SaveSignatureUpload2Action) strictly validates the base64 and
 # caps the size server-side. Unhook only that argument, only on POST.
-SecRule REQUEST_URI "@beginsWith /carlos/signature_pad/SaveSignatureUpload" \
+SecRule REQUEST_URI "@rx ^/carlos/signature_pad/SaveSignatureUpload(?:[;?]|$)" \
     "id:1020,phase:1,pass,nolog,chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -96,7 +106,7 @@ SecRule REQUEST_URI "@beginsWith /carlos/signature_pad/SaveSignatureUpload" \
 # value is consumed as an image source and re-encoded by the eForm render
 # pipeline, never reflected raw. Only this argument, only on POST to the save
 # route; every other argument (the form fields themselves) stays inspected.
-SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
+SecRule REQUEST_URI "@rx ^/carlos/eform/addEForm(?:[;?]|$)" \
     "id:1030,phase:1,pass,nolog,chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -123,7 +133,7 @@ SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
 # openosp-image-link channel (as appendImageInputs() already does for <img src>),
 # after which this rule drops to a 1030-style per-argument removal. Do NOT widen
 # this beyond 941130/941170 or beyond POST /carlos/eform/addEForm.
-SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
+SecRule REQUEST_URI "@rx ^/carlos/eform/addEForm(?:[;?]|$)" \
     "id:1040,phase:1,pass,nolog,chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\

--- a/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -100,6 +100,17 @@ SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
 # Remove exactly those two data-URI signatures for this POST; every other XSS/
 # SQLi/RCE rule still scores all fields, and stored-XSS defence for rendered
 # eForms remains the application's CI-enforced context-aware output encoding.
+#
+# ACCEPTED RESIDUAL SCOPE (tracked in carlos-emr/carlos#3552): because the
+# signature fields are un-enumerable, this is request-wide, so 941130/941170 no
+# longer score the OTHER eForm fields either — an authenticated submitter's
+# data:text/html;base64, javascript:, xlink:href or bare formaction= in an
+# author-named field is not caught HERE (it becomes stored XSS only through an
+# output-encoding gap, the app-side control). No narrower pure-WAF form exists.
+# The real fix is app-side: route signature data-URIs through the enumerable
+# openosp-image-link channel (as appendImageInputs() already does for <img src>),
+# after which this rule drops to a 1030-style per-argument removal. Do NOT widen
+# this beyond 941130/941170 or beyond POST /carlos/eform/addEForm.
 SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
     "id:1040,phase:1,pass,nolog,chain"
     SecRule REQUEST_METHOD "@streq POST" \

--- a/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -75,5 +75,34 @@ SecRule REQUEST_URI "@beginsWith /carlos/signature_pad/SaveSignatureUpload" \
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS:signatureImage,\
         ctl:ruleRemoveTargetByTag=attack-rce;ARGS:signatureImage"
 
-# id 1030 is reserved for the eform-editor base64 field; add it here only once
-# `carlos-ctl waf tail` confirms the failing route and argument name.
+# eForm save: the floating toolbar's appendImageInputs() serializes every image
+# on the form into hidden ARGS:openosp-image-link inputs as
+# {"id":...,"value":"data:image/png;base64,..."} so JS-set images (signature
+# captures, letterheads) survive save/PDF render. The data:image/...;base64
+# prefix matches the XSS attribute-vector rules (941130/941170, anomaly 33 on a
+# real save) and 403s the save — confirmed live via the modsec audit log. The
+# value is consumed as an image source and re-encoded by the eForm render
+# pipeline, never reflected raw. Only this argument, only on POST to the save
+# route; every other argument (the form fields themselves) stays inspected.
+SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
+    "id:1030,phase:1,pass,nolog,chain"
+    SecRule REQUEST_METHOD "@streq POST" \
+        "t:none,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:openosp-image-link,\
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:openosp-image-link,\
+        ctl:ruleRemoveTargetByTag=attack-rce;ARGS:openosp-image-link"
+
+# The same save also carries data:image/...;base64 URIs in the eForm's OWN
+# fields (signature pads persist the drawn signature into a form field, and
+# field names are form-author-defined, so no ARGS list can enumerate them).
+# 941130/941170 both fire on the "data:image/...;base64" prefix itself —
+# confirmed via the audit log on a live save (each is +5..+8, blocking alone).
+# Remove exactly those two data-URI signatures for this POST; every other XSS/
+# SQLi/RCE rule still scores all fields, and stored-XSS defence for rendered
+# eForms remains the application's CI-enforced context-aware output encoding.
+SecRule REQUEST_URI "@beginsWith /carlos/eform/addEForm" \
+    "id:1040,phase:1,pass,nolog,chain"
+    SecRule REQUEST_METHOD "@streq POST" \
+        "t:none,\
+        ctl:ruleRemoveById=941130,\
+        ctl:ruleRemoveById=941170"

--- a/debian/carlos-emr.postinst
+++ b/debian/carlos-emr.postinst
@@ -190,9 +190,16 @@ case "$1" in
         # false after this runs, keeps their choice because the sentinel stops the
         # migration re-running, and the exact whole-line match ignores any value
         # that is not the old stock false.
+        # The sentinel is written on FRESH installs too, not just upgrades: a
+        # fresh install of this release never shipped the old false default, so
+        # any false the operator sets afterwards is an explicit choice - without
+        # the sentinel, the next upgrade would see a non-empty "$2", match the
+        # exact old-stock line, and silently flip that choice back to true.
+        # Only the value REWRITE stays upgrade-only.
         CONSULT_SIG_SENTINEL="${STATE}/.consult-signature-default-migrated"
-        if [ -n "${2:-}" ] && [ ! -e "${CONSULT_SIG_SENTINEL}" ] && [ -f "${PROPERTIES}" ]; then
-            if grep -qx 'consultation_signature_enabled=false' "${PROPERTIES}"; then
+        if [ ! -e "${CONSULT_SIG_SENTINEL}" ]; then
+            if [ -n "${2:-}" ] && [ -f "${PROPERTIES}" ] \
+                && grep -qx 'consultation_signature_enabled=false' "${PROPERTIES}"; then
                 sed -i 's/^consultation_signature_enabled=false$/consultation_signature_enabled=true/' "${PROPERTIES}"
                 echo "carlos-emr: enabled consultation signatures (migrated the old stock default off -> on)"
             fi

--- a/debian/rules
+++ b/debian/rules
@@ -193,6 +193,8 @@ override_dh_auto_install:
 	    .devcontainer/db/scripts/demo-name-sanitization-on.sql \
 	    .devcontainer/db/scripts/demo-specialists.sql \
 	    .devcontainer/db/scripts/demo-provider-links.sql \
+	    .devcontainer/db/scripts/demo-program-links.sql \
+	    .devcontainer/db/scripts/demo-issue-codes.sql \
 	    database/mysql/updates/update-2012-07-12.sql \
 	    database/mysql/updates/update-2026-03-22-rtl-2026.3.0-modernize.sql \
 	    database/mysql/updates/update-2026-03-12-rtl-enable-direct.sql \

--- a/debian/rules
+++ b/debian/rules
@@ -196,6 +196,7 @@ override_dh_auto_install:
 	    database/mysql/updates/update-2012-07-12.sql \
 	    database/mysql/updates/update-2026-03-22-rtl-2026.3.0-modernize.sql \
 	    database/mysql/updates/update-2026-03-12-rtl-enable-direct.sql \
+	    database/mysql/updates/update-2026-06-29-rtl-attachment-route-fix.sql \
 	    $(STAGE)/$(SHAREDIR)/demo/
 	# Tomcat's global web.xml and catalina.properties come from the
 	# distribution's own tomcat11 package (a build dependency) rather than

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -159,7 +159,9 @@ waits and says so.
 To build the packages from source instead, see the header of
 [`debian/rules`](../debian/rules) — including how to reuse a prebuilt WAR —
 and [`release/README.md`](../release/README.md) for where the packaging
-lives and why.
+lives and why. To validate a build end to end — install into a disposable VM
+with the demo dataset and run the whole Playwright suite through the WAF —
+follow [`docs/ui-tests/deb-install-validation.md`](ui-tests/deb-install-validation.md).
 
 ## Quickstart — the first hour
 

--- a/docs/ui-tests/README.md
+++ b/docs/ui-tests/README.md
@@ -5,6 +5,7 @@ Comprehensive UI testing for CARLOS EMR using Playwright MCP (Model Context Prot
 ## 📚 Quick Start
 
 - **New to UI testing?** Start with [UI-TEST-PROCESS.md](UI-TEST-PROCESS.md) - Complete testing procedures
+- **Validating the .deb packages?** Use [deb-install-validation.md](deb-install-validation.md) - Build, install into a VM, and run the whole Playwright suite through the nginx + ModSecurity front door
 - **Testing eForm PDF fidelity?** Use [eform-pdf-render-smoke-test.md](eform-pdf-render-smoke-test.md) - Branch-focused smoke test runbook
 - **Running Test 1?** See [test-1/test-1-EXECUTION.md](test-1/test-1-EXECUTION.md) - Step-by-step execution guide
 - **Test results?** Check [test-1/test-1-results.md](test-1/test-1-results.md) - Latest test results with screenshots

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -306,6 +306,12 @@ check fails anyway): the filtered demo snapshot carries `casemgmt_note_link`
 rows whose TICKLER target no longer exists (new ticklers reuse those ids and
 "inherit" orphaned notes — `tickler-note-dialog` purges them in setup); the HRM
 parser logs `FileNotFoundException` for lab files the dump references but does
-not ship (cosmetic); and nullable `consultationRequests` columns
-(`providerNo`, `urgency`, `status`) occur naturally in the dump — pages must
-render them, and regressions there have been 500s in the past.
+not ship (cosmetic); the Rich Text Letter page logs a 404 + MIME-refusal
+console error for `displayImage.do?imagefile=stamps.js` on every stock install
+(by design — `EFormAssetDeployer` never auto-deploys `stamps.js` because it
+holds clinic-specific signature stamps; the editor works without it); and
+`consultationRequests.providerNo`/`urgency`/`status` are nullable in the
+SCHEMA but always populated in the dump — regressions on the null path have
+been 500s in the past, so exercise it by nulling a row explicitly
+(`UPDATE consultationRequests SET providerNo=NULL, urgency=NULL WHERE
+requestId=<id>;`) rather than assuming the dump provides one.

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -90,6 +90,7 @@ carlos-emr carlos-emr/tls-mode select selfsigned
 carlos-emr carlos-emr/acme-email string
 carlos-emr carlos-emr/java-heap string 2g
 carlos-emr carlos-emr/reset-seed-admin boolean false
+carlos-emr carlos-emr/install-demo-data boolean true
 EOF
 lxc file push /tmp/carlos-preseed.txt carlos-test/root/
 lxc file push ../carlos-emr_*_all.deb ../carlos-emr-drugref_*_all.deb \
@@ -114,45 +115,29 @@ Every line must be `OK` (services, loopback-only Tomcat/MariaDB, WAF blocking a
 probe SQLi with 403, live DrugRef lookup, renderer service, Flyway history).
 Do not continue on a failing check — every later step assumes this baseline.
 
-## 4. Load the demo dataset and test fixtures
+## 4. Demo dataset and test fixtures
 
-The packaged install seeds reference data only. The checks need the development
-demo dataset plus a handful of fixtures. **Order matters** — this mirrors
-`.devcontainer/db/scripts/populate_db.sh`, which is the authority if the two
-ever disagree:
+`install-demo-data=true` in the preseed above makes the installer load the
+package's own demonstration dataset (`carlos-ctl demo-data`): the additive
+per-province patient snapshot, the referral-specialist and provider-link
+seeds, the name sanitization, and the Rich Text Letter chain including the
+attachment-route fix. Being additive (`INSERT IGNORE` only), it never touches
+the Flyway-seeded rows, so the V1.0.17 digital-signatures default survives.
+(The devcontainer counterpart is `.devcontainer/db/scripts/populate_db.sh`;
+if the two ever disagree about the RTL chain, that script and
+`debian/assets/carlos_ctl/dbops.py` are the authorities.)
+
+One database tweak and three fixtures remain:
 
 ```bash
-# Push the demo SQL into the VM
-for f in .devcontainer/db/scripts/development.sql \
-         .devcontainer/db/scripts/development_privileges.sql \
-         database/mysql/updates/update-2025-11-06-demo-name-sanitization.sql \
-         database/mysql/updates/update-2012-07-12.sql \
-         database/mysql/updates/update-2026-03-22-rtl-2026.3.0-modernize.sql \
-         database/mysql/updates/update-2026-03-12-rtl-enable-direct.sql \
-         database/mysql/updates/update-2026-06-29-rtl-attachment-route-fix.sql; do
-  lxc file push "$f" carlos-test/root/demo/
-done
-
-lxc exec carlos-test -- bash -c '
-  cd /root/demo
-  for f in development.sql development_privileges.sql \
-           update-2025-11-06-demo-name-sanitization.sql \
-           update-2012-07-12.sql \
-           update-2026-03-22-rtl-2026.3.0-modernize.sql \
-           update-2026-03-12-rtl-enable-direct.sql \
-           update-2026-06-29-rtl-attachment-route-fix.sql; do
-    mariadb -u root oscar < "$f"
-  done
-  # development.sql truncate-reloads Facility with the old snapshot default;
-  # re-assert the product default (V1.0.17) so signature workflows run.
-  mariadb -u root oscar -e "UPDATE Facility SET enableDigitalSignatures = 1;"
-  # The seed row ships forcePasswordReset=1; the checks need a direct login.
-  # (login-playwright-checks.js exercises the forced-reset flow itself and
-  # restores whatever state it changes.)
-  mariadb -u root oscar -e "UPDATE security SET forcePasswordReset=0 WHERE user_name=\"carlosdoc\";"'
+# The seed row ships forcePasswordReset=1; the checks need a direct login.
+# (login-playwright-checks.js exercises the forced-reset flow itself and
+# restores whatever state it changes.)
+lxc exec carlos-test -- mariadb -u root oscar \
+  -e "UPDATE security SET forcePasswordReset=0 WHERE user_name='carlosdoc';"
 ```
 
-Fixtures the SQL alone does not provide:
+Fixtures the dataset alone does not provide:
 
 ```bash
 # a) Demo document FILES. The dump ships document table rows; the PDFs they
@@ -167,6 +152,8 @@ lxc exec carlos-test -- bash -c \
 
 # b) Provider stamp for the consultation-signature checks: any small PNG,
 #    named consult_sig_<providerNo>.png in the eForm image directory.
+#    (Any PNG will do, e.g.: convert -size 240x80 xc:white consult_sig_999998.png,
+#    or reuse a repo image such as release/4422-84v9-1.png renamed.)
 lxc file push consult_sig_999998.png \
   carlos-test/var/lib/carlos-emr/OscarDocument/carlos/eform/images/
 lxc exec carlos-test -- bash -c \
@@ -225,6 +212,7 @@ export CONSULT_STAMP_PROVIDER_NO=999998 CONSULT_UNSIGNED_REQUEST_ID=3
 export PATIENT_LIST_FIXTURE_PROFILE=local-seed-obec-report-v1
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
+  case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below
   timeout 300 node "$s" && echo "PASS $s" || echo "FAIL $s"
 done
 ```

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -1,0 +1,323 @@
+# Deb Install Validation Runbook
+
+This runbook builds the CARLOS Debian packages from source, installs them into a
+disposable Ubuntu 26.04 VM with the demo dataset, and drives the full
+`scripts/*-playwright-checks.js` suite against the packaged deployment — through
+the real front door (nginx + ModSecurity/CRS on `:443`), not the devcontainer's
+bare Tomcat.
+
+It is the procedure that first surfaced the WAF false positives on note-saving
+and eForm saves, the add-patient validation regression, and the nullable-column
+500s on the consultation surfaces. Last validated end-to-end 2026-08-28 with
+**33/33 scripts passing**.
+
+## Scope
+
+This validation answers one question:
+
+Does a clinician-facing workflow that passes in the devcontainer still work on a
+clean packaged install — schema migrated by Flyway, WAF in blocking mode,
+self-signed TLS, services running as their unprivileged accounts?
+
+Testing `http://127.0.0.1:18080/carlos` (Tomcat directly) **bypasses the WAF
+and answers a different question**. Every check below goes through `:443`.
+
+## Host prerequisites
+
+- LXD with a VM-capable storage pool and a NAT bridge (the VM needs outbound
+  network for `apt`).
+- ~20 GB free disk (16 GiB VM root + the three `.deb` files) and enough RAM to
+  give the VM 8 GiB. Do not run heavy Maven builds while VMs are up on a
+  memory-constrained host — the build below is done **before** the VM exists.
+- Build dependencies satisfied on the host: `dpkg-checkbuilddeps` must be clean
+  (OpenJDK 21, Maven, debhelper, tomcat11 packages).
+
+## 1. Build the packages
+
+From the repo root:
+
+```bash
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+export MAVEN_OPTS="-Xmx3g"
+dpkg-buildpackage -us -uc -b
+```
+
+This compiles the CARLOS WAR, fetches and builds DrugRef at the ref pinned in
+`debian/drugref.pin`, and downloads the Chromium revision pinned in
+`debian/chromium.pin`. The three `.deb` files land in the parent directory.
+
+For iterative rebuilds, cache the parts that do not change and skip their
+network fetches (see the header of [`debian/rules`](../../debian/rules) for the
+full input list):
+
+```bash
+mkdir -p ../build-cache
+cp    debian/build/drugref2.war ../build-cache/
+cp -a debian/build/chromium     ../build-cache/chromium
+# later rebuilds:
+DRUGREF_WAR=$PWD/../build-cache/drugref2.war \
+CHROMIUM_DIST=$PWD/../build-cache/chromium \
+dpkg-buildpackage -us -uc -b
+```
+
+## 2. Create the test VM
+
+```bash
+lxc launch ubuntu:26.04 carlos-test --vm \
+    -c limits.cpu=2 -c limits.memory=8GiB -d root,size=16GiB
+lxc exec carlos-test -- cloud-init status --wait
+
+# Mount the repo read-only: the checks read fixtures and src/** paths,
+# and script edits on the host are live in the VM with no re-push.
+lxc config device add carlos-test carlosrepo disk \
+    source=$PWD path=/root/carlos readonly=true
+```
+
+## 3. Install the packages (non-interactive)
+
+Preseed debconf so the install runs unattended. `reset-seed-admin=false` is the
+critical answer: it keeps the published dev credential
+(`carlosdoc` / `carlos2026` / PIN `2026`) that every check logs in with. Decline
+it **only** on a disposable machine that will never hold patient data — which
+this VM is.
+
+```bash
+cat > /tmp/carlos-preseed.txt <<'EOF'
+carlos-emr carlos-emr/server-name string localhost
+carlos-emr carlos-emr/bind-ip string 0.0.0.0
+carlos-emr carlos-emr/province select on
+carlos-emr carlos-emr/tls-mode select selfsigned
+carlos-emr carlos-emr/acme-email string
+carlos-emr carlos-emr/java-heap string 2g
+carlos-emr carlos-emr/reset-seed-admin boolean false
+EOF
+lxc file push /tmp/carlos-preseed.txt carlos-test/root/
+lxc file push ../carlos-emr_*_all.deb ../carlos-emr-drugref_*_all.deb \
+              ../carlos-emr-eform-renderer_*_amd64.deb carlos-test/root/
+
+lxc exec carlos-test -- bash -c '
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  debconf-set-selections /root/carlos-preseed.txt
+  apt-get install -y /root/carlos-emr_*_all.deb \
+                     /root/carlos-emr-drugref_*_all.deb \
+                     /root/carlos-emr-eform-renderer_*_amd64.deb'
+```
+
+Then verify the deployment before anything else:
+
+```bash
+lxc exec carlos-test -- carlos-ctl check
+```
+
+Every line must be `OK` (services, loopback-only Tomcat/MariaDB, WAF blocking a
+probe SQLi with 403, live DrugRef lookup, renderer service, Flyway history).
+Do not continue on a failing check — every later step assumes this baseline.
+
+## 4. Load the demo dataset and test fixtures
+
+The packaged install seeds reference data only. The checks need the development
+demo dataset plus a handful of fixtures. **Order matters** — this mirrors
+`.devcontainer/db/scripts/populate_db.sh`, which is the authority if the two
+ever disagree:
+
+```bash
+# Push the demo SQL into the VM
+for f in .devcontainer/db/scripts/development.sql \
+         .devcontainer/db/scripts/development_privileges.sql \
+         database/mysql/updates/update-2025-11-06-demo-name-sanitization.sql \
+         database/mysql/updates/update-2012-07-12.sql \
+         database/mysql/updates/update-2026-03-22-rtl-2026.3.0-modernize.sql \
+         database/mysql/updates/update-2026-03-12-rtl-enable-direct.sql \
+         database/mysql/updates/update-2026-06-29-rtl-attachment-route-fix.sql; do
+  lxc file push "$f" carlos-test/root/demo/
+done
+
+lxc exec carlos-test -- bash -c '
+  cd /root/demo
+  for f in development.sql development_privileges.sql \
+           update-2025-11-06-demo-name-sanitization.sql \
+           update-2012-07-12.sql \
+           update-2026-03-22-rtl-2026.3.0-modernize.sql \
+           update-2026-03-12-rtl-enable-direct.sql \
+           update-2026-06-29-rtl-attachment-route-fix.sql; do
+    mariadb -u root oscar < "$f"
+  done
+  # development.sql truncate-reloads Facility with the old snapshot default;
+  # re-assert the product default (V1.0.17) so signature workflows run.
+  mariadb -u root oscar -e "UPDATE Facility SET enableDigitalSignatures = 1;"
+  # The seed row ships forcePasswordReset=1; the checks need a direct login.
+  # (login-playwright-checks.js exercises the forced-reset flow itself and
+  # restores whatever state it changes.)
+  mariadb -u root oscar -e "UPDATE security SET forcePasswordReset=0 WHERE user_name=\"carlosdoc\";"'
+```
+
+Fixtures the SQL alone does not provide:
+
+```bash
+# a) Demo document FILES. The dump ships document table rows; the PDFs they
+#    reference live in the repo. Without them, attaching a document to a
+#    consultation or eForm packet fails PDF conversion.
+for f in .devcontainer/db/db_data/documents/*.pdf; do
+  lxc file push "$f" carlos-test/var/lib/carlos-emr/OscarDocument/carlos/document/
+done
+lxc exec carlos-test -- bash -c \
+  'chown carlos:carlos /var/lib/carlos-emr/OscarDocument/carlos/document/*.pdf
+   chmod 0640          /var/lib/carlos-emr/OscarDocument/carlos/document/*.pdf'
+
+# b) Provider stamp for the consultation-signature checks: any small PNG,
+#    named consult_sig_<providerNo>.png in the eForm image directory.
+lxc file push consult_sig_999998.png \
+  carlos-test/var/lib/carlos-emr/OscarDocument/carlos/eform/images/
+lxc exec carlos-test -- bash -c \
+  'chown carlos:carlos /var/lib/carlos-emr/OscarDocument/carlos/eform/images/consult_sig_999998.png
+   chmod 0640          /var/lib/carlos-emr/OscarDocument/carlos/eform/images/consult_sig_999998.png'
+
+# c) The three LOCAL_SEED_OBEC_REPORT appointments that
+#    patient-list-by-appointment-export-playwright-checks.js documents as its
+#    operator-provisioned fixture contract (see that script's header):
+lxc exec carlos-test -- mariadb -u root oscar -e "
+INSERT INTO appointment (provider_no, appointment_date, start_time, end_time,
+    name, demographic_no, notes, reason, location, resources, type, style,
+    billing, status, createdatetime, creator)
+VALUES
+ ('9','2026-08-07','09:00:00','09:15:00','LOCAL_SEED_OBEC_REPORT_1',714,'','','','',NULL,'','','t',NOW(),'carlosdoc'),
+ ('999998','2026-08-08','10:00:00','10:15:00','LOCAL_SEED_OBEC_REPORT_2',71,'','','','',NULL,'','','t',NOW(),'carlosdoc'),
+ ('999998','2026-08-10','11:00:00','11:15:00','LOCAL_SEED_OBEC_REPORT_3',81,'','','','',NULL,'','','t',NOW(),'carlosdoc');"
+```
+
+Restart once after loading so nothing serves from a pre-load cache:
+
+```bash
+lxc exec carlos-test -- carlos-ctl restart
+```
+
+## 5. Install the Playwright harness in the VM
+
+```bash
+lxc exec carlos-test -- bash -c '
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get install -y nodejs npm
+  cd /root && npm init -y && npm install playwright
+  npx --yes playwright install --with-deps chromium'
+```
+
+The scripts run from `/root/carlos` (the repo mount) so their relative fixture
+paths resolve; Node still finds Playwright via `/root/node_modules`.
+
+## 6. Run the suite
+
+Environment contract (one block, exported before every script):
+
+```bash
+cd /root/carlos
+export BASE_URL=https://127.0.0.1/carlos
+export TEST_USER=carlosdoc TEST_PASSWORD=carlos2026 TEST_PIN=2026
+# DB-backed checks: root over the MariaDB unix socket (the password value is
+# ignored by unix_socket auth but the scripts require it to be set).
+export MYSQL_HOST=localhost MYSQL_USER=root MYSQL_PASSWORD=dummy MYSQL_DATABASE=oscar
+# Published seed hash for carlos2026 (from database/mysql/migration/on/V1.0.2__on_data.sql)
+export TEST_PASSWORD_HASH='{bcrypt}$2a$10$RcoNeqhcLzkfBzAoTQ5C5.nnsOs15iOasQCp0/smjDAuTtkMQ.Uju'
+# Record pointers into the demo dataset:
+export PRESCRIPTION_SCRIPT_ID=45 PRESCRIPTION_DEMOGRAPHIC_NO=1
+export CONSULT_DEMO_NO=1 CONSULT_SERVICE_ID=1 CONSULT_REQUEST_ID=1
+export CONSULT_STAMP_PROVIDER_NO=999998 CONSULT_UNSIGNED_REQUEST_ID=3
+export PATIENT_LIST_FIXTURE_PROFILE=local-seed-obec-report-v1
+
+for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
+  timeout 300 node "$s" && echo "PASS $s" || echo "FAIL $s"
+done
+```
+
+Notes on the contract:
+
+- **`BASE_URL` uses `127.0.0.1`, deliberately.** The scripts set
+  `ignoreHTTPSErrors`, and Chromium is lenient about loopback certificates, so
+  every script works against the self-signed cert. The cost: a numeric-IP
+  `Host:` header trips CRS rule **920350** (+3 anomaly on every request), which
+  a production hostname never sees. When judging any WAF block found this way,
+  discount 920350 and look at the *other* matched rules. Using the real
+  `server_name` FQDN instead avoids 920350 but fails the handful of scripts
+  that create a browser context without `ignoreHTTPSErrors`.
+- **`PRESCRIPTION_SCRIPT_ID` must point at a prescription that has `drugs`
+  rows.** The demo dump contains drugless `prescription` rows (46+); a
+  drugless script renders no preview and the check times out. Script 45 has
+  drugs; verify with
+  `SELECT p.script_no FROM prescription p JOIN drugs d ON d.script_no=p.script_no`.
+- **`CONSULT_UNSIGNED_REQUEST_ID` is consumed.** The stamp-update scenario
+  signs that consultation, so a second back-to-back run needs the fixture
+  reset: `UPDATE consultationRequests SET signature_img=NULL WHERE requestId=3;`
+- `eform-consultation-acceptance` skips its stored image-layer template probe
+  (with a `[skip]` note) unless `LIBRARY_EFORM_NAME` names a form that exists
+  in the library; the main acceptance workflow runs regardless.
+- `eform-corpus-soak-playwright-checks.js` additionally needs a corpus
+  directory (see `docs/eform-corpus-soak-method.md`) and is not part of the
+  standard pass.
+
+## 7. Exercise the upgrade path
+
+Re-installing the same (or a newer) package pair over the live install is the
+upgrade path — schema migrates before the service restarts:
+
+```bash
+lxc exec carlos-test -- bash -c '
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get install -y --reinstall /root/carlos-emr_*_all.deb \
+      /root/carlos-emr-drugref_*_all.deb \
+      /root/carlos-emr-eform-renderer_*_amd64.deb'
+lxc exec carlos-test -- carlos-ctl check   # expect the same all-OK, with any
+                                           # new migrations counted in flyway_schema_history
+```
+
+## Diagnosing failures
+
+**A "timed-out" save with a clean application log usually means the WAF ate the
+request.** A ModSecurity block returns nginx's 403 page and the request **never
+reaches Tomcat**, so it appears in `/var/log/nginx/access.log` and in
+`/var/log/carlos-emr/modsec/modsec_audit.log` (JSON, one transaction per line —
+the matched rule ids, the argument, and the matched bytes are all in
+`messages[].details`) but not in Tomcat's access log. `carlos-ctl waf tail`
+prints the same signal live. Package-shipped exclusions live in
+`debian/assets/modsecurity/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf`
+(ids 1000–1999); site exclusions belong in the operator-owned
+`local-exclusions-*.conf` files (ids 5000–5999).
+
+**Schema is validated at boot — do not hand-apply migrations the deployed WAR
+does not ship.** The package configures `carlos.flyway.onBoot=validate`: a
+database *ahead* of the WAR fails validation and the application refuses to
+start on its next restart. Land the migration in the tree, rebuild the
+packages, and let the reinstall apply it.
+
+**Hot-validating a one-file fix without a full package rebuild.** JSPs can be
+pushed straight into the exploded webapp
+(`/usr/share/carlos-emr/webapp/carlos/…`) — Tomcat recompiles them on the next
+request. A single Java class can be compiled against the exploded WAR and
+dropped in, followed by `carlos-ctl restart`:
+
+```bash
+W=target/carlos-*-SNAPSHOT/WEB-INF
+javac -nowarn -cp "$W/classes:$W/lib/*:/usr/share/java/tomcat11-servlet-api.jar:/usr/share/java/tomcat11-el-api.jar:/usr/share/java/tomcat11-jsp-api.jar:$HOME/.m2/repository/com/github/spotbugs/spotbugs-annotations/4.9.3/spotbugs-annotations-4.9.3.jar" \
+      -d /tmp/classout path/to/The2Action.java
+lxc file push /tmp/classout/.../The2Action.class \
+  carlos-test/usr/share/carlos-emr/webapp/carlos/WEB-INF/classes/.../The2Action.class
+lxc exec carlos-test -- carlos-ctl restart
+```
+
+This is a validation shortcut only — the fix is not real until it survives a
+full `dpkg-buildpackage` + reinstall cycle.
+
+**Caches can make direct-SQL fixtures invisible.** `getActiveProviders()` is
+`@Cacheable` (`ACTIVE_PROVIDERS`, 5-minute TTL) and only
+`saveProvider()`/`updateProvider()` evict it — a provider INSERTed behind the
+app's back stays missing from admin dropdowns until the TTL expires. Prefer
+driving the app's own UI (as `add-login-account-playwright-checks.js` does) or
+restart after seeding.
+
+**Known demo-data sharp edges** (handled by the steps above, listed for when a
+check fails anyway): the filtered demo snapshot carries `casemgmt_note_link`
+rows whose TICKLER target no longer exists (new ticklers reuse those ids and
+"inherit" orphaned notes — `tickler-note-dialog` purges them in setup); the HRM
+parser logs `FileNotFoundException` for lab files the dump references but does
+not ship (cosmetic); and nullable `consultationRequests` columns
+(`providerNo`, `urgency`, `status`) occur naturally in the dump — pages must
+render them, and regressions there have been 500s in the past.

--- a/docs/ui-tests/eform-pdf-render-smoke-test.md
+++ b/docs/ui-tests/eform-pdf-render-smoke-test.md
@@ -46,7 +46,10 @@ user-facing error handling?
 
 6. Set `CHROME_PATH` only if Playwright cannot find Chromium automatically.
 
-7. Confirm the database has the Rich Text Letter attachment-route migration applied:
+7. Confirm the database has the Rich Text Letter attachment-route migration applied.
+   `populate_db.sh` now applies it as part of the demo-data load, so a freshly built
+   devcontainer database already has it; apply it manually only to a database seeded
+   before that change:
 
    ```bash
    mysql -h db -u root -p"$MYSQL_ROOT_PASSWORD" oscar \

--- a/scripts/add-login-account-playwright-checks.js
+++ b/scripts/add-login-account-playwright-checks.js
@@ -243,10 +243,13 @@ async function seedProviderViaUi(page, providerNo, siteId) {
   ]);
   await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
 
+  // Newest row first by the audit timestamp, not by provider_no: provider_no is
+  // a VARCHAR, so ordering by it is lexicographic ('9' > '10'), and a stale row
+  // from a prior failed run could otherwise win the tie.
   const createdNo = sql(
     `SELECT provider_no FROM provider`
       + ` WHERE last_name='Playwright' AND first_name='${escapeSql(uniqueFirstName)}'`
-      + ` ORDER BY provider_no DESC LIMIT 1`
+      + ` ORDER BY lastUpdateDate DESC, provider_no DESC LIMIT 1`
   );
   assert(createdNo, `Add Provider form did not create provider ${providerNo} (last page: ${page.url()})`);
 

--- a/scripts/add-login-account-playwright-checks.js
+++ b/scripts/add-login-account-playwright-checks.js
@@ -267,11 +267,24 @@ async function seedProviderViaUi(page, providerNo, siteId) {
   return createdNo;
 }
 
-function cleanupRows(providerNo, username) {
+function cleanupRows(providerNo, username, firstName) {
+  // Also match the fixture's unique Playwright/<firstName> provider row by NAME,
+  // not just by provider_no: with provider_no_auto the app assigns a number that
+  // differs from the fixture id, so a run that fails mid-seed would otherwise
+  // leave that row (and its providersite) behind — cleanup by the fixture id
+  // alone never matches it. The name is stamped from the fixture id and is
+  // unique per run, so this cannot touch another run's provider. providersite is
+  // cleared before provider (FK), and its name-match resolves the provider_no
+  // via a subquery on the still-present provider row.
+  const nameMatch = firstName
+    ? `last_name='Playwright' AND first_name='${escapeSql(firstName)}'`
+    : null;
   const statements = [
     `DELETE FROM security WHERE user_name='${escapeSql(username)}' OR provider_no='${escapeSql(providerNo)}'`,
-    `DELETE FROM providersite WHERE provider_no='${escapeSql(providerNo)}'`,
-    `DELETE FROM provider WHERE provider_no='${escapeSql(providerNo)}'`,
+    `DELETE FROM providersite WHERE provider_no='${escapeSql(providerNo)}'`
+      + (nameMatch ? ` OR provider_no IN (SELECT provider_no FROM provider WHERE ${nameMatch})` : ''),
+    `DELETE FROM provider WHERE provider_no='${escapeSql(providerNo)}'`
+      + (nameMatch ? ` OR (${nameMatch})` : ''),
   ];
 
   const errors = [];
@@ -335,6 +348,10 @@ async function providerOptions(page) {
 async function run() {
   let providerNo = null;
   let username = null;
+  // Stable across the providerNo reassignment below: seedProviderViaUi names the
+  // created row Account<fixture id>, so cleanup can find it by name even after
+  // providerNo is replaced with the app-assigned number.
+  let fixtureFirstName = null;
   let browser = null;
 
   try {
@@ -347,6 +364,7 @@ async function run() {
     const fixture = chooseFixture();
     providerNo = fixture.providerNo;
     username = fixture.username;
+    fixtureFirstName = `Account${fixture.providerNo}`;
     const result = {
       baseUrl: baseUrl.toString(),
       adminProviderNo: adminNo,
@@ -358,7 +376,7 @@ async function run() {
       steps: [],
     };
 
-    cleanupRows(providerNo, username);
+    cleanupRows(providerNo, username, fixtureFirstName);
 
     const launchOptions = { headless: true };
     if (chromePath) {
@@ -467,7 +485,7 @@ async function run() {
     } finally {
       try {
         if (providerNo && username) {
-          cleanupRows(providerNo, username);
+          cleanupRows(providerNo, username, fixtureFirstName);
         }
       } finally {
         cleanupMysqlDefaultsFile();

--- a/scripts/add-login-account-playwright-checks.js
+++ b/scripts/add-login-account-playwright-checks.js
@@ -209,19 +209,59 @@ function sharedSiteId(providerNo) {
   return out || '1';
 }
 
-function seedProvider(providerNo, siteId) {
+async function seedProviderViaUi(page, providerNo, siteId) {
+  // Create the provider through the app's own Add Provider form rather than a
+  // direct SQL INSERT: getActiveProviders() is @Cacheable (ACTIVE_PROVIDERS,
+  // 5-minute TTL), so a provider inserted behind the app's back stays missing
+  // from the add-login dropdown until the cache expires — exactly the failure
+  // this check produced on the packaged (.deb) install, where earlier page
+  // loads had already warmed the cache. saveProvider() evicts that cache, so
+  // creating the provider the way an administrator actually does keeps the
+  // dropdown fresh — and exercises the real add-provider path as a bonus.
   const numericSiteId = Number(siteId);
   assert(Number.isInteger(numericSiteId), `ADD_LOGIN_SITE_ID must be an integer, got ${siteId}`);
-  sql(
-    `INSERT INTO provider`
-      + ` (provider_no, last_name, first_name, provider_type, specialty, sex, status, lastUpdateDate)`
-      + ` VALUES`
-      + ` ('${escapeSql(providerNo)}', 'Playwright', 'Account', 'doctor', 'GP', 'M', '1', NOW())`
+  const uniqueFirstName = `Account${providerNo}`;
+
+  await page.goto('admin/ViewProviderAddARecordHtm', { waitUntil: 'networkidle', timeout: 30000 });
+  const providerNoInput = page.locator('form[name="searchprovider"] input[name="provider_no"]').first();
+  await providerNoInput.waitFor({ state: 'visible', timeout: 15000 });
+  // With provider_no_auto the field is readonly "-new-" and the app assigns
+  // the number; otherwise fill the fixture id. Either way the created row is
+  // recovered below by its unique name stamp.
+  const autoNumbered = (await providerNoInput.getAttribute('readonly')) !== null;
+  if (!autoNumbered) {
+    await providerNoInput.fill(providerNo);
+  }
+  await page.locator('input[name="last_name"]').fill('Playwright');
+  await page.locator('input[name="first_name"]').fill(uniqueFirstName);
+  await page.locator('select[name="provider_type"]').selectOption('doctor');
+  await page.locator('input[name="specialty"]').fill('GP');
+  await page.locator('select[name="sex"]').selectOption('M');
+  await Promise.all([
+    page.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {}),
+    page.locator('form[name="searchprovider"] input[type="submit"]').first().click(),
+  ]);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+  const createdNo = sql(
+    `SELECT provider_no FROM provider`
+      + ` WHERE last_name='Playwright' AND first_name='${escapeSql(uniqueFirstName)}'`
+      + ` ORDER BY provider_no DESC LIMIT 1`
   );
-  sql(
-    `INSERT INTO providersite(provider_no, site_id)`
-      + ` VALUES ('${escapeSql(providerNo)}', ${numericSiteId})`
-  );
+  assert(createdNo, `Add Provider form did not create provider ${providerNo} (last page: ${page.url()})`);
+
+  // Multisite installs scope the dropdown by providersite; Add Provider only
+  // writes that row when multisites is enabled, so backfill it if absent.
+  const siteRows = Number(sql(
+    `SELECT COUNT(*) FROM providersite WHERE provider_no='${escapeSql(createdNo)}'`
+  ));
+  if (siteRows === 0) {
+    sql(
+      `INSERT INTO providersite(provider_no, site_id)`
+        + ` VALUES ('${escapeSql(createdNo)}', ${numericSiteId})`
+    );
+  }
+  return createdNo;
 }
 
 function cleanupRows(providerNo, username) {
@@ -316,7 +356,6 @@ async function run() {
     };
 
     cleanupRows(providerNo, username);
-    seedProvider(providerNo, siteId);
 
     const launchOptions = { headless: true };
     if (chromePath) {
@@ -335,6 +374,13 @@ async function run() {
 
     await login(page);
     result.steps.push('logged in as admin');
+
+    // Adopt the number the app actually assigned (differs from the fixture id
+    // when provider_no_auto is on) so the dropdown assertions and cleanup all
+    // target the row that exists.
+    providerNo = await seedProviderViaUi(page, providerNo, siteId);
+    result.providerNo = providerNo;
+    result.steps.push(`created provider ${providerNo} via the Add Provider form`);
 
     await page.goto('admin/ViewSecurityAddARecord', { waitUntil: 'networkidle', timeout: 30000 });
     const initialOptions = await providerOptions(page);

--- a/scripts/consultation-nullable-fields-playwright-checks.js
+++ b/scripts/consultation-nullable-fields-playwright-checks.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for consultations whose nullable columns are
+ * actually NULL, driven the way a user works: login, the schedule banner's
+ * Consultations link, the consultation list, open the request, Print Preview.
+ *
+ * consultationRequests.providerNo and .urgency are nullable in the schema
+ * but always populated in the demo snapshot, so this check creates the
+ * condition itself: it NULLs both columns on one seeded request (restoring
+ * the original values afterwards), then asserts that
+ *   1. the consultation form still renders (EctViewRequest2Action used to
+ *      NPE in provDao.getProvider(null) and 500 the page), and
+ *   2. Print Preview still returns a real PDF (ConsultationPDFCreator used
+ *      to NPE on urgency.equals(...) and on the null provider's OHIP), by
+ *      decoding the JSON consultPDF payload and checking the %PDF magic.
+ *
+ * Requires the deb-install env contract (docs/ui-tests/deb-install-validation.md §6):
+ *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN,
+ *   MYSQL_HOST/USER/PASSWORD/DATABASE (to stage and restore the NULLs)
+ * Optional: CONSULT_NULLABLE_REQUEST_ID (default 2), CHROME_PATH,
+ *   CONSULT_NULLABLE_SCREENSHOT_DIR (default /tmp).
+ */
+
+const { chromium } = require('playwright');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  assert,
+  assertNotErrorPage,
+  buildFailureDetails,
+  createRecorder,
+  getLaunchOptions,
+  login,
+  screenshot,
+  validateBaseUrl,
+  wirePage,
+} = require('./eform-local-playwright-utils');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  screenshotDir: process.env.CONSULT_NULLABLE_SCREENSHOT_DIR || '/tmp',
+};
+const requestId = process.env.CONSULT_NULLABLE_REQUEST_ID || '2';
+assert(/^\d+$/.test(requestId), `CONSULT_NULLABLE_REQUEST_ID must be numeric, got ${requestId}`);
+
+const mysqlHost = process.env.MYSQL_HOST || '127.0.0.1';
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'oscar';
+
+let mysqlDefaults = null;
+function initMysqlDefaults() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'consult-nullable-'));
+  const file = path.join(dir, 'mysql-defaults.cnf');
+  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  mysqlDefaults = { dir, file };
+}
+function cleanupMysqlDefaults() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+function sql(query) {
+  assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', mysqlHost, '-u', mysqlUser, mysqlDatabase, '-N', '-B', '-e', query,
+  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000 }).trim();
+}
+function sqlValue(value) {
+  return value === '' || value === 'NULL' ? 'NULL' : `'${value.replace(/'/g, "''")}'`;
+}
+
+(async () => {
+  const recorder = createRecorder();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  initMysqlDefaults();
+  let original = null;
+  try {
+    // Stage the nullable state, remembering what to restore.
+    const row = sql(`SELECT IFNULL(providerNo,'NULL'), IFNULL(urgency,'NULL') FROM consultationRequests WHERE requestId=${requestId}`);
+    assert(row, `consultationRequests row ${requestId} not found`);
+    const [origProvider, origUrgency] = row.split('\t');
+    original = { providerNo: origProvider, urgency: origUrgency };
+    sql(`UPDATE consultationRequests SET providerNo=NULL, urgency=NULL WHERE requestId=${requestId}`);
+
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1100 } });
+    const schedulePage = await login(context, config, recorder);
+
+    // User path: the schedule banner's Consultations link opens the list.
+    const listPopup = context.waitForEvent('page', { timeout: 15000 }).catch(() => null);
+    await schedulePage.locator("a[onclick*='/carlos/encounter/IncomingConsultation']").first().click();
+    let listPage = await listPopup;
+    if (!listPage) {
+      listPage = context.pages()[context.pages().length - 1];
+    }
+    wirePage(listPage, 'consultation-list', recorder);
+    await listPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(listPage, 'consultation list');
+    await screenshot(listPage, config.screenshotDir, 'consultation-nullable-list');
+
+    // Open the staged request from the list the way a user would; the list
+    // links carry requestId=<id>. Fall back to direct navigation only if the
+    // list pagination/filters hide this request.
+    const rowLink = listPage.locator(`a[href*='requestId=${requestId}'], a[onclick*='requestId=${requestId}']`).first();
+    let consultPage = listPage;
+    if (await rowLink.count()) {
+      const consultPopup = context.waitForEvent('page', { timeout: 15000 }).catch(() => null);
+      await rowLink.click();
+      const popped = await consultPopup;
+      if (popped) {
+        consultPage = popped;
+        wirePage(consultPage, 'consultation-form', recorder);
+      }
+    } else {
+      await listPage.goto(`${config.baseUrl.href.replace(/\/$/, '')}/encounter/ViewRequest?requestId=${requestId}`, { waitUntil: 'domcontentloaded', timeout: 30000 }); // nosemgrep // validateBaseUrl restricts hosts to loopback by default; requestId is digits-only.
+    }
+    await consultPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+    // Regression 1: the form must render despite providerNo/urgency NULL.
+    await assertNotErrorPage(consultPage, `consultation ${requestId} with NULL providerNo/urgency`);
+    await consultPage.locator('form[name="EctConsultationFormRequest2Form"]').waitFor({ state: 'attached', timeout: 15000 });
+    const fatal500s = recorder.badResponses.filter((r) => r.status >= 500);
+    assert(fatal500s.length === 0, `consultation form load produced 5xx responses: ${JSON.stringify(fatal500s)}`);
+    await screenshot(consultPage, config.screenshotDir, 'consultation-nullable-form');
+
+    // Regression 2: Print Preview must return a real PDF. The button posts
+    // submission="And Print Preview" to /encounter/RequestConsultation and
+    // receives JSON with a base64 consultPDF.
+    const pdfResponsePromise = consultPage.waitForResponse(
+      (response) => /\/encounter\/RequestConsultation/.test(response.url()) && response.request().method() === 'POST',
+      { timeout: 30000 },
+    );
+    // Exactly the plain "And Print Preview" button: checkForm('And Print
+    // Preview',…) takes the AJAX/JSON path, while the sibling buttons
+    // ("Update … And Print Preview", "Submit … And Print Preview") do a full
+    // form submit that answers with HTML, not the consultPDF JSON.
+    await consultPage.locator('input[type="button"][onclick*="checkForm(\'And Print Preview\'"]').first().click();
+    const pdfResponse = await pdfResponsePromise;
+    assert(pdfResponse.ok(), `Print Preview POST failed with HTTP ${pdfResponse.status()}`);
+    const payload = await pdfResponse.json().catch(() => null);
+    assert(payload, 'Print Preview did not return JSON');
+    assert(!payload.errorMessage, `Print Preview returned an error: ${payload.errorMessage}`);
+    assert(payload.consultPDF, 'Print Preview JSON carried no consultPDF payload');
+    const pdfBytes = Buffer.from(payload.consultPDF, 'base64');
+    assert(pdfBytes.subarray(0, 5).toString('utf8') === '%PDF-',
+      `consultPDF payload is not a PDF (starts with ${pdfBytes.subarray(0, 8).toString('hex')})`);
+    await screenshot(consultPage, config.screenshotDir, 'consultation-nullable-preview');
+
+    await context.close();
+    console.log(`PASS consultation ${requestId} renders and print-previews a ${pdfBytes.length}-byte PDF with NULL providerNo/urgency`);
+  } catch (error) {
+    console.error('FAIL consultation nullable-fields Playwright check');
+    console.error(error.stack || error.message);
+    console.error(JSON.stringify(buildFailureDetails(recorder), null, 2));
+    process.exitCode = 1;
+  } finally {
+    try {
+      if (original) {
+        sql(`UPDATE consultationRequests SET providerNo=${sqlValue(original.providerNo)}, urgency=${sqlValue(original.urgency)} WHERE requestId=${requestId}`);
+      }
+    } catch (restoreError) {
+      console.error(`WARN failed to restore consultationRequests ${requestId}: ${restoreError.message}`);
+    }
+    cleanupMysqlDefaults();
+    await browser.close();
+  }
+})();

--- a/scripts/demo-additive-exclude.txt
+++ b/scripts/demo-additive-exclude.txt
@@ -47,7 +47,6 @@ ctl_billingservice_premium
 ctl_diagcode
 ctl_doc_class
 ctl_doctype
-ctl_document
 ctl_frequency
 ctl_specialinstructions
 CtlRelationships
@@ -68,6 +67,9 @@ HRMCategory
 icd9
 Icd9Synonym
 ichppccode
+# issue: the snapshot's catalog additionally carries the demo-only
+# 'ExternalNote' row (id 73) that the additively-loaded casemgmt_issue rows
+# reference; the guarded demo-issue-codes.sql seeds that one row.
 issue
 LookupList
 LookupListItem
@@ -116,3 +118,9 @@ emailConfig
 # provider_facility is Flyway-seeded and FK-constrained; the guarded
 # demo-provider-links.sql adds the dev links instead.
 provider_facility
+# program_provider is Flyway-seeded with auto-increment ids 1-33 and the
+# snapshot's rows carry explicit ids in that same range, so under INSERT
+# IGNORE every snapshot row (the program-10034 enrolments that make demo
+# patients' eCharts reachable) is dropped by PK collision. The guarded
+# demo-program-links.sql adds them without explicit ids instead.
+program_provider

--- a/scripts/demographic-add-playwright-checks.js
+++ b/scripts/demographic-add-playwright-checks.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for the add-demographic form (add.jsp), driven the
+ * way a user reaches it: login, Search popup, a search with no matches, the
+ * "Create Demographic" link, fill the form, save, land on the master record.
+ *
+ * Pins the add.jsp script-block regression where a missing brace in
+ * parseHINforVC() made the whole inline <script> fail to parse, so EVERY
+ * page function (aSubmit, the validators, the DOB sync) came up undefined and
+ * the Add button silently did nothing ("aSubmit is not defined"). The check
+ * asserts the functions exist before it ever submits, so a re-broken script
+ * block fails loudly rather than as an opaque form that will not save.
+ *
+ * The created patient is removed again through the master-record UI's data
+ * this script captures (SQL delete of the demographic row it created), so
+ * repeat runs do not accumulate records. Requires the standard deb-install
+ * env contract (see docs/ui-tests/deb-install-validation.md §6):
+ *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN,
+ *   MYSQL_HOST/USER/PASSWORD/DATABASE (for the cleanup delete)
+ * Optional: CHROME_PATH, DEMOGRAPHIC_ADD_SCREENSHOT_DIR (default /tmp).
+ */
+
+const { chromium } = require('playwright');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  assert,
+  buildFailureDetails,
+  createRecorder,
+  getLaunchOptions,
+  gotoApp,
+  login,
+  screenshot,
+  validateBaseUrl,
+  wirePage,
+  assertNotErrorPage,
+} = require('./eform-local-playwright-utils');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  screenshotDir: process.env.DEMOGRAPHIC_ADD_SCREENSHOT_DIR || '/tmp',
+};
+const mysqlHost = process.env.MYSQL_HOST || '127.0.0.1';
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'oscar';
+
+// Unique, clearly synthetic name so a failed cleanup is identifiable and a
+// stray record can never be mistaken for a real patient.
+const fixtureLastName = `PLAYWRIGHT-ADD-${Date.now()}`;
+const fixtureFirstName = 'Check';
+
+let mysqlDefaults = null;
+function initMysqlDefaults() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'demographic-add-'));
+  const file = path.join(dir, 'mysql-defaults.cnf');
+  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  mysqlDefaults = { dir, file };
+}
+function cleanupMysqlDefaults() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+function sql(query) {
+  assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', mysqlHost, '-u', mysqlUser, mysqlDatabase, '-N', '-B', '-e', query,
+  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000 }).trim();
+}
+
+(async () => {
+  const recorder = createRecorder();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  initMysqlDefaults();
+  let createdDemographicNo = null;
+  try {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1100 } });
+    const schedulePage = await login(context, config, recorder);
+
+    // User path: Search popup from the schedule banner.
+    const searchPopup = context.waitForEvent('page');
+    await schedulePage.locator('a').filter({ hasText: /^Search$/ }).click();
+    const searchPage = await searchPopup;
+    wirePage(searchPage, 'search', recorder);
+    await searchPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+
+    // A no-match search renders the results page that carries "Create Demographic".
+    await searchPage.locator('#keyword, input[name="keyword"]').first().fill(fixtureLastName);
+    await Promise.all([
+      searchPage.waitForLoadState('domcontentloaded').catch(() => {}),
+      searchPage.locator("input[type='submit']").first().click(),
+    ]);
+    await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await searchPage.locator("a[href*='ViewDemographicAddARecordHtm']").first().click();
+    await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(searchPage, 'add-demographic form');
+
+    // The brace-fix pin: with the broken script block, none of these existed.
+    const scriptState = await searchPage.evaluate(() => ({
+      aSubmit: typeof window.aSubmit,
+      parseHINforVC: typeof window.parseHINforVC,
+      syncInputDobParts: typeof window.syncInputDobParts,
+    }));
+    assert(scriptState.aSubmit === 'function',
+      `add.jsp inline script did not define aSubmit (${JSON.stringify(scriptState)}) — script block is broken again`);
+    assert(scriptState.parseHINforVC === 'function',
+      `add.jsp inline script did not define parseHINforVC (${JSON.stringify(scriptState)})`);
+    assert(recorder.pageErrors.length === 0,
+      `add-demographic form raised page errors: ${JSON.stringify(recorder.pageErrors)}`);
+    await screenshot(searchPage, config.screenshotDir, 'demographic-add-form');
+
+    // Fill a minimal valid patient the way a user would. The HIN stays empty
+    // on purpose: aSubmit() still runs parseHINforVC() on submit (the pin for
+    // the brace regression), and an empty HIN cannot trip the ON checksum
+    // validator into an alert that would silently cancel the save.
+    const form = searchPage.locator('form[name="adddemographic"]');
+    await form.locator('input[name="last_name"]').fill(fixtureLastName);
+    await form.locator('input[name="first_name"]').fill(fixtureFirstName);
+    await form.locator('select[name="sex"]').selectOption('F');
+    await form.locator('input[name="inputDOB"]').fill('1990-01-15');
+    // The save-path validator rejects an empty/invalid postal code with an
+    // alert, so give it a syntactically valid (Canada Post reserved) one.
+    await form.locator('input[name="postal"]').fill('M5W 1E6');
+
+    // The "Add Record" submit is form-associated but rendered outside the
+    // form element's subtree, so locate it at page level.
+    await Promise.all([
+      searchPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {}),
+      searchPage.locator('input[type="submit"][value="Add Record"]').first().click(),
+    ]);
+    await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    assert(recorder.dialogs.length === 0,
+      `add-form validation blocked the save with a dialog: ${JSON.stringify(recorder.dialogs)}`);
+    await assertNotErrorPage(searchPage, 'post-save page');
+    const savedBody = await searchPage.locator('body').innerText();
+    assert(/Successful Addition of a Demographic Record/i.test(savedBody),
+      `post-save page did not confirm the save: ${savedBody.replace(/\s+/g, ' ').slice(0, 300)}`);
+    await screenshot(searchPage, config.screenshotDir, 'demographic-add-saved');
+
+    // Continue the way a user does: "Go to record" opens the new master
+    // record, which must show the patient it just created.
+    await Promise.all([
+      searchPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {}),
+      searchPage.locator('a').filter({ hasText: /Go to record/i }).first().click(),
+    ]);
+    await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(searchPage, 'new master record');
+    const masterBody = await searchPage.locator('body').innerText();
+    assert(masterBody.includes(fixtureLastName),
+      `master record does not show the new patient ${fixtureLastName}: ${masterBody.replace(/\s+/g, ' ').slice(0, 300)}`);
+    await screenshot(searchPage, config.screenshotDir, 'demographic-add-master-record');
+
+    const found = sql(`SELECT demographic_no FROM demographic WHERE last_name='${fixtureLastName}' AND first_name='${fixtureFirstName}'`);
+    assert(/^\d+$/.test(found), `saved patient not found in the database (got '${found}')`);
+    createdDemographicNo = found;
+
+    const fatalConsole = recorder.consoleIssues.filter((issue) => /is not defined|SyntaxError|ReferenceError/i.test(issue.text || ''));
+    assert(fatalConsole.length === 0, `fatal console errors during add flow: ${JSON.stringify(fatalConsole)}`);
+
+    await context.close();
+    console.log(`PASS add-demographic form scripts intact, patient saved and verified (demographic_no ${createdDemographicNo})`);
+  } catch (error) {
+    console.error('FAIL add-demographic Playwright check');
+    console.error(error.stack || error.message);
+    console.error(JSON.stringify(buildFailureDetails(recorder), null, 2));
+    process.exitCode = 1;
+  } finally {
+    // Remove the synthetic patient (and the admission the add flow creates)
+    // so repeat runs stay clean. Looked up by the unique per-run last name —
+    // never a bare number — so a bug can never delete a pre-existing record,
+    // and a run that failed BEFORE capturing the id still cleans up after
+    // itself if the save had already gone through.
+    try {
+      const leftover = createdDemographicNo
+        || sql(`SELECT demographic_no FROM demographic WHERE last_name='${fixtureLastName}' AND first_name='${fixtureFirstName}'`);
+      if (/^\d+$/.test(leftover)) {
+        sql(`DELETE FROM admission WHERE client_id=${leftover}`);
+        sql(`DELETE FROM demographicArchive WHERE demographic_no=${leftover}`);
+        sql(`DELETE FROM demographic WHERE demographic_no=${leftover} AND last_name='${fixtureLastName}'`);
+      }
+    } catch (cleanupError) {
+      console.error(`WARN cleanup failed: ${cleanupError.message}`);
+    }
+    cleanupMysqlDefaults();
+    await browser.close();
+  }
+})();

--- a/scripts/demographic-master-crud-smoke.js
+++ b/scripts/demographic-master-crud-smoke.js
@@ -25,7 +25,11 @@ const config = {
   username: process.env.CARLOS_USER || 'carlosdoc',
   password: process.env.CARLOS_PASSWORD || 'carlos2026',
   pin: process.env.CARLOS_PIN || '2026',
-  chromiumPath: process.env.CHROMIUM_PATH || '/root/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome',
+  // Empty by default so Playwright uses its own bundled chromium; a pinned
+  // build path (e.g. the devcontainer's) would break on any other install
+  // (deb, CI) where that exact revision is not present. Override CHROMIUM_PATH
+  // only to force a specific binary (e.g. the packaged eForm-render chromium).
+  chromiumPath: process.env.CHROMIUM_PATH || '',
   headless: process.env.HEADLESS !== 'false',
   keepOpen: process.env.KEEP_OPEN === 'true',
   timeout: Number(process.env.PLAYWRIGHT_TIMEOUT || 30000),
@@ -371,13 +375,19 @@ async function returnToDemographicSearch(searchPage) {
 }
 
 async function main() {
-  const launchOptions = { headless: config.headless };
+  const launchOptions = {
+    headless: config.headless,
+    // Required when the bundled chromium runs as root (deb test VM / CI).
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  };
   if (config.chromiumPath) {
     launchOptions.executablePath = config.chromiumPath;
   }
 
   const browser = await chromium.launch(launchOptions);
-  const context = await browser.newContext({ viewport: { width: 1400, height: 1000 } });
+  // ignoreHTTPSErrors: the packaged deployment serves a self-signed certificate
+  // by default, so a real install is reached over HTTPS with an untrusted CA.
+  const context = await browser.newContext({ viewport: { width: 1400, height: 1000 }, ignoreHTTPSErrors: true });
   context.setDefaultTimeout(config.timeout);
 
   context.on('page', page => {

--- a/scripts/eform-admin-schedule-navigation-playwright-checks.js
+++ b/scripts/eform-admin-schedule-navigation-playwright-checks.js
@@ -255,6 +255,8 @@ async function importZip(page, zipPath) {
     browser = await chromium.launch(getLaunchOptions(config.chromePath));
     context = await browser.newContext({
       acceptDownloads: true,
+      // The packaged deployment serves a self-signed certificate by default.
+      ignoreHTTPSErrors: true,
       viewport: { width: 1440, height: 1400 },
     });
     const landingPage = await login(context, config, recorder);

--- a/scripts/eform-admin-schedule-navigation-playwright-checks.js
+++ b/scripts/eform-admin-schedule-navigation-playwright-checks.js
@@ -84,9 +84,18 @@ async function openFocusedManager(page) {
     `Manage eForms link did not retain scheduleNav=1: ${managerHref}`,
   );
   await managerLink.click();
+  // Wait for BOTH iframes' forms before counting: count() does not auto-wait,
+  // and on a cold install (first JSP compile) the import frame finishes well
+  // after the upload frame, which made this check flake on fresh VMs.
   await page.frameLocator('#uploadFrame')
     .locator('form[action$="/eform/uploadHtml"]')
     .waitFor({ state: 'visible', timeout: 15000 });
+  // attached, not visible: the import form is styled hidden until its tab
+  // is opened, but its scheduleNav input is already in the DOM once loaded.
+  await page.frameLocator('#importFrame')
+    .locator('form')
+    .first()
+    .waitFor({ state: 'attached', timeout: 15000 });
   assert(
     await page.frameLocator('#uploadFrame').locator('input[name="scheduleNav"][value="1"]').count(),
     'HTML Upload form did not receive scheduleNav=1',

--- a/scripts/eform-consultation-acceptance-playwright-checks.js
+++ b/scripts/eform-consultation-acceptance-playwright-checks.js
@@ -60,7 +60,11 @@ const screenshotDir = process.env.EFORM_CONSULT_SCREENSHOT_DIR || '/tmp';
 
 const bgImageName = 'playwright_consult_acceptance_bg.png';
 const transparentPngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl5n2QAAAAASUVORK5CYII=';
-const libraryEformName = 'Signature trick';
+// The image-layer template probe targets a form that ships in no repo fixture
+// or seed - it exists only in richer dev libraries. LIBRARY_EFORM_NAME selects
+// a different form; when the named form is absent the probe is skipped (with a
+// note) so the main documented acceptance workflow still runs everywhere.
+const libraryEformName = process.env.LIBRARY_EFORM_NAME || 'Signature trick';
 const libraryEformExpectedTemplateImages = [
   '2025_06_12_PCXX108060A_Regional_Community_Pain_Self_Management_Program_Referral__Form_NWM11.png',
   '2025_06_12_PCXX108060A_Regional_Community_Pain_Self_Management_Program_Referral__Form_NWM21.png',
@@ -222,7 +226,10 @@ function wirePage(page, label) {
     if (/\/eform\/displayImage(?:\.do)?\?imagefile=/.test(responseUrl)) {
       displayImageResponses.push({ label, status, url: responseUrl, contentType });
     }
-    if (responseUrl.includes('/previewDocs?method=renderEFormPDF')) {
+    // getPdf() POSTs to /previewDocs with method=renderEFormPDF in the body
+    // (previews are mutator-gated POSTs, not GETs with a query string).
+    if (responseUrl.includes('/previewDocs')
+        && (response.request().postData() || '').includes('method=renderEFormPDF')) {
       eformPreviewResponses.push({ label, status, url: responseUrl, contentType });
     }
     if (/\/encounter\/RequestConsultation$/.test(responseUrl) && response.request().method() === 'POST') {
@@ -565,7 +572,9 @@ async function openConsultAttachmentPanelAndAttachEform(page, fdid) {
   await page.locator(`#eFormNo${fdid}`).waitFor({ state: 'visible', timeout: 15000 });
   const eformEntry = page.locator(`#eFormNo${fdid}`).locator('xpath=ancestor::li[1]');
   await Promise.all([
-    page.waitForResponse((response) => response.url().includes('/previewDocs?method=renderEFormPDF') && response.request().method() === 'GET'),
+    page.waitForResponse((response) => response.url().includes('/previewDocs')
+      && response.request().method() === 'POST'
+      && (response.request().postData() || '').includes('method=renderEFormPDF')),
     eformEntry.locator('button.preview-button').click(),
   ]);
   await eformEntry.locator(`input[type="checkbox"][value="${fdid}"]`).check();
@@ -607,13 +616,17 @@ async function openConsultAttachmentPanelAndAttachEform(page, fdid) {
     const landingPage = await login(context);
     await landingPage.close();
 
-    libraryFid = await findExistingLibraryEform(context, libraryEformName);
-    const libraryTemplateHtml = await readManagerTemplateHtml(context, libraryFid);
-    assert(libraryTemplateHtml.includes('${oscar_image_path}'), `Existing library eForm ${libraryEformName} did not retain oscar_image_path image references`);
-    for (const imageName of libraryEformExpectedTemplateImages) {
-      assert(libraryTemplateHtml.includes(imageName), `Existing library eForm ${libraryEformName} template did not retain expected background image ${imageName}`);
+    libraryFid = await findExistingLibraryEform(context, libraryEformName).catch(() => null);
+    if (libraryFid) {
+      const libraryTemplateHtml = await readManagerTemplateHtml(context, libraryFid);
+      assert(libraryTemplateHtml.includes('${oscar_image_path}'), `Existing library eForm ${libraryEformName} did not retain oscar_image_path image references`);
+      for (const imageName of libraryEformExpectedTemplateImages) {
+        assert(libraryTemplateHtml.includes(imageName), `Existing library eForm ${libraryEformName} template did not retain expected background image ${imageName}`);
+      }
+      libraryRuntimeProbe = await probeExistingLibraryEform(context, libraryFid);
+    } else {
+      console.log(`[skip] Library eForm "${libraryEformName}" is not in this database's eForm library; skipping the stored image-layer template probe (set LIBRARY_EFORM_NAME to probe a different form).`);
     }
-    libraryRuntimeProbe = await probeExistingLibraryEform(context, libraryFid);
 
     await ensureImageUploaded(context, fixture.imagePath, bgImageName);
     const uploadResult = await uploadEform(context, formName, formSubject, fixture.htmlPath);
@@ -642,7 +655,9 @@ async function openConsultAttachmentPanelAndAttachEform(page, fdid) {
     const syntheticBackgroundResponses = collectDisplayImageFetches(bgImageName);
     assert(syntheticBackgroundResponses.length > 0, `displayImage was never requested for ${bgImageName}`);
     assert(syntheticBackgroundResponses.some((response) => response.status === 200), `displayImage never returned 200 for ${bgImageName}: ${JSON.stringify(syntheticBackgroundResponses, null, 2)}`);
-    assert(libraryRuntimeProbe.renderSurfaceUsable, `Existing library eForm ${libraryEformName} did not render a usable background-backed surface: ${JSON.stringify(libraryRuntimeProbe)}`);
+    if (libraryRuntimeProbe) {
+      assert(libraryRuntimeProbe.renderSurfaceUsable, `Existing library eForm ${libraryEformName} did not render a usable background-backed surface: ${JSON.stringify(libraryRuntimeProbe)}`);
+    }
     assert(eformPreviewResponses.some((response) => response.status === 200), `Consultation attachment preview never produced a 200 renderEFormPDF response: ${JSON.stringify(eformPreviewResponses, null, 2)}`);
     assert(badResponses.length === 0, `unexpected HTTP errors: ${JSON.stringify(badResponses, null, 2)}`);
     const renderConsoleIssues = consoleIssues.filter((issue) => ['add-eform', 'saved-direct', 'patient-list-popup', 'consult-new'].includes(issue.label));

--- a/scripts/eform-consultation-acceptance-playwright-checks.js
+++ b/scripts/eform-consultation-acceptance-playwright-checks.js
@@ -335,6 +335,15 @@ async function findExistingLibraryEform(context, formName) {
   try {
     await gotoApp(page, '/eform/efmformmanager');
     await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    // Confirm the manager page itself rendered before waiting for a specific
+    // form row: otherwise a 500/broken manager page yields a row-wait
+    // TimeoutError that the caller's TimeoutError->skip catch would silently
+    // downgrade to "form absent". A missing table is a real failure (plain
+    // Error, not a TimeoutError), so it propagates.
+    if ((await page.locator('#eformTbl').count()) === 0) {
+      const body = await page.locator('body').innerText().catch(() => '');
+      throw new Error(`eForm manager page did not render its table (#eformTbl absent) — not a form-absent condition. body: ${body.slice(0, 200).replace(/\s+/g, ' ')}`);
+    }
     const row = page.locator('#eformTbl tbody tr', { hasText: formName }).first();
     await row.waitFor({ state: 'visible', timeout: 15000 });
     const editHref = await row.locator('a[href*="efmformmanageredit?fid="]').first().getAttribute('href');

--- a/scripts/eform-consultation-acceptance-playwright-checks.js
+++ b/scripts/eform-consultation-acceptance-playwright-checks.js
@@ -616,7 +616,14 @@ async function openConsultAttachmentPanelAndAttachEform(page, fdid) {
     const landingPage = await login(context);
     await landingPage.close();
 
-    libraryFid = await findExistingLibraryEform(context, libraryEformName).catch(() => null);
+    // Skip the probe only when the form is genuinely absent (the row wait times
+    // out); let any other failure (a 500 on the manager page, a broken lookup)
+    // propagate rather than be silently downgraded to "[skip]".
+    libraryFid = await findExistingLibraryEform(context, libraryEformName)
+      .catch((error) => {
+        if (error && error.name === 'TimeoutError') return null;
+        throw error;
+      });
     if (libraryFid) {
       const libraryTemplateHtml = await readManagerTemplateHtml(context, libraryFid);
       assert(libraryTemplateHtml.includes('${oscar_image_path}'), `Existing library eForm ${libraryEformName} did not retain oscar_image_path image references`);

--- a/scripts/fixtures/eform/test-pattern.html
+++ b/scripts/fixtures/eform/test-pattern.html
@@ -607,10 +607,10 @@ Third line</textarea>
       <h2>Render-Only Control Coverage</h2>
       <div class="grid-4">
         <label>Number A
-          <input type="number" name="test_pattern_calc_one" id="test_pattern_calc_one" value="12.5" step="0.1">
+          <input type="number" name="test_pattern_calc_one" id="test_pattern_calc_one" value="12.5" step="0.05">
         </label>
         <label>Number B
-          <input type="number" name="test_pattern_calc_two" id="test_pattern_calc_two" value="7.5" step="0.1">
+          <input type="number" name="test_pattern_calc_two" id="test_pattern_calc_two" value="7.5" step="0.05">
         </label>
         <label>Calculated total
           <input type="text" name="test_pattern_calc_total" id="test_pattern_calc_total" value="20.0" readonly>

--- a/scripts/logout-session-invalidation-playwright-checks.js
+++ b/scripts/logout-session-invalidation-playwright-checks.js
@@ -120,7 +120,15 @@ async function assertLoggedOutPage(page, label) {
     await login(primary);
 
     await safeGoto(primary, '/logoutPage', { waitUntil: 'domcontentloaded' });
-    await primary.waitForURL((url) => url.pathname === baseUrl.pathname + '/logout', { timeout: 10000 });
+    // logout.jsp auto-POSTs to /logout ~500ms after load, and Logout2Action
+    // redirects /logout -> /index. The browser therefore SETTLES on /index (the
+    // /logout POST is a transient 302, never a landing URL), so waiting for a
+    // settled /logout times out. Wait for the logged-out destination the app
+    // actually lands on; assertLoggedOutPage below verifies the logged-out state.
+    await primary.waitForURL((url) => {
+      const p = url.pathname;
+      return p === baseUrl.pathname + '/index' || p === baseUrl.pathname + '/logout';
+    }, { timeout: 15000 });
     await assertLoggedOutPage(primary, 'logout action destination');
 
     const postLogoutPage = await context.newPage();

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -115,13 +115,17 @@ const testPin = process.env.TEST_PIN || (loopbackTarget ? '2026' : '');
 
 // The locally seeded LOCAL_SEED_OBEC_REPORT_* appointments, all with a NULL
 // appointment type on purpose. Names are FAKE-* synthetic dev data, not PHI.
+// The provider name for 9 carries the FAKE- prefixes because the canonical
+// demo load (devcontainer populate_db.sh and the deb's carlos-ctl demo-data)
+// runs demo-name-sanitization.sql over the provider table too — only the
+// functional accounts (-1, 999998 carlosdoc) are exempt and keep their names.
 const SEED_DATE_FROM = '2026-08-07';
 const SEED_DATE_TO = '2026-08-10';
 const PROVIDER_ALL = 'all';
 const PROVIDER_WELCH = '9';
 const PROVIDER_CARLOSDOC = '999998';
 const EXPECTED_ROWS = {
-  [PROVIDER_WELCH]: ['FAKE-Abbott,FAKE-Jerilyn,555-555-5555,555-555-5555,09:00:00,2026-08-07,,Kristen Welch,'],
+  [PROVIDER_WELCH]: ['FAKE-Abbott,FAKE-Jerilyn,555-555-5555,555-555-5555,09:00:00,2026-08-07,,FAKE-Kristen FAKE-Welch,'],
   [PROVIDER_CARLOSDOC]: [
     'FAKE-Altenwerth,FAKE-Izola,555-555-5555,555-555-5555,10:00:00,2026-08-08,,doctor carlosdoc,',
     'FAKE-Altenwerth,FAKE-Josh,555-555-5555,555-555-5555,11:00:00,2026-08-10,,doctor carlosdoc,',

--- a/scripts/rx-preview-pharmacy-playwright-checks.js
+++ b/scripts/rx-preview-pharmacy-playwright-checks.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for the prescription preview's pharmacyId guard
+ * (rx/Preview2.jsp), driven the way a user reprints: login, the patient's Rx
+ * module, the Reprint panel, the seeded script's row, the rendered preview.
+ *
+ * ViewScript2.jsp builds the preview iframe URL with
+ * pharmacyId=<noNull(request param)>, so a reprint for a patient without a
+ * preferred pharmacy hands Preview2.jsp an EMPTY pharmacyId — which used to
+ * fall through to Integer.parseInt("") and 500 the whole preview. Clients
+ * can also echo the literal string "null". Every seeded prescription patient
+ * carries demographicPharmacy links, so this check stages the no-pharmacy
+ * state itself (unlinking the patient's pharmacies and restoring them in a
+ * finally), walks the real reprint journey — the Reprint panel embeds
+ * viewScript as an iframe, whose own #preview iframe is the Preview2 render —
+ * and then re-renders the preview with pharmacyId=null literal. Both must
+ * render and the whole flow must stay free of 5xx responses.
+ *
+ * Requires the deb-install env contract (docs/ui-tests/deb-install-validation.md §6):
+ *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN,
+ *   MYSQL_HOST/USER/PASSWORD/DATABASE (to stage and restore the pharmacy links)
+ * Optional: PRESCRIPTION_SCRIPT_ID (default 45; must have drugs rows),
+ *   PRESCRIPTION_DEMOGRAPHIC_NO (default 1), CHROME_PATH,
+ *   RX_PREVIEW_SCREENSHOT_DIR (default /tmp).
+ */
+
+const { chromium } = require('playwright');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  assert,
+  assertNotErrorPage,
+  buildFailureDetails,
+  createRecorder,
+  getLaunchOptions,
+  gotoApp,
+  login,
+  screenshot,
+  validateBaseUrl,
+  wirePage,
+} = require('./eform-local-playwright-utils');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  screenshotDir: process.env.RX_PREVIEW_SCREENSHOT_DIR || '/tmp',
+};
+const scriptId = process.env.PRESCRIPTION_SCRIPT_ID || '45';
+const demographicNo = process.env.PRESCRIPTION_DEMOGRAPHIC_NO || '1';
+assert(/^\d+$/.test(scriptId), `PRESCRIPTION_SCRIPT_ID must be numeric, got ${scriptId}`);
+assert(/^\d+$/.test(demographicNo), `PRESCRIPTION_DEMOGRAPHIC_NO must be numeric, got ${demographicNo}`);
+
+const mysqlHost = process.env.MYSQL_HOST || '127.0.0.1';
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'oscar';
+
+let mysqlDefaults = null;
+function initMysqlDefaults() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rx-preview-'));
+  const file = path.join(dir, 'mysql-defaults.cnf');
+  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  mysqlDefaults = { dir, file };
+}
+function cleanupMysqlDefaults() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+function sql(query) {
+  assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', mysqlHost, '-u', mysqlUser, mysqlDatabase, '-N', '-B', '-e', query,
+  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000 }).trim();
+}
+
+// The pharmacy unlink is staged through the table's own soft-delete model
+// (DemographicPharmacy.ACTIVE='1' / INACTIVE='0') rather than DELETE+re-
+// INSERT, and only the ids captured here are flipped back, so a crashed run
+// can be repaired by re-running the script or restoring exactly those ids.
+function stageNoPharmacy() {
+  const linkIds = sql(`SELECT GROUP_CONCAT(id) FROM demographicPharmacy WHERE demographic_no=${demographicNo} AND status='1'`);
+  if (linkIds) {
+    sql(`UPDATE demographicPharmacy SET status='0' WHERE id IN (${linkIds})`);
+  }
+  return linkIds;
+}
+function restorePharmacy(linkIds) {
+  if (linkIds) {
+    sql(`UPDATE demographicPharmacy SET status='1' WHERE id IN (${linkIds})`);
+  }
+}
+
+async function assertPreviewRenders(hostFrame, label) {
+  const previewHandle = await hostFrame.locator('#preview').elementHandle({ timeout: 30000 });
+  const frame = await previewHandle.contentFrame();
+  assert(frame, `${label}: preview iframe did not expose a frame`);
+  // Preview2.jsp renders #signature at the foot of a successful preview; an
+  // error page or the pre-fix parseInt("") 500 never reaches it.
+  try {
+    await frame.locator('#signature').waitFor({ state: 'attached', timeout: 30000 });
+  } catch (error) {
+    const bodyText = await frame.locator('body').innerText().catch(() => '');
+    throw new Error(`${label}: preview did not render (#signature missing) at ${frame.url()}: ${bodyText.replace(/\s+/g, ' ').slice(0, 400)}`);
+  }
+  return frame.url();
+}
+
+(async () => {
+  const recorder = createRecorder();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  initMysqlDefaults();
+  let stagedLinkIds = null;
+  try {
+    stagedLinkIds = stageNoPharmacy();
+
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1100 } });
+    const schedulePage = await login(context, config, recorder);
+    await schedulePage.close();
+
+    // User path: the patient's Rx module, the Reprint panel, the script row.
+    const rxPage = await context.newPage();
+    wirePage(rxPage, 'rx-module', recorder);
+    await gotoApp(rxPage, config.baseUrl, `/rx/choosePatient?demographicNo=${demographicNo}`);
+    await rxPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(rxPage, 'rx module');
+
+    await rxPage.locator('a').filter({ hasText: /^Reprint$/ }).first().click();
+    const reprintRow = rxPage.locator(`#reprint a[onclick*="reprint2('${scriptId}')"]`).first();
+    await reprintRow.waitFor({ state: 'visible', timeout: 15000 });
+    await reprintRow.click();
+
+    // reprint2() embeds viewScript as an iframe in the Rx page rather than
+    // navigating; find that frame, then its nested #preview (Preview2) frame.
+    let viewScriptFrame = null;
+    for (let attempt = 0; attempt < 30 && !viewScriptFrame; attempt += 1) {
+      viewScriptFrame = rxPage.frames().find((f) => f.url().includes('/rx/viewScript'));
+      if (!viewScriptFrame) {
+        await rxPage.waitForTimeout(1000);
+      }
+    }
+    assert(viewScriptFrame, 'reprint did not embed a /rx/viewScript frame');
+    const viewScriptParams = new URL(viewScriptFrame.url()).searchParams;
+    assert(viewScriptParams.get('scriptId') === scriptId,
+      `embedded viewScript is for script ${viewScriptParams.get('scriptId')}, expected ${scriptId}`);
+    // The staging above is what makes this the regression branch: with no
+    // active pharmacy link the UI builds pharmacyId= EMPTY (or omits it).
+    const uiPharmacyId = viewScriptParams.get('pharmacyId');
+    assert(uiPharmacyId === null || uiPharmacyId === '',
+      `staging failed — the reprint UI still carried a pharmacy (pharmacyId=${JSON.stringify(uiPharmacyId)})`);
+
+    const emptyFrameUrl = await assertPreviewRenders(viewScriptFrame, 'reprint preview (no pharmacy)');
+    const emptyParam = new URL(emptyFrameUrl).searchParams.get('pharmacyId');
+    assert(emptyParam === null || emptyParam === '',
+      `Preview2 unexpectedly received a pharmacy (pharmacyId=${JSON.stringify(emptyParam)} at ${emptyFrameUrl})`);
+    await screenshot(rxPage, config.screenshotDir, 'rx-preview-pharmacy-empty');
+
+    // Branch 2: the literal string "null" clients can echo back, rendered as
+    // a top-level viewScript page like the prescription-signature check does.
+    const nullPage = await context.newPage();
+    wirePage(nullPage, 'rx-null-literal', recorder);
+    await gotoApp(nullPage, config.baseUrl, `/rx/viewScript?scriptId=${scriptId}&pharmacyId=null`);
+    await nullPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(nullPage, 'reprint view (pharmacyId=null literal)');
+    await assertPreviewRenders(nullPage.mainFrame(), 'reprint preview (pharmacyId=null literal)');
+    await screenshot(nullPage, config.screenshotDir, 'rx-preview-pharmacy-null-literal');
+
+    const fatal500s = recorder.badResponses.filter((r) => r.status >= 500);
+    assert(fatal500s.length === 0, `preview flow produced 5xx responses: ${JSON.stringify(fatal500s)}`);
+
+    await context.close();
+    console.log(`PASS rx preview renders for script ${scriptId} with no-pharmacy and "null" pharmacyId`);
+  } catch (error) {
+    console.error('FAIL rx preview pharmacyId Playwright check');
+    console.error(error.stack || error.message);
+    console.error(JSON.stringify(buildFailureDetails(recorder), null, 2));
+    process.exitCode = 1;
+  } finally {
+    try {
+      restorePharmacy(stagedLinkIds);
+    } catch (restoreError) {
+      console.error(`WARN failed to restore demographicPharmacy links (${stagedLinkIds}): ${restoreError.message}`);
+    }
+    cleanupMysqlDefaults();
+    await browser.close();
+  }
+})();

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -165,7 +165,12 @@ async function login(context) {
 
 async function clickScheduleLink(context, schedulePage, linkSpec) {
   const locator = schedulePage.locator(linkSpec.selector).first();
-  if (!await locator.count()) {
+  // Wait for the link to attach rather than reading count() once: selecting a provider
+  // reloads the schedule window, and its navigation commits (URL updates) before the body
+  // renders, so an immediate count() races the reload and reports every link missing.
+  try {
+    await locator.waitFor({ state: 'attached', timeout: 15000 });
+  } catch {
     findings.push({ label: linkSpec.label, type: 'missing-user-link', selector: linkSpec.selector });
     return;
   }
@@ -289,6 +294,11 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {});
   await assertNoErrorPage(resultPage, 'schedule-provider-search');
   await resultPage.close();
+  // Selecting a provider navigates the MAIN schedule window (the popup submits into
+  // its opener), so schedulePage is mid-reload when this returns. Wait for that reload
+  // to settle before the caller asserts the schedule nav links — otherwise every link
+  // check races a torn-down DOM and reports a false "missing-user-link".
+  await schedulePage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
 }
 
 (async () => {

--- a/scripts/tickler-note-dialog-playwright-checks.js
+++ b/scripts/tickler-note-dialog-playwright-checks.js
@@ -183,6 +183,19 @@ function cleanupTicklerRows() {
   sql(`DELETE FROM tickler WHERE message LIKE '${escapedStamp}'`);
 }
 
+function purgeDanglingTicklerNoteLinks() {
+  // Filtered demo snapshots (and any hand-pruned dev database) can carry
+  // casemgmt_note_link rows whose TICKLER table_id no longer exists in the
+  // tickler table. Ticklers created by this test then REUSE those
+  // auto-increment ids and "inherit" the orphaned notes, which reads exactly
+  // like the stale-data leak this script exists to detect. Those links are
+  // unreachable garbage (their tickler is gone; the app only soft-deletes
+  // ticklers, so this state never arises from the UI) - purge them so the
+  // fresh-tickler-has-a-blank-dialog premise holds. Links of existing
+  // ticklers are untouched.
+  sql(`DELETE FROM casemgmt_note_link WHERE table_name = ${NOTE_LINK_TABLE_TICKLER} AND table_id NOT IN (SELECT tickler_no FROM tickler)`);
+}
+
 function cleanupNoteRows() {
   if (createdTicklerIds.length === 0) {
     return;
@@ -364,6 +377,7 @@ async function closeDialogIfOpen(page) {
 
 (async () => {
   cleanupTicklerRows();
+  purgeDanglingTicklerNoteLinks();
 
   const launchOptions = {
     headless: true,

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
@@ -593,9 +593,12 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
         }
 
         infoTable.addCell(setInfoCell(cell, getResource("msgUrgency")));
-        infoTable.addCell(setDataCell(cell, (reqFrm.urgency.equals("1") ? getResource("msgUrgent") :
-                (reqFrm.urgency.equals("2") ? getResource("msgNUrgent") :
-                        (reqFrm.urgency.equals("3")) ? getResource("msgReturn")
+        // urgency is nullable on consultationRequests (legacy/imported rows, partial
+        // integration updates); a missing urgency must print blank, not NPE the whole
+        // consultation PDF out of print/preview/fax.
+        infoTable.addCell(setDataCell(cell, ("1".equals(reqFrm.urgency) ? getResource("msgUrgent") :
+                ("2".equals(reqFrm.urgency) ? getResource("msgNUrgent") :
+                        ("3".equals(reqFrm.urgency)) ? getResource("msgReturn")
                                 : "  "))));
 
         infoTable.addCell(setInfoCell(cell, getResource("msgService")));
@@ -903,14 +906,18 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
      */
     private PdfPTable createReferringPracAndMRPDetailTable(LoggedInInfo loggedInInfo) {
         ProviderDao proDAO = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
-        io.github.carlos_emr.carlos.commn.model.Provider pro = proDAO.getProvider(reqFrm.providerNo);
+        // providerNo is nullable on consultationRequests, and either provider number can
+        // reference a since-removed provider row. A missing provider must print without
+        // an OHIP suffix, not NPE the whole consultation PDF out of print/preview/fax.
+        io.github.carlos_emr.carlos.commn.model.Provider pro =
+                reqFrm.providerNo != null ? proDAO.getProvider(reqFrm.providerNo) : null;
         DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, Integer.parseInt(reqFrm.demoNo));
-        String ohipNo = pro.getOhipNo();
+        String ohipNo = pro != null ? pro.getOhipNo() : "";
         String famDocOhipNo = "";
         if (demo.getProviderNo() != null && !demo.getProviderNo().equals("")) {
             pro = proDAO.getProvider(demo.getProviderNo());
-            famDocOhipNo = pro.getOhipNo();
+            famDocOhipNo = pro != null ? pro.getOhipNo() : "";
         }
 
         PdfPTable table = new PdfPTable(new float[]{1.0f, 1.0f});

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctViewRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctViewRequest2Action.java
@@ -184,8 +184,12 @@ public class EctViewRequest2Action extends ActionSupport {
         thisForm.setPatientAge(demo.getAge());
 
         ProviderDao provDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);
-        Provider prov = provDao.getProvider(consult.getProviderNo());
-        thisForm.setProviderName(prov.getFormattedName());
+        // providerNo is nullable on consultationRequests (legacy/imported rows, and
+        // integration-created requests) and can also reference a since-removed
+        // provider. A missing referring provider must render as blank, not NPE the
+        // whole consultation view into a 500.
+        Provider prov = consult.getProviderNo() != null ? provDao.getProvider(consult.getProviderNo()) : null;
+        thisForm.setProviderName(prov != null ? prov.getFormattedName() : "");
 
         boolean isEReferral = extraMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
         thisForm.seteReferral(isEReferral);

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyData.java
@@ -129,7 +129,11 @@ public class RxPharmacyData {
      * @return the pharmacy, or null when the id is not numeric or is unknown
      */
     public PharmacyInfo getPharmacy(String ID) {
-        if (ID == null || !ID.matches("\\d{1,9}")) {
+        // [0-9] spelled out rather than \d for explicitness: without
+        // UNICODE_CHARACTER_CLASS the two are equivalent (ASCII-only), and
+        // the guard must stay narrower than Integer.parseInt, which DOES
+        // accept Unicode digits.
+        if (ID == null || !ID.matches("[0-9]{1,9}")) {
             return null;
         }
         PharmacyInfo pharmacyInfo = pharmacyInfoDao.getPharmacy(Integer.parseInt(ID));

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyData.java
@@ -119,10 +119,19 @@ public class RxPharmacyData {
     /**
      * Returns the latest data about a pharmacy.
      *
+     * <p>Every caller hands this a request-sourced string (the Rx preview and
+     * view pages, the pharmacy-info AJAX action, the customized-PDF servlet)
+     * and each already handles a null result, so a value that is not a plain
+     * numeric id answers null here rather than letting
+     * {@code Integer.parseInt} throw and 500 the whole page.</p>
+     *
      * @param ID pharmacy id
-     * @return returns a pharmacy class corresponding latest data from the pharmacy ID
+     * @return the pharmacy, or null when the id is not numeric or is unknown
      */
     public PharmacyInfo getPharmacy(String ID) {
+        if (ID == null || !ID.matches("\\d{1,9}")) {
+            return null;
+        }
         PharmacyInfo pharmacyInfo = pharmacyInfoDao.getPharmacy(Integer.parseInt(ID));
         return pharmacyInfo;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
@@ -49,6 +49,7 @@ import io.github.carlos_emr.carlos.prescript.data.RxDrugData.DrugMonograph.DrugC
 import io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData;
 import io.github.carlos_emr.carlos.prescript.util.RxUtil;
 import io.github.carlos_emr.carlos.util.StringUtils;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -575,7 +576,7 @@ public final class RxWriteScript2Action extends ActionSupport {
 				drugId = Encode.forJava(drugId);
 			}
 
-            logger.debug("requesting drug from drugref id=" + drugId);
+            logger.debug("requesting drug from drugref id={}", LogSafe.sanitize(drugId)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
             RxDrugData.DrugMonograph dmono = drugData.getDrug2(drugId);
 
             // A DrugRef id that resolves to no product surfaces here as an empty
@@ -587,7 +588,7 @@ public final class RxWriteScript2Action extends ActionSupport {
             if (dmono == null
                     || (dmono.name == null
                         && (dmono.getProduct() == null || dmono.getProduct().isEmpty()))) {
-                logger.warn("createNewRx: no prescribable DrugRef product for drug id " + drugId);
+                logger.warn("createNewRx: no prescribable DrugRef product for drug id {}", LogSafe.sanitize(drugId)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
                 request.setAttribute("rxStageError",
                     "The selected item could not be added as a prescription. "
                     + "Please choose a specific drug product (a brand or a strength), "

--- a/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
@@ -263,7 +263,6 @@
                     if (document.adddemographic.ver) {
                         document.adddemographic.ver.value = lastTwo;
                     }
-				// Validate Alberta HIN (9 digits) if province is AB
 				}
             }
 

--- a/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
@@ -264,6 +264,7 @@
                         document.adddemographic.ver.value = lastTwo;
                     }
 				// Validate Alberta HIN (9 digits) if province is AB
+				}
             }
 
             function formatPhoneNum(el) {

--- a/src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp
@@ -293,7 +293,10 @@
         PharmacyInfo pharmacy;
         String pharmacyId = request.getParameter("pharmacyId");
 
-        if (pharmacyId != null && !"null".equalsIgnoreCase(pharmacyId)) {
+        // viewScript builds this iframe URL with pharmacyId= EMPTY when the patient
+        // has no preferred pharmacy, so a blank value must mean "no pharmacy" here -
+        // it used to fall through to Integer.parseInt("") and 500 the whole preview.
+        if (pharmacyId != null && !pharmacyId.isBlank() && !"null".equalsIgnoreCase(pharmacyId)) {
             pharmacy = pharmacyData.getPharmacy(pharmacyId);
             if (pharmacy != null) {
                 pharmaFax = pharmacy.getFax();

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyDataUnitTest.java
@@ -92,4 +92,13 @@ class RxPharmacyDataUnitTest extends CarlosUnitTestBase {
         assertThat(rxPharmacyData.getPharmacy("1234567890")).isNull();
         verifyNoInteractions(pharmacyInfoDao);
     }
+
+    @Test
+    @DisplayName("should return null for Unicode digits even though parseInt would accept them")
+    void shouldReturnNull_forUnicodeDigits() {
+        // Arabic-Indic "123": Integer.parseInt would parse this to 123, so the
+        // guard must reject it explicitly to keep ids ASCII-only.
+        assertThat(rxPharmacyData.getPharmacy("١٢٣")).isNull();
+        verifyNoInteractions(pharmacyInfoDao);
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPharmacyDataUnitTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.prescript.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.carlos_emr.carlos.commn.dao.DemographicPharmacyDao;
+import io.github.carlos_emr.carlos.commn.dao.PharmacyInfoDao;
+import io.github.carlos_emr.carlos.commn.model.PharmacyInfo;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link RxPharmacyData#getPharmacy(String)}.
+ *
+ * <p>Every caller hands the method a request-sourced string, so a value that
+ * is not a plain numeric id must answer null instead of letting
+ * {@code Integer.parseInt} throw a NumberFormatException that 500s the Rx
+ * preview/view pages (found via the deb-install Playwright validation).</p>
+ */
+@Tag("unit")
+@Tag("prescription")
+class RxPharmacyDataUnitTest extends CarlosUnitTestBase {
+
+    private PharmacyInfoDao pharmacyInfoDao;
+    private RxPharmacyData rxPharmacyData;
+
+    @BeforeEach
+    void setUp() {
+        pharmacyInfoDao = createAndRegisterMock(PharmacyInfoDao.class);
+        registerMock(DemographicPharmacyDao.class, Mockito.mock(DemographicPharmacyDao.class));
+        rxPharmacyData = new RxPharmacyData();
+    }
+
+    @Test
+    @DisplayName("should return pharmacy when the id is numeric")
+    void shouldReturnPharmacy_whenIdIsNumeric() {
+        PharmacyInfo pharmacy = new PharmacyInfo();
+        when(pharmacyInfoDao.getPharmacy(6)).thenReturn(pharmacy);
+
+        assertThat(rxPharmacyData.getPharmacy("6")).isSameAs(pharmacy);
+        verify(pharmacyInfoDao).getPharmacy(6);
+    }
+
+    @Test
+    @DisplayName("should return null without touching the DAO for non-numeric ids")
+    void shouldReturnNull_forNonNumericId() {
+        assertThat(rxPharmacyData.getPharmacy("abc")).isNull();
+        assertThat(rxPharmacyData.getPharmacy("6; DROP TABLE x")).isNull();
+        assertThat(rxPharmacyData.getPharmacy("-1")).isNull();
+        verifyNoInteractions(pharmacyInfoDao);
+    }
+
+    @Test
+    @DisplayName("should return null for null, blank, and the literal string null")
+    void shouldReturnNull_forNullBlankAndLiteralNull() {
+        assertThat(rxPharmacyData.getPharmacy(null)).isNull();
+        assertThat(rxPharmacyData.getPharmacy("")).isNull();
+        assertThat(rxPharmacyData.getPharmacy("null")).isNull();
+        verifyNoInteractions(pharmacyInfoDao);
+    }
+
+    @Test
+    @DisplayName("should return null when the id exceeds the nine-digit cap")
+    void shouldReturnNull_whenIdExceedsDigitCap() {
+        assertThat(rxPharmacyData.getPharmacy("1234567890")).isNull();
+        verifyNoInteractions(pharmacyInfoDao);
+    }
+}


### PR DESCRIPTION
Follow-up to #3547, found by building the three debs from source, clean-installing them into a fresh Ubuntu 26.04 VM with the demo dataset, and driving the **entire** `scripts/` Playwright suite through the nginx + ModSecurity front door on `:443`. End state: `carlos-ctl check` all-OK and **33/33 checks passing**, re-verified after a final rebuild from this branch's HEAD via the reinstall/upgrade path.

## Production bugs fixed (each reproduced live on the packaged install, then re-validated)

- **WAF blocked clinical note-saving** — CRS 932110 matched the `&cmd=` inside eChart's app-generated `reloadUrl`; a +5 critical, so every encounter-note save 403'd. Exclusion 1010 extended to `ARGS:reloadUrl`.
- **WAF blocked eForm saves carrying signature/image data** — CRS 941130/941170 fire on the `data:image/...;base64` prefix, both in the floating toolbar's `openosp-image-link` inputs and in form-author-named fields (anomaly 33 on a real save). Exclusions 1030 + 1040 (the id the policy file had reserved for this case).
- **Add-patient page had no client-side validation** — a missing `}` in `parseHINforVC()` killed the page's whole inline script; patients saved with phone/HIN/DOB/duplicate checks all dead.
- **Consultation view 500'd on a null `providerNo`** — NPE in `EctViewRequest2Action.fillFormValues`, masked behind `ResponseSanitizationFilter`'s secondary "Cannot reset buffer" failure.
- **Consultation print/preview/fax PDF NPE'd** on null `urgency` and missing referring/family-provider rows in `ConsultationPDFCreator`.
- **Prescription preview 500'd for patients with no pharmacy** — the app builds the preview URL with `pharmacyId=` empty and `Preview2.jsp` fell through to `Integer.parseInt("")`.
- **Sonar S5145 on #3547's merged code** — `drugId` request parameter logged raw in `RxWriteScript2Action`; both log sites now go through `LogSafe.sanitize`.

## Defaults & data flow

- **Digital signatures default ON** (stock + demo): Flyway `V1.0.17` flips the seeded facility once at migrate time (validated through the packaged migrate: 18 migrations, boot-validate green); `populate_db.sh` re-asserts it after `development.sql` truncate-reloads Facility.
- **`populate_db.sh` now applies `update-2026-06-29-rtl-attachment-route-fix.sql`** — without it the seeded Rich Text Letter's Attach flow 404s on every fresh database (previously a manual step buried in the smoke-test runbook). Demo flow only; stock installs seed no eForms.

## Test harness

Made the reference checks runnable against a packaged install (self-signed TLS, bundled-Chromium default, UI-driven provider seeding around the 5-minute `ACTIVE_PROVIDERS` cache, dangling tickler-note-link purge, stale GET-vs-POST preview predicates, fixture `step` mismatch, optional library-form probe) and fixed two pre-existing test races (`schedule-links`, `logout-session-invalidation`).

## Docs

New runbook **`docs/ui-tests/deb-install-validation.md`** capturing the whole procedure — build, VM, preseeded install, demo-data + fixture load order, suite environment contract, upgrade-path check, and the diagnosis lessons (WAF blocks look like timeouts with a clean Tomcat log; `flyway.onBoot=validate` bricks a restart if the DB is ahead of the WAR; cache pitfalls) — cross-linked from `install-deb.md` and the ui-tests index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnov5ppnJbdnyEDMMAJMdm

## Summary by Sourcery

Harden the Debian deployment and end-to-end validation workflow so packaged installations support core clinical, eForm, consultation, prescription, and signature workflows reliably.

Bug Fixes:
- Prevent ModSecurity false positives from blocking clinical note and eForm saves through the packaged HTTPS front door.
- Restore add-patient client-side validation and prevent consultation, consultation PDF, and prescription preview failures for nullable or missing data.
- Sanitize prescription drug identifiers before logging them.

Enhancements:
- Enable digital signatures by default for the seeded facility and keep demo data aligned with the stock installation.
- Include the Rich Text Letter attachment-route correction in demo database setup.
- Make the Playwright validation suite portable to packaged installs and address pre-existing navigation, logout, cache, and fixture reliability issues.

Documentation:
- Add a runbook for building, installing, upgrading, and validating Debian packages through nginx and ModSecurity.

Tests:
- Expand packaged-install UI validation coverage and make optional eForm probes and bundled Chromium execution suitable for clean deployment environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `.deb` deployment after full Playwright validation through nginx and ModSecurity: clinical saves and nullable consultation/prescription workflows that previously 403'd or 500'd now complete, and the seeded facility enables digital signatures by default.

**Bug Fixes**

- ModSecurity now excludes eChart `reloadUrl` and eForm base64 image data on the affected POST routes; exclusions are path-anchored and remove only the rules that actually false-positive.
- Prescription previews and other pharmacy-lookup pages handle blank or non-numeric `pharmacyId` values — `RxPharmacyData` now validates the id as ASCII digits only and returns null, pinned by a new unit test.
- Consultation views and print/preview/fax PDFs tolerate missing providers and urgency instead of 500ing.
- Restores add-patient client-side validation and sanitizes `drugId` request logging.
- The demo dataset no longer silently drops `program_provider` enrolments or the `ExternalNote` issue catalog row, which broke patient eChart access and the issues module; `ctl_document` loads again so attach dialogs are not empty, and the devcontainer db image now copies the new guard scripts so its initialization no longer aborts on them.
- Rich Text Letter attachment routes now ship in both demo-data loaders.

**Defaults & Validation**

- Migration `V1.0.17` flips only facility 1 to signatures-on; it is a one-time override, so operators who prefer signatures off must disable it again after upgrade.
- Fresh installs now write the consultation-signature sentinel so an explicit `false` survives future upgrades; demo loading re-applies the facility default after its data reload.
- Adds user-journey checks for add-patient validation, nullable consultations, and prescription reprints, and runs the whole Playwright suite against packaged HTTPS installs; the new runbook documents the build, install, upgrade, and 33-check pass.
- Adds recovery guidance for stale Maven caches affecting dependency submission after JitPack vendoring; it does not change the workflow.

<sup>Written for commit 4f8abd38420229ab3a646087f14abaaba0281c98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

