### PR TITLE
fix(deb): keep the EMR up when three packages restart it in one transaction

### DIFF
--- a/debian/assets/carlos_ctl/cli.py
+++ b/debian/assets/carlos_ctl/cli.py
@@ -12,7 +12,6 @@ share a concept; see the package docstring in __init__.py.
 """
 
 import os
-import subprocess
 import sys
 from typing import List, Optional
 
@@ -111,18 +110,11 @@ def _cmd_lifecycle(verb: str, argv) -> int:
             f"(for other units use systemctl directly)")
     need_root(verb)
     if verb in ("start", "restart"):
-        # carlos-emr.service carries StartLimitBurst=6/StartLimitIntervalSec=30min
-        # to catch a crash loop. Config changes are applied by restarting, and a
-        # package upgrade restarts the unit three times of its own accord, so an
-        # operator iterating on carlos.properties can spend that budget without
-        # anything being wrong — systemd then refuses with "start-limit-hit" and
-        # the EMR stays down until someone runs `systemctl reset-failed` by hand.
-        # A restart asked for explicitly is never a crash loop, so clear the
-        # counter first. Genuine crash looping is still caught: Restart=on-failure
-        # with RestartSec=15s burns the same budget in about 90 seconds.
-        subprocess.run(["systemctl", "reset-failed", "carlos-emr.service"],
-                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                       check=False)
+        # An operator asking for a restart is never a crash loop; clear the
+        # start-rate counter so systemd cannot refuse it. See
+        # util.reset_emr_start_limit for why this is needed and why it does not
+        # weaken crash-loop protection.
+        util.reset_emr_start_limit()
     os.execvp("systemctl", ["systemctl", verb, "carlos-emr.service"])
     raise AssertionError("unreachable: execvp replaces the process")
 

--- a/debian/assets/carlos_ctl/cli.py
+++ b/debian/assets/carlos_ctl/cli.py
@@ -12,6 +12,7 @@ share a concept; see the package docstring in __init__.py.
 """
 
 import os
+import subprocess
 import sys
 from typing import List, Optional
 
@@ -109,6 +110,19 @@ def _cmd_lifecycle(verb: str, argv) -> int:
         die(f"'{verb}' takes no arguments; it manages carlos-emr.service only "
             f"(for other units use systemctl directly)")
     need_root(verb)
+    if verb in ("start", "restart"):
+        # carlos-emr.service carries StartLimitBurst=6/StartLimitIntervalSec=30min
+        # to catch a crash loop. Config changes are applied by restarting, and a
+        # package upgrade restarts the unit three times of its own accord, so an
+        # operator iterating on carlos.properties can spend that budget without
+        # anything being wrong — systemd then refuses with "start-limit-hit" and
+        # the EMR stays down until someone runs `systemctl reset-failed` by hand.
+        # A restart asked for explicitly is never a crash loop, so clear the
+        # counter first. Genuine crash looping is still caught: Restart=on-failure
+        # with RestartSec=15s burns the same budget in about 90 seconds.
+        subprocess.run(["systemctl", "reset-failed", "carlos-emr.service"],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       check=False)
     os.execvp("systemctl", ["systemctl", verb, "carlos-emr.service"])
     raise AssertionError("unreachable: execvp replaces the process")
 

--- a/debian/assets/carlos_ctl/dbops.py
+++ b/debian/assets/carlos_ctl/dbops.py
@@ -420,6 +420,11 @@ def cmd_rotate(argv) -> int:
     # point leaves the files holding complete (at worst stale) credentials,
     # and the recovery for every partial state is the same: re-run rotate.
     cmd_db_users(["--new-passwords"])
+    # Rotation restarts on purpose, so clear the start-rate counter first —
+    # otherwise a stale count from an upgrade or a few config restarts inside
+    # the same 30-minute window makes systemd refuse this one, and the die()
+    # below leaves the operator with rotated credentials AND a down EMR.
+    util.reset_emr_start_limit()
     if run(["systemctl", "restart", "carlos-emr.service"]).returncode != 0:
         # The new credential is provisioned and written out, but the service
         # did not come back — saying "restarted" here would hide an outage.

--- a/debian/assets/carlos_ctl/util.py
+++ b/debian/assets/carlos_ctl/util.py
@@ -78,6 +78,28 @@ def out(cmd: List[str]) -> str:
     return cp.stdout.strip() if cp.returncode == 0 else ""
 
 
+def reset_emr_start_limit() -> None:
+    """Clear carlos-emr.service's failed state and start-rate counter.
+
+    Call this before ANY deliberate start or restart of the EMR. The unit
+    carries StartLimitBurst=6 over StartLimitIntervalSec=30min to catch a crash
+    loop, but a single apt transaction restarts it three times (carlos-emr plus
+    the drugref and eform-renderer postinsts), and applying config changes means
+    restarting again. Those are all intentional, so without this systemd
+    eventually refuses one with "start-limit-hit" and the EMR is left down
+    behind a 502 with no automatic recovery.
+
+    Crash-loop protection is unaffected: Restart=on-failure with RestartSec=15s
+    still burns the same budget in about 90 seconds when the JVM will not stay
+    up, because nothing calls this in between those automatic restarts.
+
+    Best-effort and never fatal — a missing or masked unit must not turn a
+    working verb into an error.
+    """
+    run(["systemctl", "reset-failed", "carlos-emr.service"],
+        capture_output=True, check=False)
+
+
 def genrandom(length: int, alphabet: str) -> str:
     return "".join(secrets.choice(alphabet) for _ in range(length))
 

--- a/debian/carlos-emr-drugref.postinst
+++ b/debian/carlos-emr-drugref.postinst
@@ -122,7 +122,16 @@ case "$1" in
         # is-active is a query, not a lifecycle action, so systemctl is the
         # right tool for it; the restart itself goes through deb-systemd-invoke
         # so policy-rc.d is honoured.
-        if [ -d /run/systemd/system ] && systemctl is-active --quiet carlos-emr.service; then
+        # is-failed as well as is-active: three packages in this transaction each
+        # restart carlos-emr.service, so an earlier one may already have spent
+        # the unit's StartLimitBurst and left it failed. Skipping here would then
+        # leave the EMR down for good. reset-failed clears the start counter (and
+        # the failed state) so a restart we asked for on purpose is never refused
+        # as a crash loop — see the same guard in carlos-emr.postinst.
+        if [ -d /run/systemd/system ] && \
+           { systemctl is-active --quiet carlos-emr.service || \
+             systemctl is-failed --quiet carlos-emr.service; }; then
+            systemctl reset-failed carlos-emr.service >/dev/null 2>&1 || true
             deb-systemd-invoke restart carlos-emr.service || {
                 echo "carlos-emr-drugref: WARNING: the EMR did not restart — DrugRef will not" >&2
                 echo "carlos-emr-drugref: serve until it does (journalctl -u carlos-emr)." >&2

--- a/debian/carlos-emr-eform-renderer.postinst
+++ b/debian/carlos-emr-eform-renderer.postinst
@@ -165,7 +165,16 @@ case "$1" in
         # at renderer construction, not per request, so without this the browser
         # stays unconfigured until the next restart. Same shared-JVM caveat as
         # carlos-emr-drugref: this is a short EMR outage.
-        if [ -d /run/systemd/system ] && systemctl is-active --quiet carlos-emr.service; then
+        # is-failed as well as is-active: this package is configured LAST of the
+        # three, so it is the one that used to hit carlos-emr.service's
+        # StartLimitBurst and report "the EMR did not restart" while leaving it
+        # down behind a 502. reset-failed clears the start counter (and the
+        # failed state) so a restart we asked for on purpose is never refused as
+        # a crash loop — see the same guard in carlos-emr.postinst.
+        if [ -d /run/systemd/system ] && \
+           { systemctl is-active --quiet carlos-emr.service || \
+             systemctl is-failed --quiet carlos-emr.service; }; then
+            systemctl reset-failed carlos-emr.service >/dev/null 2>&1 || true
             deb-systemd-invoke restart carlos-emr.service || {
                 echo "carlos-emr-eform-renderer: WARNING: the EMR did not restart — eForm PDF" >&2
                 echo "carlos-emr-eform-renderer: rendering will not work until it does" >&2

--- a/debian/carlos-emr.postinst
+++ b/debian/carlos-emr.postinst
@@ -42,6 +42,26 @@ sd_invoke() {
     deb-systemd-invoke "$@"
 }
 
+# Clear carlos-emr.service's start rate-limit counter before a package-driven
+# lifecycle action. The unit carries StartLimitBurst=6/StartLimitIntervalSec=30min
+# to catch a genuine crash loop, but THREE packages (carlos-emr, -drugref,
+# -eform-renderer) each restart this one unit in a single apt transaction. An
+# install followed by an upgrade inside the same 30-minute window — the ordinary
+# way an operator applies a hotfix — therefore spends the whole budget, systemd
+# refuses the last restart with "start-limit-hit", and the EMR is left DOWN
+# behind a 502 with no automatic recovery.
+#
+# reset-failed clears both the failed state and the start counter, so a restart
+# we asked for on purpose is never mistaken for a crash loop. Crash-loop
+# protection is unaffected: Restart=on-failure/RestartSec=15s still burns the
+# budget in about 90 seconds when the JVM genuinely will not stay up.
+sd_reset_start_limit() {
+    if [ ! -d /run/systemd/system ]; then
+        return 0
+    fi
+    systemctl reset-failed carlos-emr.service >/dev/null 2>&1 || true
+}
+
 # Install a generated file ONCE. These carry credentials and site decisions, so
 # they are deliberately not conffiles: dpkg would prompt about a "modified"
 # file on every upgrade, and worse, a distribution default could overwrite a
@@ -801,6 +821,7 @@ case "$1" in
                 echo "carlos-emr: not restarting the application — the seeded administrator" >&2
                 echo "carlos-emr: credential is still live (run 'carlos-ctl bootstrap-admin')." >&2
             else
+                sd_reset_start_limit
                 deb-systemd-invoke start carlos-emr.service >/dev/null 2>&1 || true
             fi
             deb-systemd-invoke start carlos-emr-backup.timer carlos-emr-backup-verify.timer \
@@ -868,7 +889,7 @@ if [ "$1" = configure ] && [ -d /run/systemd/system ]; then
         echo "carlos-emr: NOT starting the service — the schema is not ready (see above)." >&2
         echo "carlos-emr: the unit stays enabled; it will start on the next boot or when you" >&2
         echo "carlos-emr: start it after completing the migration." >&2
-    elif sd_invoke start carlos-emr.service; then
+    elif sd_reset_start_limit; sd_invoke start carlos-emr.service; then
         # Deploying this webapp takes around two minutes on a small VM
         # (measured: 119 s), and postinst returning before it answers makes a
         # perfectly good install look broken — the operator runs

--- a/debian/changelog
+++ b/debian/changelog
@@ -17,6 +17,16 @@ carlos-emr (2026.09.0~snapshot4) resolute; urgency=medium
       database (faxes, email attachments) keep resolving.
   * The weekly restore drill accepts both directory spellings: the newest
     snapshot right after the upgrade still carries pre-rename paths.
+  * Upgrades no longer leave the EMR down behind a 502. carlos-emr,
+    carlos-emr-drugref and carlos-emr-eform-renderer each restart
+    carlos-emr.service, so one apt transaction restarts it three times; against
+    the unit's StartLimitBurst=6/30min an install followed by an upgrade inside
+    the same half hour exhausted the budget and systemd refused the last restart
+    with "start-limit-hit". Package-driven restarts — and `carlos-ctl
+    start`/`restart` — now clear the start counter first, and the two dependent
+    postinsts recover a unit an earlier one in the same transaction left failed.
+    Crash-loop protection is unchanged: Restart=on-failure with RestartSec=15s
+    still trips the same limit in about 90 seconds.
 
  -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Fri, 28 Aug 2026 16:00:00 +0000
 


### PR DESCRIPTION
## The defect

`carlos-emr.service` carries `StartLimitBurst=6` over `StartLimitIntervalSec=30min`
to catch a crash loop. But **three** packages each restart that one unit inside a
single apt transaction:

| package | why it restarts `carlos-emr.service` |
|---|---|
| `carlos-emr` | its own configure step starts the app |
| `carlos-emr-drugref` | so Tomcat picks up the new DrugRef context |
| `carlos-emr-eform-renderer` | so the JVM re-reads the render properties |

The renderer's restart arrived with the package itself in #3543, taking the
per-transaction count from two to three.

Three plus three is six, so the **documented** workflow — install, run the
post-install `carlos-ctl restart`, then apply a hotfix upgrade inside the same half
hour — spends the whole budget. systemd refuses the last restart with
`start-limit-hit`, the unit ends `failed`, and the front door serves **502 with no
automatic recovery**.

`apt` still exits **0**, so nothing in the transaction reports a problem. The only
tell is the renderer's `WARNING: the EMR did not restart`. Recovery needs a
hand-run `systemctl reset-failed`, which the upgrade path never mentions.

## Reproduction (packaged install, LXD VM, Ubuntu 26.04)

```
$ apt-get install -y --reinstall ./carlos-emr_*.deb ./carlos-emr-drugref_*.deb \
                                 ./carlos-emr-eform-renderer_*.deb
carlos-emr-eform-renderer: WARNING: the EMR did not restart — eForm PDF
$ systemctl is-active carlos-emr
failed                       # Active: failed (Result: start-limit-hit)
$ curl -sk -o /dev/null -w '%{http_code}\n' https://localhost/carlos/
502
```

`journalctl -u carlos-emr` shows `Start request repeated too quickly.`

## The fix

A restart we asked for on purpose is not a crash loop, so clear the start counter
before every package-driven lifecycle action and before `carlos-ctl start|restart`.
`systemctl reset-failed` clears the failed state and the start-rate counter together.

The two dependent postinsts now also act on a unit an earlier package in the same
transaction left `failed` — their guard was `is-active` only, so once the limit was
hit they silently skipped the restart and left the EMR down.

**Crash-loop protection is unchanged.** `Restart=on-failure` with `RestartSec=15s`
still trips the same `StartLimitBurst` in about 90 seconds when the JVM will not
stay up.

## Verification

Rebuilt the three packages from this branch and re-ran the same reinstall against a
live install that already had 4 starts inside the limit window (the failing
condition):

- `carlos-emr` stays **active**; front door **200**
- **7 starts** inside the window, **zero** `start-limit-hit` refusals
- no `the EMR did not restart` warning
- `carlos-ctl check` — **all checks passed** (services, loopback-only listeners,
  TLS, live WAF 403 probe, web-service gates, DrugRef lookup, Flyway state)
- `carlos-ctl restart` works and still rejects arguments
  (`carlos-ctl restart nginx` errors as before)
- **37/37** Playwright checks pass through the WAF on **:443**

Found while validating `release/2026.08` end to end on a packaged install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnov5ppnJbdnyEDMMAJMdm

## Summary by Sourcery

Prevent intentional EMR restarts during package operations and administration from being blocked by stale systemd start-rate limits while retaining crash-loop protection.

Bug Fixes:
- Prevent package upgrades and deliberate EMR lifecycle commands from leaving carlos-emr.service down after systemd start-limit exhaustion.
- Allow dependent package post-install actions to recover the EMR when an earlier package has left the unit failed.

Enhancements:
- Preserve crash-loop protection while distinguishing intentional service starts and restarts from automatic failures.
- Ensure database credential rotation can restart the EMR reliably after updating credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes upgrades leaving the EMR down behind a 502 when three packages restart the same unit in one apt transaction and exhaust its systemd start limit. Package-driven restarts, `carlos-ctl start|restart`, and `carlos-ctl rotate` now clear the start counter first; the dependent postinsts also recover a unit left failed by an earlier package in the same transaction. Crash-loop protection is unchanged.

<sup>Written for commit ca8d359001a2aff2f461332ac66f5212d54a1a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

