### PR TITLE
fix(tickler): ViewTicklerDemoMain 500s on demoview=0 and other non-patient values

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerDemoMain.jsp
@@ -54,6 +54,25 @@
     if (request.getParameter("limit2") != null) strLimit2 = request.getParameter("limit2");
     String demoview = request.getParameter("demoview") == null ? "all" : request.getParameter("demoview");
 
+    // A valid, POSITIVE demographic number, or null when demoview is absent,
+    // non-numeric or 0. The tickler search below binds this as a NON-NULL
+    // positional parameter (WHERE t.demographicNo = ?1) and the Add-Tickler
+    // button further down dereferences the fetched demographic, so each of
+    // those inputs used to yield a 500: an absent param bound null
+    // (IllegalArgumentException), a non-numeric value threw NumberFormatException,
+    // and a schedule tickler alert on an appointment with NO linked patient
+    // reaches this page as demoview=0 (infirmarydemographiclist.jspf) whose
+    // demographic 0 does not exist. Parse defensively and treat all three as
+    // "no patient context".
+    Integer demoViewDemographicNo = null;
+    String demoViewParam = request.getParameter("demoview");
+    if (demoViewParam != null && demoViewParam.matches("\\d+")) {
+        int parsedDemoViewNo = Integer.parseInt(demoViewParam);
+        if (parsedDemoViewNo > 0) {
+            demoViewDemographicNo = parsedDemoViewNo;
+        }
+    }
+
 //Retrieve encounter id for updating encounter navbar if info this page changes anything
     String parentAjaxId;
     if (request.getParameter("parentAjaxId") != null)
@@ -827,7 +846,12 @@
                             if (dateEnd.compareTo("") == 0) dateEnd = "8888-12-31";
                             if (dateBegin.compareTo("") == 0) dateBegin = "0001-01-01";
 
-                            List<Tickler> ticklers = ticklerManager.search_tickler_bydemo(loggedInInfo, request.getParameter("demoview") == null ? null : Integer.parseInt(request.getParameter("demoview")), ticklerview, ConversionUtils.fromDateString(dateBegin), ConversionUtils.fromDateString(dateEnd));
+                            // This query is demographic-scoped and binds a non-null id; with no
+                            // patient context there are no ticklers to show, so render the empty
+                            // list rather than crash on the null positional bind.
+                            List<Tickler> ticklers = demoViewDemographicNo == null
+                                    ? java.util.Collections.<Tickler>emptyList()
+                                    : ticklerManager.search_tickler_bydemo(loggedInInfo, demoViewDemographicNo, ticklerview, ConversionUtils.fromDateString(dateBegin), ConversionUtils.fromDateString(dateEnd));
                             String rowColour = "lilac";
                             for (Tickler t : ticklers) {
                                 Demographic d = demographicDao.getDemographicById(t.getDemographicNo());
@@ -1012,20 +1036,24 @@
                         </tr>
                         <%
                             }
-                            Demographic d = demographicDao.getDemographicById(request.getParameter("demoview") == null ? null : Integer.parseInt(request.getParameter("demoview")));
+                            // May be null: demoview can carry no patient context (absent/0), and
+                            // even a positive id can reference a since-removed demographic. The
+                            // Add-Tickler button below, which pre-fills this patient, is rendered
+                            // only when this is non-null.
+                            Demographic d = demoViewDemographicNo == null ? null : demographicDao.getDemographicById(demoViewDemographicNo);
                         %>
                         <tr bgcolor=#FFFFFF class="noprint">
                             <td colspan="11" class="white"><a id="checkAllLink" name="checkAllLink"
                                                               href="javascript:CheckAll();"><fmt:message key="tickler.ticklerDemoMain.btnCheckAll"/></a> - <a
                                     href="javascript:ClearAll();"><fmt:message key="tickler.ticklerDemoMain.btnClearAll"/></a> &nbsp; &nbsp; &nbsp;
-                                &nbsp; &nbsp; <input type="button" name="button"
+                                &nbsp; &nbsp; <% if (d != null) { %><input type="button" name="button"
                                                      <c:set var="__enc_1"><carlos:encode value='<%= parentAjaxId %>' context="uriComponent"/></c:set>
                                                      <c:set var="__enc_2"><carlos:encode value='<%= d.getChartNo() %>' context="uriComponent"/></c:set>
                                                      <c:set var="__enc_3"><carlos:encode value='<%= d.getDisplayName() %>' context="uriComponent"/></c:set>
                                                      v                                                     
 alue="<fmt:message key="tickler.ticklerDemoMain.btnAddTickler"/>"
                                                      onClick="popupPage('400','600', '<%= request.getContextPath() %>/tickler/ViewAddTickler?updateParent=true&parentAjaxId=<carlos:encode value='${__enc_1}' context="javaScriptAttribute"/>&bFirstDisp=false&messageID=null&demographic_no=<carlos:encode value='<%= String.valueOf(d.getDemographicNo()) %>' context="javaScriptAttribute"/>&chart_no=<carlos:encode value='${__enc_2}' context="javaScriptAttribute"/>&name=<carlos:encode value='${__enc_3}' context="javaScriptAttribute"/>')"
-                                                     class="sbttn"> <input type="hidden" name="submit_form"
+                                                     class="sbttn"><% } %> <input type="hidden" name="submit_form"
                                                                            value=""> <% if (ticklerview.compareTo("D") == 0) {%>
                                 <input
                                         type="button"


### PR DESCRIPTION
## The defect

`ticklerDemoMain.jsp` read the `demoview` request parameter twice with a bare `Integer.parseInt(request.getParameter("demoview"))` and then dereferenced the demographic it fetched. Three ordinary inputs each produced a **500**:

| `demoview` | failure |
|---|---|
| **`0`** (the reachable one) | `infirmarydemographiclist.jspf` renders a tickler "!" alert link with `demoview=0` for a schedule appointment that has **no linked patient** (`demographic_no == 0`). Demographic 0 doesn't exist → `getDemographicById(0)` returns null → the Add-Tickler button dereferences it (NPE). A large unknown id fails identically. |
| absent | `search_tickler_bydemo` binds `demographicNo` as a **non-null** positional parameter (`WHERE t.demographicNo = ?1`); a null bind threw `IllegalArgumentException: Null value for positional parameter ?1`. |
| non-numeric (`all`) | `Integer.parseInt("all")` threw `NumberFormatException`. |

The 500 surfaced only as a masked `Cannot reset buffer after response has been committed` from `ResponseSanitizationFilter`; the real causes are above.

## Reproduction (packaged install, :443)

`GET /carlos/tickler/ViewTicklerDemoMain?demoview=0` → 500 (Error Page). Real trigger: open the schedule, click the tickler "!" alert on an appointment with no patient.

## The fix

Parse `demoview` once into a nullable **positive** Integer; treat absent / `0` / non-numeric uniformly as "no patient context":
- skip the demographic-scoped query in that case (render the empty list rather than crash on the null bind);
- render the Add-Tickler button only when a demographic was actually found.

The working `demoview=<real demographic>` path is unchanged — patient's ticklers list and the Add-Tickler button (carrying the correct `demographic_no`) render exactly as before.

## Verification (real UI, :443)

| case | before | after |
|---|---|---|
| `demoview=0` (no patient) | 500 | 200, clean page, no Add-Tickler button |
| `demoview=all` / non-numeric | 500 | 200 |
| absent / `demoview=-5` | 500 | 200 |
| `demoview=1373` (real patient) | 200 | 200 — Add-Tickler button present, href carries `demographic_no=1373` |
| `demoview=7` (has ticklers) | 200 | 200 — list renders its rows |

Confirmed the fix is compiled into the live Jasper class (not a stale cache). `tickler-note-dialog-playwright-checks.js` — the only scripted check that references this page — passes. (`tickler-crud` is a pre-existing flaky check on the *separate* `ticklerMain.jsp`: it failed then passed on retry, unrelated to this change.)

## Out of scope (noted)

`ticklerDemoMain.jsp:833` reads `d.getProviderNo()` one line before its own `if (d != null)` guard — a separate latent NPE for a tickler whose demographic was removed. Left as-is to keep this fix scoped to the reported `demoview=0` crash; worth a follow-up.

Pre-existing bug (the null-handling dates to 2026-07-07), targeted at `release/2026.08` per the release policy and as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnov5ppnJbdnyEDMMAJMdm

## Summary by Sourcery

Handle invalid or missing demographic context safely so the tickler demo page renders without errors.

Bug Fixes:
- Prevent the tickler demo page from returning 500 errors for absent, zero, invalid, or unknown demographic values.
- Preserve the patient-specific tickler view while omitting the Add-Tickler action when no valid demographic is available.

Enhancements:
- Treat invalid demographic parameters as an empty, non-patient tickler context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 500 error in `ticklerDemoMain.jsp` when `demoview` is `0`, absent, or non-numeric, by parsing it once into a nullable positive Integer and treating all three invalid inputs uniformly as "no patient context". The page now renders an empty tickler list and omits the Add-Tickler button for those cases; the working `demoview=<real demographic>` path is unchanged. A latent NPE on a tickler whose demographic was removed is noted as a follow-up, left out of scope.

<sup>Written for commit ed9dbbdbab16f8eb7b0dae43ea9b21cae2d83079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

