### PR TITLE
fix(deb): harden unauthenticated remote attack surface for release

### DIFF
--- a/debian/assets/carlos_ctl/validate.py
+++ b/debian/assets/carlos_ctl/validate.py
@@ -281,6 +281,32 @@ def cmd_check(argv) -> int:
     else:
         _bad("the front door exposes /drugref2 — it is an unauthenticated service")
 
+    # /ws/** (CXF SOAP/REST) is exempt from the login filter: every service is
+    # expected to authenticate itself (OAuth 1.0a / WS-Security). Prove two
+    # invariants at runtime rather than trusting the config — the service-list
+    # catalog is not handed to an anonymous client, and a PHI data service
+    # refuses an unauthenticated call.
+    ws_list = _curl(resolve + [f"https://{s.server_name}/carlos/ws/services"], timeout=10).stdout
+    if "Available SOAP services" in ws_list or "Available RESTful services" in ws_list:
+        _bad("the CXF service-list catalog is served at /carlos/ws — set "
+             "hide-service-list-page=true on the CXFServlet (WEB-INF/web.xml)")
+    else:
+        _ok("the CXF service-list catalog is not exposed")
+    # An empty SOAP envelope carries no WS-Security header, so a gated data
+    # service must reject it. Any non-200 (401/403/500) is a pass; only a 200
+    # means the authentication gate let an anonymous caller through.
+    ws_code = _curl(resolve + ["-o", "/dev/null", "-w", "%{http_code}", "-X", "POST",
+                               "-H", "Content-Type: text/xml", "-d",
+                               "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+                               "<s:Body/></s:Envelope>",
+                               f"https://{s.server_name}/carlos/ws/DemographicService"],
+                    timeout=10).stdout.strip()
+    if ws_code == "200":
+        _bad("an unauthenticated SOAP call to /carlos/ws/DemographicService returned 200 — "
+             "the WS-Security authentication gate is not enforcing")
+    else:
+        _ok(f"an unauthenticated web-service call is rejected ({ws_code or '000'})")
+
     print("\nWAF")
     engine = ""
     try:

--- a/debian/assets/carlos_ctl/validate.py
+++ b/debian/assets/carlos_ctl/validate.py
@@ -79,10 +79,20 @@ def cmd_check(argv) -> int:
             _ok(f"{unit} is running")
         else:
             _bad(f"{unit} is NOT running (systemctl status {unit})")
-    for unit in ("carlos-emr-backup.timer", "carlos-emr-backup-verify.timer",
-                 "carlos-emr-cert-renew.timer"):
+    # carlos-emr.service is checked for ENABLED as well as running. A unit can be
+    # active now and still disabled — which is exactly the state the postinst
+    # leaves behind when the seeded administrator credential could not be
+    # replaced. Without this the EMR passes every check today and silently fails
+    # to come back at the next reboot.
+    for unit in ("carlos-emr.service", "carlos-emr-backup.timer",
+                 "carlos-emr-backup-verify.timer", "carlos-emr-cert-renew.timer"):
         if run(["systemctl", "is-enabled", "--quiet", unit], capture_output=True).returncode == 0:
             _ok(f"{unit} is enabled")
+        elif unit == "carlos-emr.service" and os.path.exists(
+                os.path.join("/var/lib/carlos-emr", ".seed-credential-live")):
+            _bad(f"{unit} is DISABLED because the seeded administrator credential is still "
+                 "live — it will NOT start at the next boot. Run 'carlos-ctl bootstrap-admin' "
+                 "(it re-enables the unit), then 'systemctl start carlos-emr'")
         else:
             _bad(f"{unit} is NOT enabled")
 
@@ -286,25 +296,43 @@ def cmd_check(argv) -> int:
     # invariants at runtime rather than trusting the config — the service-list
     # catalog is not handed to an anonymous client, and a PHI data service
     # refuses an unauthenticated call.
-    # CXF renders the service-list catalog at the SERVLET ROOT (/carlos/ws/),
-    # not at a /services sub-path — a GET to /carlos/ws/services is pathInfo
-    # "/services", matches no destination and 404s even with the catalog
-    # enabled, so probing it would false-pass. Probe the real listing URL.
-    ws_list = _curl(resolve + [f"https://{s.server_name}/carlos/ws/"], timeout=10).stdout
-    if "Available SOAP services" in ws_list or "Available RESTful services" in ws_list:
+    # CXF serves the service-list catalog from the SERVLET ROOT. The trailing
+    # slash is required: LoginFilter's exemption list holds "/ws/" and only
+    # prefix-matches an entry ending in "/", so a GET to /carlos/ws would be
+    # redirected to the login page and the probe would see no markers and pass
+    # for the wrong reason. (The old /carlos/ws/services probe was blind because
+    # applicationContextREST.xml registers a real jaxrs:server at address
+    # "/services", so CXF dispatches there instead of rendering the catalog.)
+    #
+    # The STATUS is asserted, not just the body: without it a 502 during a Tomcat
+    # restart, a 429 from limit_req, a redirect, or a curl timeout (empty stdout)
+    # would every one of them print "catalog is not exposed".
+    ws_list = _curl(resolve + ["-w", "\n%{http_code}",
+                               f"https://{s.server_name}/carlos/ws/"], timeout=10).stdout
+    ws_list_body, _, ws_list_code = ws_list.rpartition("\n")
+    ws_list_code = ws_list_code.strip()
+    if "Available SOAP services" in ws_list_body or "Available RESTful services" in ws_list_body:
         _bad("the CXF service-list catalog is served at /carlos/ws/ — set "
              "hide-service-list-page=true on the CXFServlet (WEB-INF/web.xml)")
-    else:
+    elif ws_list_code == "404":
+        # CXF's own "No service was found." 404 is the healthy hidden-catalog shape.
         _ok("the CXF service-list catalog is not exposed")
-    # An empty SOAP envelope carries no WS-Security header, so a gated data
-    # service must reject it. Distinguish a genuine auth rejection (the WSS4J
-    # interceptor maps a missing token to 400/401) from a 200 (auth bypassed)
-    # and from a 403/404/redirect (a WAF block or moved path that MASKS the auth
-    # check rather than proving it) — the latter is inconclusive, not a pass.
+    else:
+        _note(f"could not confirm the CXF catalog is hidden: /carlos/ws/ returned "
+              f"{ws_list_code or '000'} (expected 404; a 502, 429 or redirect masks this check)")
+    # A gated data service must reject an unauthenticated call. The body is a
+    # REAL operation, not an empty envelope: WS-Security runs at PRE_PROTOCOL,
+    # strictly before unmarshalling, so a well-formed request still yields 400
+    # while the gate is present — but if the interceptor is ever removed, an
+    # empty envelope would die later in unmarshalling with a 500 and land in the
+    # inconclusive bucket below, i.e. the probe would MISS the exact regression
+    # it exists to catch. With a real operation the ungated case returns 200 and
+    # trips the _bad branch.
+    ws_body = ('<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body>'
+               '<getDemographic xmlns="http://ws.oscarehr.org/"><arg0>1</arg0></getDemographic>'
+               '</s:Body></s:Envelope>')
     ws_code = _curl(resolve + ["-o", "/dev/null", "-w", "%{http_code}", "-X", "POST",
-                               "-H", "Content-Type: text/xml", "-d",
-                               "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-                               "<s:Body/></s:Envelope>",
+                               "-H", "Content-Type: text/xml", "-d", ws_body,
                                f"https://{s.server_name}/carlos/ws/DemographicService"],
                     timeout=10).stdout.strip()
     if ws_code == "200":
@@ -315,6 +343,18 @@ def cmd_check(argv) -> int:
     else:
         _note(f"could not confirm the /ws auth gate: /carlos/ws/DemographicService returned "
               f"{ws_code or '000'} (a WAF 403, a 404, or a redirect can mask the auth check)")
+    # Pin the path-normalisation guard: nginx and Tomcat normalise in different
+    # orders, so a dot segment carrying a matrix parameter used to slip past every
+    # path-scoped rule (rate limits and the DrugRef/SystemInfoService 404s alike)
+    # and still reach the servlet. Anything but 400 means that guard is gone.
+    for probe in ("/carlos/.;x/login", "/carlos/..;x/drugref2/DrugrefService"):
+        code = _curl(resolve + ["-o", "/dev/null", "-w", "%{http_code}",
+                                f"https://{s.server_name}{probe}"], timeout=10).stdout.strip()
+        if code == "400":
+            _ok(f"a dot-segment path-normalisation bypass is rejected ({probe})")
+        else:
+            _bad(f"{probe} returned {code or '000'}, expected 400 — the path-normalisation "
+                 "guard in the nginx site config is missing or was reordered")
 
     print("\nWAF")
     engine = ""

--- a/debian/assets/carlos_ctl/validate.py
+++ b/debian/assets/carlos_ctl/validate.py
@@ -286,15 +286,21 @@ def cmd_check(argv) -> int:
     # invariants at runtime rather than trusting the config — the service-list
     # catalog is not handed to an anonymous client, and a PHI data service
     # refuses an unauthenticated call.
-    ws_list = _curl(resolve + [f"https://{s.server_name}/carlos/ws/services"], timeout=10).stdout
+    # CXF renders the service-list catalog at the SERVLET ROOT (/carlos/ws/),
+    # not at a /services sub-path — a GET to /carlos/ws/services is pathInfo
+    # "/services", matches no destination and 404s even with the catalog
+    # enabled, so probing it would false-pass. Probe the real listing URL.
+    ws_list = _curl(resolve + [f"https://{s.server_name}/carlos/ws/"], timeout=10).stdout
     if "Available SOAP services" in ws_list or "Available RESTful services" in ws_list:
-        _bad("the CXF service-list catalog is served at /carlos/ws — set "
+        _bad("the CXF service-list catalog is served at /carlos/ws/ — set "
              "hide-service-list-page=true on the CXFServlet (WEB-INF/web.xml)")
     else:
         _ok("the CXF service-list catalog is not exposed")
     # An empty SOAP envelope carries no WS-Security header, so a gated data
-    # service must reject it. Any non-200 (401/403/500) is a pass; only a 200
-    # means the authentication gate let an anonymous caller through.
+    # service must reject it. Distinguish a genuine auth rejection (the WSS4J
+    # interceptor maps a missing token to 400/401) from a 200 (auth bypassed)
+    # and from a 403/404/redirect (a WAF block or moved path that MASKS the auth
+    # check rather than proving it) — the latter is inconclusive, not a pass.
     ws_code = _curl(resolve + ["-o", "/dev/null", "-w", "%{http_code}", "-X", "POST",
                                "-H", "Content-Type: text/xml", "-d",
                                "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">"
@@ -304,8 +310,11 @@ def cmd_check(argv) -> int:
     if ws_code == "200":
         _bad("an unauthenticated SOAP call to /carlos/ws/DemographicService returned 200 — "
              "the WS-Security authentication gate is not enforcing")
+    elif ws_code in ("400", "401"):
+        _ok(f"an unauthenticated web-service call is rejected by the auth gate ({ws_code})")
     else:
-        _ok(f"an unauthenticated web-service call is rejected ({ws_code or '000'})")
+        _note(f"could not confirm the /ws auth gate: /carlos/ws/DemographicService returned "
+              f"{ws_code or '000'} (a WAF 403, a 404, or a redirect can mask the auth check)")
 
     print("\nWAF")
     engine = ""

--- a/debian/assets/modsecurity/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+++ b/debian/assets/modsecurity/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
@@ -13,12 +13,24 @@
 # indistinguishable from a mistake three years later.
 
 # CSRFGuard tokens are long random strings that the SQLi and XSS rule groups
-# read as encoded payloads. The token name is fixed by the application's
-# CsrfGuard configuration.
-SecRuleUpdateTargetByTag "attack-sqli" "!ARGS:OWASP_CSRFTOKEN"
-SecRuleUpdateTargetByTag "attack-xss"  "!ARGS:OWASP_CSRFTOKEN"
+# read as encoded payloads. The parameter name MUST match the application's
+# configured CsrfGuard TokenName — Owasp.CsrfGuard.properties sets
+# `org.owasp.csrfguard.TokenName=CSRF-TOKEN`, so the request parameter (and
+# header) is `CSRF-TOKEN`. The earlier `OWASP_CSRFTOKEN` was CSRFGuard's default
+# *SessionKey*, a server-side session attribute that never appears in a request:
+# excluding it suppressed no real false positive while leaving an attacker a
+# rule-free parameter name to smuggle SQLi/XSS payloads past these two groups.
+# Keyed on the real name the exclusion is also gated by CSRFGuard's own token
+# validation — a request whose CSRF-TOKEN is an injection string rather than a
+# valid token is rejected before it can reach a sink.
+SecRuleUpdateTargetByTag "attack-sqli" "!ARGS:CSRF-TOKEN"
+SecRuleUpdateTargetByTag "attack-xss"  "!ARGS:CSRF-TOKEN"
 
 # The session cookie is base64-ish and trips the same groups on every request
-# once it happens to contain a matching substring.
-SecRuleUpdateTargetByTag "attack-sqli" "!REQUEST_COOKIES:/JSESSIONID/"
-SecRuleUpdateTargetByTag "attack-xss"  "!REQUEST_COOKIES:/JSESSIONID/"
+# once it happens to contain a matching substring. The name is ANCHORED:
+# `/JSESSIONID/` is an unanchored regex that also matches any attacker-named
+# cookie merely CONTAINING the substring (e.g. `xJSESSIONIDx`), which would strip
+# that cookie's value from the SQLi/XSS groups and hand the attacker a WAF-blind
+# channel. `/^JSESSIONID$/` matches only the real Tomcat session cookie.
+SecRuleUpdateTargetByTag "attack-sqli" "!REQUEST_COOKIES:/^JSESSIONID$/"
+SecRuleUpdateTargetByTag "attack-xss"  "!REQUEST_COOKIES:/^JSESSIONID$/"

--- a/debian/assets/modsecurity/crs-overrides.conf
+++ b/debian/assets/modsecurity/crs-overrides.conf
@@ -71,14 +71,18 @@ SecAction \
 # The CRS default list already covers what CARLOS posts
 # (application/x-www-form-urlencoded, multipart/form-data, application/json,
 # text/xml, application/xml, application/soap+xml). It is restated explicitly
-# so a CRS default change cannot start rejecting a clinical form, with ONE
-# addition, named and justified:
-#   text/plain — navigator.sendBeacon() payloads, which the logout-broadcast
-#                and session-heartbeat client code emit.
-# Deliberately NOT added (a previous revision had them "just in case"):
-#   application/octet-stream — the widest possible type: a request declaring
-#                it gets no body parser at all, so every ARGS-based CRS rule
-#                inspects nothing. No front-door CARLOS workflow posts it.
+# so a CRS default change cannot start rejecting a clinical form.
+# Deliberately NOT allowed (each gets NO body parser, so every ARGS-based CRS
+# rule would inspect nothing in its body):
+#   text/plain — was previously allowed "for navigator.sendBeacon() payloads",
+#                but the current logout-broadcast / note-lock beacons post
+#                application/x-www-form-urlencoded or an empty body, and no
+#                other front-door workflow posts text/plain. Allowing it only
+#                created an ARGS-inspection blind spot an attacker could POST
+#                through. If a future endpoint genuinely needs text/plain, scope
+#                it to that route rather than re-allowing it application-wide.
+#   application/octet-stream — the widest possible type; no front-door CARLOS
+#                workflow posts it.
 #   multipart/related — no front-door workflow posts it either; the SOAP
 #                integrations use application/soap+xml.
 SecAction \
@@ -87,7 +91,7 @@ SecAction \
     nolog,\
     pass,\
     t:none,\
-    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |text/plain|'"
+    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json|'"
 
 # --- what is deliberately NOT changed ---------------------------------------
 # tx.crs_validate_utf8_encoding stays at the CRS default (off at PL1). The

--- a/debian/assets/nginx/carlos-emr.conf
+++ b/debian/assets/nginx/carlos-emr.conf
@@ -181,6 +181,23 @@ server {
         include /etc/carlos-emr/nginx/proxy-params.conf;
     }
 
+    # The SOAP LoginService and the OAuth 1.0a request-token endpoint are
+    # unauthenticated credential/token surfaces by necessity (a client posts
+    # credentials to obtain a token), so they are the machine-facing equivalent
+    # of the human login route and get the same per-address request-rate and
+    # connection ceilings. Scoped to these two exact routes only — the rest of
+    # /ws is ordinary authenticated API traffic and must not be throttled. The
+    # optional context-segment matrix param is tolerated as on the login route,
+    # and `\b` stops the match at the route name (no /ws/LoginServiceFoo).
+    location ~* "^/carlos(;[^/]*)?/ws/(LoginService|oauth/initiate)\b" {
+        limit_req zone=carlos_login burst=20 nodelay;
+        limit_req_status 429;
+        limit_conn carlos_login_conn 12;
+        include /etc/nginx/snippets/carlos-emr-headers.conf;
+        proxy_pass http://carlos_backend;
+        include /etc/carlos-emr/nginx/proxy-params.conf;
+    }
+
     location / {
         proxy_pass http://carlos_backend;
         include /etc/carlos-emr/nginx/proxy-params.conf;

--- a/debian/assets/nginx/carlos-emr.conf
+++ b/debian/assets/nginx/carlos-emr.conf
@@ -198,6 +198,16 @@ server {
         include /etc/carlos-emr/nginx/proxy-params.conf;
     }
 
+    # SystemInfoService is a loopback-only liveness endpoint (server time,
+    # timezone, liveness, an internal paging constant). The front door has no
+    # route to it — a local monitor reaches it directly on 127.0.0.1:18080. The
+    # in-app LoopbackOnlyInInterceptor enforces the same thing, so neither gate
+    # is load-bearing on its own (the DrugRef pattern). `\b` stops the match at
+    # the route name; the optional context matrix param is covered as elsewhere.
+    location ~* "^/carlos(;[^/]*)?/ws/SystemInfoService\b" {
+        return 404;
+    }
+
     location / {
         proxy_pass http://carlos_backend;
         include /etc/carlos-emr/nginx/proxy-params.conf;

--- a/debian/assets/nginx/carlos-emr.conf
+++ b/debian/assets/nginx/carlos-emr.conf
@@ -107,6 +107,31 @@ server {
         return 302 /carlos/;
     }
 
+    # --- path-normalisation guard (MUST stay the first regex location) --------
+    # nginx and Tomcat normalise in DIFFERENT ORDERS, and that difference defeats
+    # every path-scoped rule below if it is not closed here:
+    #
+    #   nginx  : percent-decode + resolve `.` / `..` in one pass, THEN match $uri
+    #   Tomcat : strip `;`-matrix params FIRST, then decode, then normalise
+    #
+    # So a dot segment WEARING a matrix param (`/carlos/.;x/login`) is invisible
+    # to nginx's normaliser — the segment is `.;x`, not `.` — and therefore fails
+    # every location regex and falls through to `location /` unthrottled, while
+    # Tomcat strips `;x`, collapses the `.`, and routes it to the login servlet.
+    # Verified: `/carlos/.;x/login`, `/carlos/mfa/.;x/loginMfa`,
+    # `/carlos/ws/.;x/LoginService`, `/carlos/%2e;x/login` all bypassed the rate
+    # limit, and `/carlos/..;x/drugref2/…` escaped the /carlos context entirely
+    # past the DrugRef 404.
+    #
+    # Enumerating `(;[^/]*)?` per segment can never close this — the attacker
+    # picks the segment count. Reject the whole class instead: nginx has already
+    # resolved every LEGITIMATE `.`/`..` before matching, so a dot segment still
+    # present in $uri is necessarily carrying a matrix parameter and is hostile.
+    # (`file.;x` does not match: the dot must start the segment.)
+    location ~ "(^|/)\.{1,2};" {
+        return 400;
+    }
+
     # DrugRef is co-deployed in the same Tomcat but is an unauthenticated
     # XML-RPC service. It must never be reachable from outside the host; the
     # Tomcat context descriptor enforces the same thing with a RemoteCIDRValve
@@ -144,10 +169,14 @@ server {
     #   /carlos;jsessionid=x/login        (matrix param on the CONTEXT segment —
     #                                      the char after `carlos` is `;`, so a
     #                                      `^/carlos/`-anchored pattern missed it)
-    #   /carlos/LOGIN                      (Struts routes case-insensitively)
-    # Hence `~*` (case-insensitive) and the optional `(;[^/]*)?` after `carlos`.
+    # `~*` (case-insensitive) is used not because Struts routes case-insensitively
+    # — action names and Tomcat's mappings are case-SENSITIVE, so /carlos/LOGIN
+    # 404s — but because failing closed on case costs nothing: the pattern then
+    # matches a superset of what can reach the servlet.
     # nginx matches this against the normalised, percent-decoded $uri, so an
-    # encoded path (e.g. /carlos/%6cogin) is decoded before matching too.
+    # encoded path (e.g. /carlos/%6cogin) is decoded before matching too. What it
+    # does NOT normalise is a dot segment carrying a matrix param — see the
+    # path-normalisation guard above, which rejects that class outright.
     #
     # The MFA submit (/carlos/mfa/loginMfa) is included: it verifies a short PIN
     # and is the other credential-guessing target, so it belongs under the same
@@ -173,10 +202,15 @@ server {
     # Tomcat strips path (matrix) parameters from EVERY segment before mapping,
     # so `(;[^/]*)?` is repeated after each interior segment: without it after
     # `mfa`, /carlos/mfa;x/loginMfa slips past this block, falls through to
-    # `location /`, and reaches the MFA servlet unthrottled. The trailing `/?`
-    # tolerates one trailing slash for the same reason; the `[^/]*` before it
-    # still keeps /carlos/loginResource/<asset> out of the budget.
-    location ~* "^/carlos(;[^/]*)?/(login|forcepasswordreset|mfa(;[^/]*)?/loginMfa)[^/]*/?$" {
+    # `location /`, and reaches the MFA servlet unthrottled.
+    #
+    # NO trailing `/?`: Struts 2's DefaultActionMapper takes the action name as
+    # the text after the last `/`, so /carlos/login/ resolves no action and 404s
+    # at the default servlet — it never reaches Login2Action, and matching it
+    # buys nothing. It does cost something: `/?` pulled the bare directory form
+    # /carlos/loginResource/ into the credential budget, which is exactly the
+    # asset path the `[^/]*$` anchor exists to keep out.
+    location ~* "^/carlos(;[^/]*)?/(login|forcepasswordreset|mfa(;[^/]*)?/loginMfa)[^/]*$" {
         limit_req zone=carlos_login burst=20 nodelay;
         limit_req_status 429;
         limit_conn carlos_login_conn 12;
@@ -189,24 +223,36 @@ server {
         include /etc/carlos-emr/nginx/proxy-params.conf;
     }
 
-    # The SOAP LoginService and the OAuth 1.0a request-token endpoint are
-    # unauthenticated credential/token surfaces by necessity (a client posts
-    # credentials to obtain a token), so they are the machine-facing equivalent
-    # of the human login route and get a per-address request-rate and connection
-    # ceiling. Scoped to these two routes only — the rest of /ws is ordinary
-    # authenticated API traffic and must not be throttled.
+    # The SOAP LoginService and the unauthenticated legs of the OAuth 1.0a flow
+    # are credential/token surfaces by necessity (a client posts credentials or a
+    # verifier to obtain a token), so they are the machine-facing equivalent of
+    # the human login route and get a per-address request-rate and connection
+    # ceiling. The rest of /ws is ordinary authenticated API traffic and must not
+    # be throttled.
     #
-    # A SEPARATE request zone (carlos_wsauth) from the human login route: a
-    # legitimate server-to-server integration and a clinic's browsers often
-    # egress the same public IP, and a shared budget would let bursty API token
-    # calls 429 human logins (and vice-versa). `\b` stops the match at the route
-    # name (no /ws/LoginServiceFoo); `(;[^/]*)?` after each interior segment
-    # covers the matrix-parameter bypass Tomcat's per-segment stripping enables
-    # (/carlos/ws;x/LoginService, /carlos/ws/oauth;x/initiate).
-    location ~* "^/carlos(;[^/]*)?/ws(;[^/]*)?/(LoginService|oauth(;[^/]*)?/initiate)\b" {
+    # BOTH unauthenticated OAuth legs are covered: `initiate` (request token) and
+    # `token` (exchanges request-token + oauth_verifier for an access token — the
+    # short-secret leg, i.e. the classic brute-force target). `authorize` is
+    # deliberately EXCLUDED: it is session-gated, so it is not a pre-auth surface
+    # and throttling it would hit signed-in users.
+    #
+    # SEPARATE zones from the human login route, for BOTH request rate and
+    # connections: a legitimate server-to-server integration and a clinic's
+    # browsers often egress the same public IP. A shared budget would let bursty
+    # API token calls 429 human logins (and vice-versa) — and sharing the
+    # CONNECTION budget is the worse of the two, because limit_req sheds a spike
+    # in milliseconds while a connection slot is held for the life of the request
+    # (up to proxy_read_timeout 300s).
+    #
+    # `\b` stops the match at the route name (no /ws/LoginServiceFoo);
+    # `(;[^/]*)?` after each interior segment covers the matrix-parameter bypass
+    # Tomcat's per-segment stripping enables (/carlos/ws;x/LoginService,
+    # /carlos/ws/oauth;x/initiate). Dot-segment variants are rejected by the
+    # path-normalisation guard at the top of this server block.
+    location ~* "^/carlos(;[^/]*)?/ws(;[^/]*)?/(LoginService|oauth(;[^/]*)?/(initiate|token))\b" {
         limit_req zone=carlos_wsauth burst=20 nodelay;
         limit_req_status 429;
-        limit_conn carlos_login_conn 12;
+        limit_conn carlos_wsauth_conn 12;
         limit_conn_status 429;
         include /etc/nginx/snippets/carlos-emr-headers.conf;
         proxy_pass http://carlos_backend;

--- a/debian/assets/nginx/carlos-emr.conf
+++ b/debian/assets/nginx/carlos-emr.conf
@@ -115,17 +115,34 @@ server {
     # against the JVM. burst=20 with nodelay leaves normal interactive use
     # untouched.
     #
-    # Scoped to /carlos/login and /carlos/forcepasswordreset ONLY, and anchored
-    # with $ so it matches those exact routes. Widening it to the rest of the
-    # application would be actively harmful: a whole clinic arrives from one
-    # NAT address, so a shared per-address budget on ordinary AJAX traffic is a
-    # waiting room that cannot open the EMR. Nobody logs in ten times a second.
-    # [^/]* (not $ alone): Tomcat strips path (matrix) parameters, so
-    # /carlos/login;jsessionid=x still reaches the login servlet — an
-    # anchored-exact match let exactly those requests bypass the limit. The
-    # same pattern also covers the forced-reset submit action
-    # (/carlos/forcepasswordresetSubmit).
-    location ~ ^/carlos/(login|forcepasswordreset)[^/]*$ {
+    # Scoped to /carlos/login and /carlos/forcepasswordreset ONLY. Widening it to
+    # the rest of the application would be actively harmful: a whole clinic
+    # arrives from one NAT address, so a shared per-address budget on ordinary
+    # AJAX traffic is a waiting room that cannot open the EMR. Nobody logs in ten
+    # times a second.
+    #
+    # The regex must match every request Tomcat routes to the login/forced-reset
+    # servlets, because a request that escapes this location falls through to
+    # `location /` below and is proxied with NO limit — an unauthenticated
+    # credential-stuffing / login-DoS bypass. Tomcat strips path (matrix)
+    # parameters from EVERY segment before mapping, so all of these reach the
+    # login servlet and must all be caught here:
+    #   /carlos/login;jsessionid=x        (matrix param on the leaf segment)
+    #   /carlos;jsessionid=x/login        (matrix param on the CONTEXT segment —
+    #                                      the char after `carlos` is `;`, so a
+    #                                      `^/carlos/`-anchored pattern missed it)
+    #   /carlos/LOGIN                      (Struts routes case-insensitively)
+    # Hence `~*` (case-insensitive) and the optional `(;[^/]*)?` after `carlos`.
+    # nginx matches this against the normalised, percent-decoded $uri, so an
+    # encoded path (e.g. /carlos/%6cogin) is decoded before matching too.
+    #
+    # The trailing `[^/]*$` is load-bearing and must stay: it stops the leaf at
+    # the segment boundary so that /carlos/loginResource/<asset> and
+    # /carlos/mfa/... — which contain a further `/` — do NOT fall into this
+    # per-address budget. Throttling the login page's own static assets would be
+    # the "waiting room" failure above. (The MFA submit route gets its own
+    # coverage; see the limits include.)
+    location ~* ^/carlos(;[^/]*)?/(login|forcepasswordreset)[^/]*$ {
         limit_req zone=carlos_login burst=20 nodelay;
         limit_req_status 429;
         include /etc/nginx/snippets/carlos-emr-headers.conf;

--- a/debian/assets/nginx/carlos-emr.conf
+++ b/debian/assets/nginx/carlos-emr.conf
@@ -79,7 +79,13 @@ server {
     # 50 MB matches Tomcat's maxPostSize and ModSecurity's
     # SecRequestBodyLimit. All three must agree; see server.xml.
     client_max_body_size 50m;
-    client_body_timeout  60s;
+    # Inter-read timeout (time between two successive body reads, not the whole
+    # transfer). 15s, not the nginx default 60s: with proxy_request_buffering
+    # off a stalled body holds a Tomcat worker thread, and when nginx times the
+    # client out it also tears down the upstream request and frees that thread.
+    # A legitimate upload — even over a slow link — delivers data continuously,
+    # so the gap between reads is milliseconds; 15s only bites a slow-POST DoS.
+    client_body_timeout  15s;
     # Scanned documents and lab PDFs stream through; buffering a 50 MB body to
     # disk before forwarding just doubles the I/O.
     proxy_request_buffering off;
@@ -105,7 +111,14 @@ server {
     # XML-RPC service. It must never be reachable from outside the host; the
     # Tomcat context descriptor enforces the same thing with a RemoteCIDRValve
     # so neither gate is load-bearing on its own.
-    location ^~ /drugref2 {
+    #
+    # Case-insensitive regex, not a `^~ /drugref2` prefix: the prefix form is
+    # case-sensitive, so `/DrugRef2/...` slipped past it into `location /` and
+    # was proxied to Tomcat (the RemoteCIDRValve then refused it, but this gate
+    # should not lean on that). `^/+` also collapses any leading-slash trick.
+    # The Tomcat context is lowercase `drugref2`, so a case variant 404s at the
+    # app anyway; this simply refuses it at the edge as intended.
+    location ~* "^/+drugref2" {
         return 404;
     }
 
@@ -136,15 +149,30 @@ server {
     # nginx matches this against the normalised, percent-decoded $uri, so an
     # encoded path (e.g. /carlos/%6cogin) is decoded before matching too.
     #
+    # The MFA submit (/carlos/mfa/loginMfa) is included: it verifies a short PIN
+    # and is the other credential-guessing target, so it belongs under the same
+    # per-address ceiling as the password step. It is named explicitly rather
+    # than by a broad /carlos/mfa/ prefix so the rest of the MFA UI is untouched.
+    #
     # The trailing `[^/]*$` is load-bearing and must stay: it stops the leaf at
-    # the segment boundary so that /carlos/loginResource/<asset> and
-    # /carlos/mfa/... — which contain a further `/` — do NOT fall into this
-    # per-address budget. Throttling the login page's own static assets would be
-    # the "waiting room" failure above. (The MFA submit route gets its own
-    # coverage; see the limits include.)
-    location ~* ^/carlos(;[^/]*)?/(login|forcepasswordreset)[^/]*$ {
+    # the segment boundary so that /carlos/loginResource/<asset> and the other
+    # /carlos/mfa/* pages — which carry a further `/` past the matched leaf — do
+    # NOT fall into this per-address budget. Throttling the login page's own
+    # static assets would be the "waiting room" failure above.
+    #
+    # limit_conn caps CONCURRENT credential connections per address: with
+    # proxy_request_buffering off a slow-drip POST holds a Tomcat worker thread,
+    # and this bounds how many one source can tie up on the auth routes. It is
+    # scoped to these routes ONLY — a shared per-address CONNECTION budget on the
+    # chatty AJAX application would be the same NAT "waiting room" hazard the
+    # request-rate zone is kept off the rest of the app to avoid.
+    # The regex is QUOTED: it contains a literal `;` (the matrix-parameter
+    # match), and an unquoted `;` in an nginx directive is a statement
+    # terminator — nginx would report `location ... has no opening "{"`.
+    location ~* "^/carlos(;[^/]*)?/(login|forcepasswordreset|mfa/loginMfa)[^/]*$" {
         limit_req zone=carlos_login burst=20 nodelay;
         limit_req_status 429;
+        limit_conn carlos_login_conn 12;
         include /etc/nginx/snippets/carlos-emr-headers.conf;
         # carlos_backend (an upstream block in conf.d/carlos-emr-limits.conf)
         # rather than the address literal: backend keepalive only works

--- a/debian/assets/nginx/carlos-emr.conf
+++ b/debian/assets/nginx/carlos-emr.conf
@@ -166,13 +166,21 @@ server {
     # scoped to these routes ONLY — a shared per-address CONNECTION budget on the
     # chatty AJAX application would be the same NAT "waiting room" hazard the
     # request-rate zone is kept off the rest of the app to avoid.
-    # The regex is QUOTED: it contains a literal `;` (the matrix-parameter
-    # match), and an unquoted `;` in an nginx directive is a statement
-    # terminator — nginx would report `location ... has no opening "{"`.
-    location ~* "^/carlos(;[^/]*)?/(login|forcepasswordreset|mfa/loginMfa)[^/]*$" {
+    # The regex is QUOTED: it contains literal `;` (the matrix-parameter match),
+    # and an unquoted `;` in an nginx directive is a statement terminator —
+    # nginx would report `location ... has no opening "{"`.
+    #
+    # Tomcat strips path (matrix) parameters from EVERY segment before mapping,
+    # so `(;[^/]*)?` is repeated after each interior segment: without it after
+    # `mfa`, /carlos/mfa;x/loginMfa slips past this block, falls through to
+    # `location /`, and reaches the MFA servlet unthrottled. The trailing `/?`
+    # tolerates one trailing slash for the same reason; the `[^/]*` before it
+    # still keeps /carlos/loginResource/<asset> out of the budget.
+    location ~* "^/carlos(;[^/]*)?/(login|forcepasswordreset|mfa(;[^/]*)?/loginMfa)[^/]*/?$" {
         limit_req zone=carlos_login burst=20 nodelay;
         limit_req_status 429;
         limit_conn carlos_login_conn 12;
+        limit_conn_status 429;
         include /etc/nginx/snippets/carlos-emr-headers.conf;
         # carlos_backend (an upstream block in conf.d/carlos-emr-limits.conf)
         # rather than the address literal: backend keepalive only works
@@ -184,15 +192,22 @@ server {
     # The SOAP LoginService and the OAuth 1.0a request-token endpoint are
     # unauthenticated credential/token surfaces by necessity (a client posts
     # credentials to obtain a token), so they are the machine-facing equivalent
-    # of the human login route and get the same per-address request-rate and
-    # connection ceilings. Scoped to these two exact routes only — the rest of
-    # /ws is ordinary authenticated API traffic and must not be throttled. The
-    # optional context-segment matrix param is tolerated as on the login route,
-    # and `\b` stops the match at the route name (no /ws/LoginServiceFoo).
-    location ~* "^/carlos(;[^/]*)?/ws/(LoginService|oauth/initiate)\b" {
-        limit_req zone=carlos_login burst=20 nodelay;
+    # of the human login route and get a per-address request-rate and connection
+    # ceiling. Scoped to these two routes only — the rest of /ws is ordinary
+    # authenticated API traffic and must not be throttled.
+    #
+    # A SEPARATE request zone (carlos_wsauth) from the human login route: a
+    # legitimate server-to-server integration and a clinic's browsers often
+    # egress the same public IP, and a shared budget would let bursty API token
+    # calls 429 human logins (and vice-versa). `\b` stops the match at the route
+    # name (no /ws/LoginServiceFoo); `(;[^/]*)?` after each interior segment
+    # covers the matrix-parameter bypass Tomcat's per-segment stripping enables
+    # (/carlos/ws;x/LoginService, /carlos/ws/oauth;x/initiate).
+    location ~* "^/carlos(;[^/]*)?/ws(;[^/]*)?/(LoginService|oauth(;[^/]*)?/initiate)\b" {
+        limit_req zone=carlos_wsauth burst=20 nodelay;
         limit_req_status 429;
         limit_conn carlos_login_conn 12;
+        limit_conn_status 429;
         include /etc/nginx/snippets/carlos-emr-headers.conf;
         proxy_pass http://carlos_backend;
         include /etc/carlos-emr/nginx/proxy-params.conf;
@@ -203,8 +218,9 @@ server {
     # route to it — a local monitor reaches it directly on 127.0.0.1:18080. The
     # in-app LoopbackOnlyInInterceptor enforces the same thing, so neither gate
     # is load-bearing on its own (the DrugRef pattern). `\b` stops the match at
-    # the route name; the optional context matrix param is covered as elsewhere.
-    location ~* "^/carlos(;[^/]*)?/ws/SystemInfoService\b" {
+    # the route name; `(;[^/]*)?` after each interior segment covers matrix-param
+    # variants (/carlos/ws;x/SystemInfoService) that Tomcat would still route.
+    location ~* "^/carlos(;[^/]*)?/ws(;[^/]*)?/SystemInfoService\b" {
         return 404;
     }
 

--- a/debian/assets/nginx/conf.d/carlos-emr-limits.conf
+++ b/debian/assets/nginx/conf.d/carlos-emr-limits.conf
@@ -9,6 +9,12 @@
 # of the EMR is a chatty AJAX application and must not be rate limited.
 limit_req_zone $binary_remote_addr zone=carlos_login:10m rate=10r/s;
 
+# Separate request budget for the machine-facing credential endpoints
+# (/carlos/ws/LoginService, /carlos/ws/oauth/initiate). Kept distinct from the
+# human login zone so a bursty server-to-server integration and the clinic's
+# browsers — which often share one NAT egress IP — cannot 429 each other.
+limit_req_zone $binary_remote_addr zone=carlos_wsauth:10m rate=10r/s;
+
 # Concurrent-connection ceiling for the credential routes only (login, forced
 # reset, MFA submit). With proxy_request_buffering off a slow-drip POST pins a
 # Tomcat worker thread; this bounds how many one address can hold on the auth

--- a/debian/assets/nginx/conf.d/carlos-emr-limits.conf
+++ b/debian/assets/nginx/conf.d/carlos-emr-limits.conf
@@ -15,14 +15,25 @@ limit_req_zone $binary_remote_addr zone=carlos_login:10m rate=10r/s;
 # browsers — which often share one NAT egress IP — cannot 429 each other.
 limit_req_zone $binary_remote_addr zone=carlos_wsauth:10m rate=10r/s;
 
-# Concurrent-connection ceiling for the credential routes only (login, forced
-# reset, MFA submit). With proxy_request_buffering off a slow-drip POST pins a
-# Tomcat worker thread; this bounds how many one address can hold on the auth
-# routes. It is deliberately NOT applied to the rest of the app: a whole clinic
-# behind one NAT address legitimately holds many concurrent connections, so a
-# shared per-address connection budget there would be a waiting room that cannot
-# open the EMR — the same reason the request-rate zone above is login-scoped.
+# Concurrent-connection ceilings for the credential routes only. With
+# proxy_request_buffering off a slow-drip POST pins a Tomcat worker thread; these
+# bound how many one address can hold on the auth routes. They are deliberately
+# NOT applied to the rest of the app: a whole clinic behind one NAT address
+# legitimately holds many concurrent connections, so a shared per-address
+# connection budget there would be a waiting room that cannot open the EMR — the
+# same reason the request-rate zones above are credential-scoped.
+#
+# Human and machine credential routes get SEPARATE connection zones for the same
+# reason they get separate request zones: they commonly share one NAT egress IP,
+# and 12 slow /ws token posts must not be able to lock clinicians out of /login.
 limit_conn_zone $binary_remote_addr zone=carlos_login_conn:10m;
+limit_conn_zone $binary_remote_addr zone=carlos_wsauth_conn:10m;
+
+# NOTE: every zone here keys on $binary_remote_addr, i.e. the TCP peer. That is
+# correct ONLY while nginx is the internet-facing listener, which is this
+# package's premise. Front this with a CDN or an L7 load balancer without
+# configuring set_real_ip_from/real_ip_header and every zone collapses into a
+# single shared bucket for all clients — the limits silently stop working.
 
 # Tomcat is one hop away on loopback and nginx is the only client, so the
 # default 8k proxy header buffer is generous — but CARLOS sets several large

--- a/debian/assets/nginx/conf.d/carlos-emr-limits.conf
+++ b/debian/assets/nginx/conf.d/carlos-emr-limits.conf
@@ -9,6 +9,15 @@
 # of the EMR is a chatty AJAX application and must not be rate limited.
 limit_req_zone $binary_remote_addr zone=carlos_login:10m rate=10r/s;
 
+# Concurrent-connection ceiling for the credential routes only (login, forced
+# reset, MFA submit). With proxy_request_buffering off a slow-drip POST pins a
+# Tomcat worker thread; this bounds how many one address can hold on the auth
+# routes. It is deliberately NOT applied to the rest of the app: a whole clinic
+# behind one NAT address legitimately holds many concurrent connections, so a
+# shared per-address connection budget there would be a waiting room that cannot
+# open the EMR — the same reason the request-rate zone above is login-scoped.
+limit_conn_zone $binary_remote_addr zone=carlos_login_conn:10m;
+
 # Tomcat is one hop away on loopback and nginx is the only client, so the
 # default 8k proxy header buffer is generous — but CARLOS sets several large
 # cookies and a long referrer on e-chart pages, and a header overflow shows up

--- a/debian/carlos-ctl.8
+++ b/debian/carlos-ctl.8
@@ -28,7 +28,17 @@ that the services are running, that no component is running as root, that
 Tomcat and MariaDB listen on loopback only, that the certificate is valid, that
 the security response headers are served, that the WAF blocks a probe
 SQL\-injection request, that DrugRef is not reachable through the front door,
+that the web\-service surface is gated (the CXF service catalog is hidden and an
+unauthenticated SOAP call is refused), that a dot\-segment path\-normalisation
+bypass is rejected, that the application unit is enabled as well as running,
 that the schema has a Flyway history, and that backups are fresh. Start here.
+.IP
+A web\-service line reported as
+.B NOTE
+rather than
+.B OK
+means the probe could not reach the application to prove the invariant (a WAF
+block, a redirect, or a restart in progress), not that a check failed.
 .TP
 .B status
 Systemd status of the EMR, nginx, MariaDB and the package's timers.

--- a/debian/carlos-emr.postinst
+++ b/debian/carlos-emr.postinst
@@ -20,6 +20,14 @@ ENV_FILE="${CONF_DIR}/carlos-emr.env"
 PROPERTIES="${CONF_DIR}/carlos.properties"
 BACKUP_ENV="${CONF_DIR}/backup.env"
 STATE=/var/lib/carlos-emr
+# Durable marker that the seeded (source-published) administrator credential is
+# still live because `carlos-ctl bootstrap-admin` could not replace it. While it
+# exists the service unit is kept disabled, and no path in this package may start
+# the EMR: a shell variable would not survive the run, and the exposure has to
+# outlast it (a reboot, or an aborted apt transaction, would otherwise bring the
+# internet-facing EMR up with a password published in the source repository).
+# Cleared automatically by the next successful bootstrap-admin.
+SEED_SENTINEL="${STATE}/.seed-credential-live"
 
 # deb-systemd-invoke rather than systemctl: it honours /usr/sbin/policy-rc.d,
 # which is how an image build or a chroot says "configure this package but do
@@ -582,6 +590,11 @@ case "$1" in
         # failed deployments (the app's boot-time validate gate refuses a
         # schema behind the WAR — by design).
         MIGRATION_OK=1
+        # Initialised for the same reason MIGRATION_OK is: dpkg passes the
+        # invoking environment straight through to maintainer scripts, so an
+        # inherited variable of this name would otherwise disable the unit on a
+        # perfectly healthy install.
+        SEED_CREDENTIAL_LIVE=0
         if mariadb --protocol=socket --user=root -e 'SELECT 1' >/dev/null 2>&1; then
             # mariadb-server was already running when this package's drop-in
             # was unpacked, so it is still on distribution defaults — STRICT
@@ -636,12 +649,37 @@ case "$1" in
                 # published credential. SEED_CREDENTIAL_LIVE makes the trailing
                 # block DISABLE the unit so it cannot auto-start until an
                 # operator replaces the credential and re-enables it.
-                if ! carlos-ctl bootstrap-admin; then
+                if carlos-ctl bootstrap-admin; then
+                    # Self-heal: if an earlier run disabled the unit because the
+                    # seeded credential was live, that condition is now cleared,
+                    # so undo it here. Without this the operator is permanently
+                    # on the hook for a manual `systemctl enable` — and the very
+                    # next configure would happily START the service while it
+                    # stayed disabled, so the EMR would silently fail to come
+                    # back at the following reboot.
+                    if [ -e "${SEED_SENTINEL}" ]; then
+                        rm -f "${SEED_SENTINEL}"
+                        deb-systemd-helper enable carlos-emr.service >/dev/null 2>&1 || true
+                        echo "carlos-emr: the seeded administrator credential has been replaced; the" >&2
+                        echo "carlos-emr: service unit has been re-enabled." >&2
+                    fi
+                elif [ "${MIGRATION_OK}" = 1 ]; then
+                    # Only treat this as "the published credential is live" when
+                    # the database and schema steps above SUCCEEDED. bootstrap-admin
+                    # also exits non-zero for environmental reasons (MariaDB
+                    # unreachable, schema not migrated); disabling the unit on
+                    # those would take a healthy production clinic offline over a
+                    # transient database problem, on a site that replaced the
+                    # seeded credential years ago.
                     MIGRATION_OK=0
                     SEED_CREDENTIAL_LIVE=1
                     echo "carlos-emr: the seeded 'carlosdoc' password could NOT be replaced — the" >&2
                     echo "carlos-emr: account still carries the credential PUBLISHED in the CARLOS" >&2
-                    echo "carlos-emr: source repository (see the disable notice at the end of setup)." >&2
+                    echo "carlos-emr: source repository (see the notice at the end of setup)." >&2
+                else
+                    echo "carlos-emr: 'carlos-ctl bootstrap-admin' also failed, but the database or" >&2
+                    echo "carlos-emr: schema step above failed first — fix that, then re-run:" >&2
+                    echo "carlos-emr:   sudo carlos-ctl db-migrate && sudo carlos-ctl bootstrap-admin" >&2
                 fi
             else
                 echo "carlos-emr: WARNING: the seeded 'carlosdoc' account keeps the password" >&2
@@ -751,8 +789,20 @@ case "$1" in
         # branch, nothing would ever start them again — a failed upgrade of
         # an unrelated package in the same transaction left the EMR down.
         # Best-effort, never failing the abort path itself.
+        #
+        # The APPLICATION start is skipped while the seed-credential sentinel
+        # exists: `systemctl start` works perfectly well on a disabled unit, so
+        # without this guard any later aborted apt transaction — including one
+        # caused by an unrelated package — would undo the fail-closed and bring
+        # the EMR up with the source-published administrator password live. The
+        # timers carry no such exposure and are always restored.
         if [ -d /run/systemd/system ]; then
-            deb-systemd-invoke start carlos-emr.service >/dev/null 2>&1 || true
+            if [ -e "${SEED_SENTINEL}" ]; then
+                echo "carlos-emr: not restarting the application — the seeded administrator" >&2
+                echo "carlos-emr: credential is still live (run 'carlos-ctl bootstrap-admin')." >&2
+            else
+                deb-systemd-invoke start carlos-emr.service >/dev/null 2>&1 || true
+            fi
             deb-systemd-invoke start carlos-emr-backup.timer carlos-emr-backup-verify.timer \
                 carlos-emr-cert-renew.timer >/dev/null 2>&1 || true
         fi
@@ -764,6 +814,39 @@ case "$1" in
 esac
 
 #DEBHELPER#
+
+# Durable fail-closed for a live seeded credential. Deliberately NOT gated on
+# /run/systemd/system: the enable/disable state is symlinks under /etc, which
+# deb-systemd-helper maintains with or without a running systemd, and the golden
+# -image / chroot build path is exactly where an undisabled unit would ship an
+# internet-facing EMR carrying the source-published administrator password.
+if [ "$1" = configure ] && [ "${SEED_CREDENTIAL_LIVE:-0}" = 1 ]; then
+    mkdir -p "${STATE}" 2>/dev/null || true
+    : > "${SEED_SENTINEL}" 2>/dev/null || true
+    chmod 0600 "${SEED_SENTINEL}" 2>/dev/null || true
+    deb-systemd-helper disable carlos-emr.service >/dev/null 2>&1 || true
+    # disable does not touch runtime state and has no --now, so stop separately.
+    # Through sd_invoke, which honours policy-rc.d (a stop is a runtime action;
+    # the disable above deliberately is not). Without this a dpkg-reconfigure
+    # leaves the JVM serving with the credential live while the notice claims
+    # the service is not running.
+    sd_invoke stop carlos-emr.service >/dev/null 2>&1 || true
+    # VERIFY rather than assert: this is the one invariant the whole branch
+    # exists to establish, and a silent failure here means the operator believes
+    # a reboot is safe when it is not.
+    if [ -d /run/systemd/system ] && systemctl is-enabled --quiet carlos-emr.service 2>/dev/null; then
+        echo "carlos-emr: *** COULD NOT DISABLE carlos-emr.service ***" >&2
+        echo "carlos-emr: the seeded 'carlosdoc' credential (published in the CARLOS source" >&2
+        echo "carlos-emr: repository) is still live AND the unit will start at the next boot." >&2
+        echo "carlos-emr: run this NOW:  sudo systemctl disable --now carlos-emr" >&2
+    else
+        echo "carlos-emr: the service has been STOPPED and DISABLED: the seeded 'carlosdoc'" >&2
+        echo "carlos-emr: credential (published in the CARLOS source repository) could not be" >&2
+        echo "carlos-emr: replaced, so the EMR must not come up with it live — including on a" >&2
+        echo "carlos-emr: reboot. Replace the credential and the unit is re-enabled for you:" >&2
+        echo "carlos-emr:   sudo carlos-ctl bootstrap-admin && sudo systemctl start carlos-emr" >&2
+    fi
+fi
 
 # Everything below runs AFTER the debhelper snippets, so the units exist and
 # are enabled by the time we start them.
@@ -778,19 +861,9 @@ if [ "$1" = configure ] && [ -d /run/systemd/system ]; then
     # renderer's postinst already does). Best-effort; never fail configure.
     systemctl --system daemon-reload >/dev/null 2>&1 || true
     if [ "${SEED_CREDENTIAL_LIVE:-0}" = 1 ]; then
-        # Durable fail-closed: the seeded 'carlosdoc' credential could not be
-        # replaced, and the schema is valid, so a plain "don't start now" would
-        # evaporate on the next boot. DISABLE the unit so it cannot auto-start
-        # until an operator replaces the credential and re-enables it. This only
-        # runs on the bootstrap-admin failure path, so it never touches a
-        # healthy install. Best-effort; never fail configure.
-        deb-systemd-helper disable carlos-emr.service >/dev/null 2>&1 \
-            || systemctl disable carlos-emr.service >/dev/null 2>&1 || true
-        echo "carlos-emr: the service is DISABLED and was NOT started: the seeded 'carlosdoc'" >&2
-        echo "carlos-emr: credential (published in the CARLOS source repository) could not be" >&2
-        echo "carlos-emr: replaced, so the EMR must not come up with it live — including on a" >&2
-        echo "carlos-emr: reboot. Replace the credential, then enable and start:" >&2
-        echo "carlos-emr:   sudo carlos-ctl bootstrap-admin && sudo systemctl enable --now carlos-emr" >&2
+        # Already stopped, disabled and reported by the block above; the only
+        # thing left to do here is NOT start the service.
+        :
     elif [ "${MIGRATION_OK:-1}" = 0 ]; then
         echo "carlos-emr: NOT starting the service — the schema is not ready (see above)." >&2
         echo "carlos-emr: the unit stays enabled; it will start on the next boot or when you" >&2

--- a/debian/carlos-emr.postinst
+++ b/debian/carlos-emr.postinst
@@ -622,12 +622,23 @@ case "$1" in
                 echo "carlos-emr:   sudo carlos-ctl db-migrate && sudo systemctl start carlos-emr" >&2
             fi
             if [ "${RESET_ADMIN}" = true ]; then
-                carlos-ctl bootstrap-admin || {
-                    echo "carlos-emr: WARNING: could not replace the seeded 'carlosdoc' password —" >&2
-                    echo "carlos-emr: the account still has the credential PUBLISHED in the CARLOS" >&2
-                    echo "carlos-emr: source repository. Run 'carlos-ctl bootstrap-admin' before" >&2
-                    echo "carlos-emr: putting patient data on this system." >&2
-                }
+                # Fail CLOSED. If the seeded 'carlosdoc' credential cannot be
+                # replaced we must NOT start the service: the account still
+                # carries the password PUBLISHED in the CARLOS source
+                # repository, and bringing up an internet-facing EMR with a
+                # known administrator login (the force-reset flag does not help
+                # — an attacker who knows the old password completes the reset)
+                # is exactly the exposure this step exists to prevent. Treat it
+                # like a failed migration (see above): MIGRATION_OK=0 keeps the
+                # unit stopped-but-enabled until the operator fixes the cause.
+                if ! carlos-ctl bootstrap-admin; then
+                    MIGRATION_OK=0
+                    echo "carlos-emr: the seeded 'carlosdoc' password could NOT be replaced. The" >&2
+                    echo "carlos-emr: service will NOT be started, so the EMR is never exposed with" >&2
+                    echo "carlos-emr: the credential PUBLISHED in the CARLOS source repository." >&2
+                    echo "carlos-emr: fix the cause, then:" >&2
+                    echo "carlos-emr:   sudo carlos-ctl bootstrap-admin && sudo systemctl start carlos-emr" >&2
+                fi
             else
                 echo "carlos-emr: WARNING: the seeded 'carlosdoc' account keeps the password" >&2
                 echo "carlos-emr: published in the CARLOS source repository. Do not put patient" >&2

--- a/debian/carlos-emr.postinst
+++ b/debian/carlos-emr.postinst
@@ -628,16 +628,20 @@ case "$1" in
                 # repository, and bringing up an internet-facing EMR with a
                 # known administrator login (the force-reset flag does not help
                 # — an attacker who knows the old password completes the reset)
-                # is exactly the exposure this step exists to prevent. Treat it
-                # like a failed migration (see above): MIGRATION_OK=0 keeps the
-                # unit stopped-but-enabled until the operator fixes the cause.
+                # is exactly the exposure this step exists to prevent. Unlike a
+                # failed migration — which the application's own schema gate
+                # refuses on every boot — a live seed credential sits over a
+                # VALID schema, so merely declining to start THIS run would still
+                # let a reboot bring the internet-facing EMR up with the
+                # published credential. SEED_CREDENTIAL_LIVE makes the trailing
+                # block DISABLE the unit so it cannot auto-start until an
+                # operator replaces the credential and re-enables it.
                 if ! carlos-ctl bootstrap-admin; then
                     MIGRATION_OK=0
-                    echo "carlos-emr: the seeded 'carlosdoc' password could NOT be replaced. The" >&2
-                    echo "carlos-emr: service will NOT be started, so the EMR is never exposed with" >&2
-                    echo "carlos-emr: the credential PUBLISHED in the CARLOS source repository." >&2
-                    echo "carlos-emr: fix the cause, then:" >&2
-                    echo "carlos-emr:   sudo carlos-ctl bootstrap-admin && sudo systemctl start carlos-emr" >&2
+                    SEED_CREDENTIAL_LIVE=1
+                    echo "carlos-emr: the seeded 'carlosdoc' password could NOT be replaced — the" >&2
+                    echo "carlos-emr: account still carries the credential PUBLISHED in the CARLOS" >&2
+                    echo "carlos-emr: source repository (see the disable notice at the end of setup)." >&2
                 fi
             else
                 echo "carlos-emr: WARNING: the seeded 'carlosdoc' account keeps the password" >&2
@@ -773,7 +777,21 @@ if [ "$1" = configure ] && [ -d /run/systemd/system ]; then
     # deb-systemd-invoke has no reload verb, so call systemctl directly (as the
     # renderer's postinst already does). Best-effort; never fail configure.
     systemctl --system daemon-reload >/dev/null 2>&1 || true
-    if [ "${MIGRATION_OK:-1}" = 0 ]; then
+    if [ "${SEED_CREDENTIAL_LIVE:-0}" = 1 ]; then
+        # Durable fail-closed: the seeded 'carlosdoc' credential could not be
+        # replaced, and the schema is valid, so a plain "don't start now" would
+        # evaporate on the next boot. DISABLE the unit so it cannot auto-start
+        # until an operator replaces the credential and re-enables it. This only
+        # runs on the bootstrap-admin failure path, so it never touches a
+        # healthy install. Best-effort; never fail configure.
+        deb-systemd-helper disable carlos-emr.service >/dev/null 2>&1 \
+            || systemctl disable carlos-emr.service >/dev/null 2>&1 || true
+        echo "carlos-emr: the service is DISABLED and was NOT started: the seeded 'carlosdoc'" >&2
+        echo "carlos-emr: credential (published in the CARLOS source repository) could not be" >&2
+        echo "carlos-emr: replaced, so the EMR must not come up with it live — including on a" >&2
+        echo "carlos-emr: reboot. Replace the credential, then enable and start:" >&2
+        echo "carlos-emr:   sudo carlos-ctl bootstrap-admin && sudo systemctl enable --now carlos-emr" >&2
+    elif [ "${MIGRATION_OK:-1}" = 0 ]; then
         echo "carlos-emr: NOT starting the service — the schema is not ready (see above)." >&2
         echo "carlos-emr: the unit stays enabled; it will start on the next boot or when you" >&2
         echo "carlos-emr: start it after completing the migration." >&2

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -3,7 +3,14 @@
 # release build: a branch name makes two builds weeks apart ship different
 # code under one package version.
 #
-# The current pin is the master merge commit of the EntityManager-leak fix
-# (carlos-emr/drugref2026#8): without it, drug searches exhaust the JDBC pool
+# The current pin is the master merge commit of the pre-release security
+# hardening (carlos-emr/drugref2026#10). It must not be moved back below this
+# revision: earlier DrugRef builds ship the bundled `root` superuser credential
+# with a password published in that source tree, browser JSPs that run a
+# destructive database re-import on an unauthenticated GET and reflect a request
+# parameter unencoded, and JPQL built by string concatenation — including an
+# unquoted numeric-context injection reachable from the unauthenticated XML-RPC
+# surface. It also carries the earlier EntityManager-leak fix
+# (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=e1d867a9a6f13cd321218fe3510de20c2e7ad61c
+ref=566a46eec559a0ba02f40afbc37ff14440bbc098

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -166,8 +166,9 @@ follow [`docs/ui-tests/deb-install-validation.md`](ui-tests/deb-install-validati
 ## Quickstart — the first hour
 
 **1. Verify the deployment.** One command probes the whole system — services,
-process ownership, network exposure, TLS, live WAF blocking, a live DrugRef
-lookup, schema state, and backup freshness:
+process ownership, network exposure, TLS, live WAF blocking, the web-service
+gates (hidden CXF catalog, an unauthenticated SOAP call refused, a dot-segment
+path bypass rejected), a live DrugRef lookup, schema state, and backup freshness:
 
 ```bash
 sudo carlos-ctl check
@@ -335,6 +336,7 @@ sudo carlos-ctl check
 | Certificate warning in the browser | `sudo carlos-ctl cert status` | Expected with the default self-signed certificate — the connection is still encrypted; switch with `sudo carlos-ctl cert acme <email>` |
 | "502 Bad Gateway" or a long spinner right after install/restart | `sudo carlos-ctl logs -f` | The webapp takes about two minutes to deploy; if it never comes up, the log says why |
 | Login rejected with the seeded credentials | `sudo cat /etc/carlos-emr/initial-admin.txt` | Using the repository's published dev password instead of the generated one. Also: the PIN must be exactly four digits — a longer PIN fails with a message blaming the *password* |
+| Install finished but the EMR is stopped, and `carlos-ctl check` says the unit is DISABLED | `sudo carlos-ctl check`, then `sudo carlos-ctl bootstrap-admin` | The installer could not replace the seeded `carlosdoc` credential (published in the source repository), so it stopped and disabled the service rather than expose the EMR with a known administrator password. It stays disabled across reboots on purpose. A successful `bootstrap-admin` re-enables the unit automatically; then `sudo systemctl start carlos-emr` |
 | A specific page or action fails, but nothing in the application log | `sudo carlos-ctl waf tail` | The WAF blocked the request before it reached the application — the tail explains which rule and why |
 | eForm print/fax produces no PDF, application log silent | `sudo journalctl -u carlos-emr-chromedriver -n 50` | The render browser is its own service with its own journal; if it cannot start, eForm rendering fails by design |
 | Drug search returns nothing when prescribing | `sudo carlos-ctl check` (DrugRef probe) | `carlos-emr-drugref` not installed, or its service is down |

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/LoopbackOnlyInInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/LoopbackOnlyInInterceptor.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.apache.logging.log4j.Logger;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import io.github.carlos_emr.carlos.utility.MiscUtils;
+
+/**
+ * Restricts a web-service endpoint to callers on the host loopback address.
+ *
+ * <p>Used to keep the unauthenticated {@code SystemInfoService} liveness endpoint
+ * reachable by a local health check while refusing every off-host client — a
+ * liveness probe cannot present a WS-Security token, so gating the endpoint on
+ * authentication would break the very use it exists for. Restricting it to the
+ * host itself removes the anonymous reconnaissance surface while preserving local
+ * monitoring.
+ *
+ * <p>The Host-level {@code RemoteIpValve} runs before this interceptor and has
+ * already replaced the peer address with the real client address from
+ * {@code X-Forwarded-For}. A request that arrived through nginx therefore presents
+ * the browser's public address here and is refused, while a local process calling
+ * Tomcat directly on 127.0.0.1 presents the loopback address and is allowed. This
+ * backs up the nginx rule that 404s the endpoint at the edge, so — as with
+ * DrugRef — neither gate is load-bearing on its own.
+ */
+public class LoopbackOnlyInInterceptor extends AbstractPhaseInterceptor<Message> {
+
+    private static final Logger logger = MiscUtils.getLogger();
+
+    public LoopbackOnlyInInterceptor() {
+        // RECEIVE is the earliest phase: reject an off-host caller before the
+        // message body is read or unmarshalled.
+        super(Phase.RECEIVE);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        HttpServletRequest request = (HttpServletRequest) message.get(AbstractHTTPDestination.HTTP_REQUEST);
+        if (request == null) {
+            // Outbound message (there is no servlet request); nothing to gate.
+            return;
+        }
+        if (isLoopback(request.getRemoteAddr())) {
+            return;
+        }
+        logger.warn("Refused off-host request to a loopback-only web service from " + request.getRemoteAddr());
+        throw new Fault(new SecurityException("loopback-only endpoint"));
+    }
+
+    /**
+     * @param ip the {@code RemoteIpValve}-resolved client address
+     * @return true when the address is an IPv4 or IPv6 host loopback address
+     */
+    private static boolean isLoopback(String ip) {
+        if (ip == null) {
+            return false;
+        }
+        return ip.startsWith("127.")
+                || "::1".equals(ip)
+                || "0:0:0:0:0:0:0:1".equals(ip)
+                || ip.startsWith("::ffff:127.");
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/LoopbackOnlyInInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/LoopbackOnlyInInterceptor.java
@@ -70,7 +70,7 @@ public class LoopbackOnlyInInterceptor extends AbstractPhaseInterceptor<Message>
         if (isLoopback(request.getRemoteAddr())) {
             return;
         }
-        logger.warn("Refused off-host request to a loopback-only web service from " + request.getRemoteAddr());
+        logger.warn("Refused off-host request to a loopback-only web service from {}", request.getRemoteAddr());
         throw new Fault(new SecurityException("loopback-only endpoint"));
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/LoopbackOnlyInInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/LoopbackOnlyInInterceptor.java
@@ -29,6 +29,7 @@ import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.logging.log4j.Logger;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
@@ -71,7 +72,13 @@ public class LoopbackOnlyInInterceptor extends AbstractPhaseInterceptor<Message>
             return;
         }
         logger.warn("Refused off-host request to a loopback-only web service from {}", request.getRemoteAddr());
-        throw new Fault(new SecurityException("loopback-only endpoint"));
+        // Set the status explicitly: org.apache.cxf.interceptor.Fault defaults to
+        // 500, which reads as an outage in monitoring rather than a deliberate
+        // refusal. 403 says what actually happened, matching the deliberate
+        // status mapping in AuthenticationInWSS4JInterceptor.
+        Fault fault = new Fault(new SecurityException("loopback-only endpoint"));
+        fault.setStatusCode(HttpServletResponse.SC_FORBIDDEN);
+        throw fault;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/AuthenticationInInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/AuthenticationInInterceptor.java
@@ -43,7 +43,6 @@ import io.github.carlos_emr.carlos.commn.model.OscarLog;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import io.github.carlos_emr.carlos.log.LogAction;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class AuthenticationInInterceptor extends AbstractPhaseInterceptor<Message> {
 
@@ -56,17 +55,11 @@ public class AuthenticationInInterceptor extends AbstractPhaseInterceptor<Messag
         return LoggedInInfo.getLoggedInInfoFromSession(request);
     }
 
-    // FindSecBugs IMPROPER_UNICODE: case-fold in a trust path; locale-safe hardening tracked in #2496. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-fold in a trust path; locale-safe hardening tracked in #2496")
     @Override
     public void handleMessage(Message message) throws Fault {
-        // allows WADL requests for unauthenticated users
-        String messageQueryString = String.valueOf(message.get(Message.QUERY_STRING));
-        boolean isServiceRequest = "_wadl".equalsIgnoreCase(messageQueryString);
-        if (isServiceRequest) {
-            return;
-        }
-
+        // WADL / service metadata is NOT exempt from authentication. Serving it
+        // to anonymous callers enumerates every REST resource and its paths;
+        // an authenticated client still receives it through the check below.
         LoggedInInfo info = getLoggedInInfo(message);
         boolean isAuthenticated = info != null && (info.getLoggedInProvider() != null || info.getLoggedInSecurity() != null);
         if (isAuthenticated) {

--- a/src/main/resources/spring_ws.xml
+++ b/src/main/resources/spring_ws.xml
@@ -89,8 +89,19 @@
 	</bean>
 
 	<!-- www service endpoints -->
-	<jaxws:endpoint implementor="#systemInfoWs" address="/SystemInfoService"/>		
-	<jaxws:endpoint implementor="#loginWs" address="/LoginService" />	
+	<!-- SystemInfoService is gated like every other data service. It previously
+	     ran with no interceptor, so an unauthenticated caller could read server
+	     time, timezone, liveness and an internal paging constant. Anonymous
+	     liveness is available at the nginx front door (GET /carlos/). -->
+	<jaxws:endpoint implementor="#systemInfoWs" address="/SystemInfoService">
+		<jaxws:inInterceptors>
+			<ref bean="authenticationInWSS4JInterceptor"/>
+		</jaxws:inInterceptors>
+	</jaxws:endpoint>
+	<!-- LoginService MUST stay unauthenticated: it is how SOAP clients obtain a
+	     security token. Its brute-force exposure is bounded by the front-door
+	     rate limit on /carlos/ws/LoginService (see debian nginx config). -->
+	<jaxws:endpoint implementor="#loginWs" address="/LoginService" />
 	
 	<jaxws:endpoint implementor="#scheduleWs" address="/ScheduleService">
 		<jaxws:inInterceptors>

--- a/src/main/resources/spring_ws.xml
+++ b/src/main/resources/spring_ws.xml
@@ -81,6 +81,7 @@
 	
 	<bean id="authenticationInWSS4JInterceptor" class="io.github.carlos_emr.carlos.webserv.AuthenticationInWSS4JInterceptor" autowire="byType" />
 	<bean id="oscarUsernameTokenValidator" class="io.github.carlos_emr.carlos.webserv.OscarUsernameTokenValidator" autowire="byType" />
+	<bean id="loopbackOnlyInInterceptor" class="io.github.carlos_emr.carlos.webserv.LoopbackOnlyInInterceptor" />
 
 	<!-- HTTP policy for lab upload service to handle long-running batch operations -->
 	<bean id="labUploadHttpServerPolicy" class="org.apache.cxf.transports.http.configuration.HTTPServerPolicy">
@@ -89,13 +90,18 @@
 	</bean>
 
 	<!-- www service endpoints -->
-	<!-- SystemInfoService is gated like every other data service. It previously
-	     ran with no interceptor, so an unauthenticated caller could read server
-	     time, timezone, liveness and an internal paging constant. Anonymous
-	     liveness is available at the nginx front door (GET /carlos/). -->
+	<!-- SystemInfoService is a liveness / system-info endpoint. It previously ran
+	     with no interceptor, so an unauthenticated off-host caller could read
+	     server time, timezone, liveness and an internal paging constant.
+	     Authentication is the wrong gate here (a liveness probe cannot present a
+	     WS-Security token), so it is restricted to the host loopback address: a
+	     local monitor calling Tomcat directly is allowed, any client arriving
+	     through nginx (which presents the real client IP via RemoteIpValve) is
+	     refused. The debian nginx config also 404s this path at the edge, so
+	     neither gate is load-bearing on its own. -->
 	<jaxws:endpoint implementor="#systemInfoWs" address="/SystemInfoService">
 		<jaxws:inInterceptors>
-			<ref bean="authenticationInWSS4JInterceptor"/>
+			<ref bean="loopbackOnlyInInterceptor"/>
 		</jaxws:inInterceptors>
 	</jaxws:endpoint>
 	<!-- LoginService MUST stay unauthenticated: it is how SOAP clients obtain a

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -387,10 +387,14 @@
 		<!-- Do not serve CXF's HTML service-list catalog. /ws/** is exempt from
 		     the login filter (each service authenticates itself via OAuth 1.0a /
 		     WS-Security), so without this an unauthenticated client could GET
-		     /carlos/ws (or /ws/services, /ws/rs) and enumerate every SOAP/REST
-		     endpoint with live ?wsdl links — free reconnaissance in front of the
-		     authenticated data services. The services stay behind their own auth
-		     interceptors regardless; this removes the catalog page. -->
+		     /carlos/ws/ and enumerate every SOAP/REST endpoint in one request.
+		     This removes the INDEX only. It does NOT close per-service metadata:
+		     WSDLGetInterceptor runs at Phase.READ and WSS4JInInterceptor returns
+		     early for every GET, so `GET /carlos/ws/<Service>?wsdl` is still
+		     answered without authentication for anyone who knows (or guesses) a
+		     service name. Closing that needs the WSDL GET support itself to be
+		     removed or gated per endpoint, which would break clients that fetch
+		     their contract at runtime — deliberately not done here. -->
 		<init-param>
 			<param-name>hide-service-list-page</param-name>
 			<param-value>true</param-value>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -384,6 +384,17 @@
 	<servlet>
 		<servlet-name>CXFServlet</servlet-name>
 		<servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
+		<!-- Do not serve CXF's HTML service-list catalog. /ws/** is exempt from
+		     the login filter (each service authenticates itself via OAuth 1.0a /
+		     WS-Security), so without this an unauthenticated client could GET
+		     /carlos/ws (or /ws/services, /ws/rs) and enumerate every SOAP/REST
+		     endpoint with live ?wsdl links — free reconnaissance in front of the
+		     authenticated data services. The services stay behind their own auth
+		     interceptors regardless; this removes the catalog page. -->
+		<init-param>
+			<param-name>hide-service-list-page</param-name>
+			<param-value>true</param-value>
+		</init-param>
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>CXFServlet</servlet-name>


### PR DESCRIPTION
## Description

Pre-release security hardening of the **Debian deployment's unauthenticated remote attack surface**. Audits found **no critical remote unauth RCE/auth-bypass/XXE/SSRF** — the perimeter (blocking WAF, loopback-only Tomcat, double-gated DrugRef, hardened systemd unit) is well-built — but several issues *were* reachable by someone not logged in. All are fixed here.

### ✅ DrugRef pin — resolved

This PR previously carried a merge-order warning: `debian/rules` builds `carlos-emr-drugref` from the SHA in `debian/drugref.pin`, so the companion hardening in **carlos-emr/drugref2026#10** would not have shipped while the old pin stood. That PR is now **merged**, and the pin has been bumped to its master merge commit `566a46ee`. Verified before pinning: the non-privileged DB placeholders are in place, no JSPs remain under `src/main/webapp`, the concatenated category predicate is parameterized, and `yessum` appears nowhere in `src/`. No further action needed at merge time.

### High — reachable without authentication

- **Login/credential rate-limit bypass, twice over.** The throttle was escaped first by a matrix parameter on the context segment (`/carlos;x/login`), then — after the first fix — by a matrix param on any *interior* segment (`/carlos/mfa;x/loginMfa`). Root cause: nginx and Tomcat normalise in **different orders** (nginx resolves `.`/`..` before matching; Tomcat strips `;`-params *first*), so a dot segment wearing a matrix param (`/carlos/.;x/login`, `/carlos/..;x/drugref2/…`) is invisible to every path-scoped rule yet still routes to the servlet. Closed as a *class* with a normalisation guard, not by enumerating segments. Measured before/after against a running nginx.
- **Seeded admin credential could go live.** A failed `carlos-ctl bootstrap-admin` was swallowed while the service still started, exposing the published `carlosdoc`/`carlos2026` login. Now fails closed durably — and safely: the condition is narrowed so a transient DB fault can't disable a healthy clinic's EMR, the unit re-enables itself on the next successful bootstrap, the abort-upgrade path can't undo it, and the disable is verified rather than asserted.

### Medium

- **Three CRS exclusion/allow-list evasions**: the CSRF exclusion targeted `OWASP_CSRFTOKEN` (CSRFGuard's *SessionKey*, never on the wire) instead of the configured `CSRF-TOKEN`, leaving a rule-free parameter name; the JSESSIONID cookie exclusion was an unanchored regex matching any attacker-named `xJSESSIONIDx`; and `text/plain` was an ARGS-inspection blind spot with no legitimate caller.
- **DoS / throttle**: slow-POST bounded (`client_body_timeout` 60s→15s), scoped `limit_conn`, MFA submit and all three unauthenticated OAuth legs covered, and human vs machine credential routes given **separate** request *and* connection budgets so a NAT-shared integration can't lock clinicians out.
- **`/ws` hardening**: CXF service-list catalog hidden; `SystemInfoService` restricted to loopback (authentication is the wrong gate for a liveness endpoint) and 404'd at the edge; the anonymous `?_wadl` bypass removed.

### Verification added

`carlos-ctl check` now proves these at runtime instead of trusting config: the CXF catalog is hidden, an unauthenticated SOAP call is refused *by the auth gate* (asserting 400/401, with a real operation body so a removed interceptor shows as 200 rather than an inconclusive 500), the dot-segment guard rejects a bypass, and the application unit is **enabled** as well as running.

## Related Issues

_None linked._

## Target Branch

`release/2026.08` — supported-release security fixes, per `docs/release-process.md`. No version/SCM metadata changes; no Flyway migration added or edited.

## How Was This Tested?

- **nginx**: `nginx -t` plus a live runtime harness (stub backend, real site config). Every bypass variant measured before and after — ten dot-segment forms went 200-unthrottled → **400**; `/carlos;x/login`, `/carlos/mfa;x/loginMfa`, `/carlos/ws;x/LoginService`, `/carlos/ws/oauth;x/initiate`, `/carlos/LOGIN` → **429** after burst; `/carlos/loginResource/*`, `/carlos/ws/DemographicService`, `file.;x` and ordinary AJAX stay **200**; a `/ws` credential flood no longer 429s human login.
- **postinst**: `sh -n`; control-flow reviewed for every branch (success, seed-live failure, DB-failure, opt-out, non-systemd, abort-upgrade).
- **Java**: full `mvn compile`. **Docs/config**: man page renders clean; `web.xml`/`spring_ws.xml` well-formed; `git diff --check` clean.
- **DrugRef pin**: target SHA confirmed to be a valid 40-char commit reachable on `drugref2026` master, parseable by `debian/rules`, and to contain the expected hardened content.
- **Still recommended before tagging**: install both `.deb`s on a disposable Ubuntu 26.04 VM and run `carlos-ctl check` — the config was validated in isolation here, not against the full installed stack.

### Known, deliberately out of scope

`GET /carlos/ws/<Service>?wsdl` remains unauthenticated (CXF serves WSDL at `Phase.READ` and WS-Security returns early for GETs). Hiding the catalog does not close it; closing it would break clients that fetch their contract at runtime, so it is documented in `web.xml` rather than changed here.

## Checklist

- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My commits follow Conventional Commits format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests — adds runtime probes to `carlos-ctl check`; nginx changes verified by the harness above
- [x] I have read the contributing guide
- [x] I selected the target branch according to the release process
- [x] I preserved the target branch version/SCM metadata
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu2YJEo1aM9uhtReMWLGKZ