### PR TITLE
fix(tickler): ViewTicklerDemoMain 500s on demoview=0 and other non-patient values

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerDemoMain.jsp
@@ -54,6 +54,25 @@
     if (request.getParameter("limit2") != null) strLimit2 = request.getParameter("limit2");
     String demoview = request.getParameter("demoview") == null ? "all" : request.getParameter("demoview");
 
+    // A valid, POSITIVE demographic number, or null when demoview is absent,
+    // non-numeric or 0. The tickler search below binds this as a NON-NULL
+    // positional parameter (WHERE t.demographicNo = ?1) and the Add-Tickler
+    // button further down dereferences the fetched demographic, so each of
+    // those inputs used to yield a 500: an absent param bound null
+    // (IllegalArgumentException), a non-numeric value threw NumberFormatException,
+    // and a schedule tickler alert on an appointment with NO linked patient
+    // reaches this page as demoview=0 (infirmarydemographiclist.jspf) whose
+    // demographic 0 does not exist. Parse defensively and treat all three as
+    // "no patient context".
+    Integer demoViewDemographicNo = null;
+    String demoViewParam = request.getParameter("demoview");
+    if (demoViewParam != null && demoViewParam.matches("\\d+")) {
+        int parsedDemoViewNo = Integer.parseInt(demoViewParam);
+        if (parsedDemoViewNo > 0) {
+            demoViewDemographicNo = parsedDemoViewNo;
+        }
+    }
+
 //Retrieve encounter id for updating encounter navbar if info this page changes anything
     String parentAjaxId;
     if (request.getParameter("parentAjaxId") != null)
@@ -827,7 +846,12 @@
                             if (dateEnd.compareTo("") == 0) dateEnd = "8888-12-31";
                             if (dateBegin.compareTo("") == 0) dateBegin = "0001-01-01";
 
-                            List<Tickler> ticklers = ticklerManager.search_tickler_bydemo(loggedInInfo, request.getParameter("demoview") == null ? null : Integer.parseInt(request.getParameter("demoview")), ticklerview, ConversionUtils.fromDateString(dateBegin), ConversionUtils.fromDateString(dateEnd));
+                            // This query is demographic-scoped and binds a non-null id; with no
+                            // patient context there are no ticklers to show, so render the empty
+                            // list rather than crash on the null positional bind.
+                            List<Tickler> ticklers = demoViewDemographicNo == null
+                                    ? java.util.Collections.<Tickler>emptyList()
+                                    : ticklerManager.search_tickler_bydemo(loggedInInfo, demoViewDemographicNo, ticklerview, ConversionUtils.fromDateString(dateBegin), ConversionUtils.fromDateString(dateEnd));
                             String rowColour = "lilac";
                             for (Tickler t : ticklers) {
                                 Demographic d = demographicDao.getDemographicById(t.getDemographicNo());
@@ -1012,20 +1036,24 @@
                         </tr>
                         <%
                             }
-                            Demographic d = demographicDao.getDemographicById(request.getParameter("demoview") == null ? null : Integer.parseInt(request.getParameter("demoview")));
+                            // May be null: demoview can carry no patient context (absent/0), and
+                            // even a positive id can reference a since-removed demographic. The
+                            // Add-Tickler button below, which pre-fills this patient, is rendered
+                            // only when this is non-null.
+                            Demographic d = demoViewDemographicNo == null ? null : demographicDao.getDemographicById(demoViewDemographicNo);
                         %>
                         <tr bgcolor=#FFFFFF class="noprint">
                             <td colspan="11" class="white"><a id="checkAllLink" name="checkAllLink"
                                                               href="javascript:CheckAll();"><fmt:message key="tickler.ticklerDemoMain.btnCheckAll"/></a> - <a
                                     href="javascript:ClearAll();"><fmt:message key="tickler.ticklerDemoMain.btnClearAll"/></a> &nbsp; &nbsp; &nbsp;
-                                &nbsp; &nbsp; <input type="button" name="button"
+                                &nbsp; &nbsp; <% if (d != null) { %><input type="button" name="button"
                                                      <c:set var="__enc_1"><carlos:encode value='<%= parentAjaxId %>' context="uriComponent"/></c:set>
                                                      <c:set var="__enc_2"><carlos:encode value='<%= d.getChartNo() %>' context="uriComponent"/></c:set>
                                                      <c:set var="__enc_3"><carlos:encode value='<%= d.getDisplayName() %>' context="uriComponent"/></c:set>
                                                      v                                                     
 alue="<fmt:message key="tickler.ticklerDemoMain.btnAddTickler"/>"
                                                      onClick="popupPage('400','600', '<%= request.getContextPath() %>/tickler/ViewAddTickler?updateParent=true&parentAjaxId=<carlos:encode value='${__enc_1}' context="javaScriptAttribute"/>&bFirstDisp=false&messageID=null&demographic_no=<carlos:encode value='<%= String.valueOf(d.getDemographicNo()) %>' context="javaScriptAttribute"/>&chart_no=<carlos:encode value='${__enc_2}' context="javaScriptAttribute"/>&name=<carlos:encode value='${__enc_3}' context="javaScriptAttribute"/>')"
-                                                     class="sbttn"> <input type="hidden" name="submit_form"
+                                                     class="sbttn"><% } %> <input type="hidden" name="submit_form"
                                                                            value=""> <% if (ticklerview.compareTo("D") == 0) {%>
                                 <input
                                         type="button"


### PR DESCRIPTION
Replaces #3559 (that branch had an unsigned merge commit failing DCO; this is the identical fix as a single signed commit off the current release/2026.08).

## The defect

`ticklerDemoMain.jsp` read `demoview` twice with a bare `Integer.parseInt(request.getParameter("demoview"))` and dereferenced the demographic it fetched. Three ordinary inputs each 500'd:

| `demoview` | failure |
|---|---|
| **`0`** (reachable) | `infirmarydemographiclist.jspf` links `demoview=0` for a schedule appointment with **no linked patient**. Demographic 0 doesn't exist → `getDemographicById(0)` null → Add-Tickler button NPE. |
| absent | `search_tickler_bydemo` binds `demographicNo` as **non-null** (`WHERE t.demographicNo = ?1`) → `IllegalArgumentException`. |
| non-numeric (`all`) | `Integer.parseInt("all")` → `NumberFormatException`. |

Masked in logs as `Cannot reset buffer after response has been committed` from `ResponseSanitizationFilter`.

## The fix

Parse `demoview` once into a nullable **positive** Integer; treat absent/0/non-numeric as "no patient context" — skip the demographic-scoped query (render empty list, no null bind) and render the Add-Tickler button only when a demographic was found. The `demoview=<real demographic>` path is unchanged.

## Verification (real UI, :443)

| case | before | after |
|---|---|---|
| `demoview=0` / `all` / `99999999` / `-5` / absent | 500 | 200, clean page |
| `demoview=1373` (real patient) | 200 | 200 — Add-Tickler button, `demographic_no=1373` |
| `demoview=7` (has ticklers) | 200 | 200 — list renders |

Confirmed compiled into the live Jasper class. `tickler-note-dialog` (only scripted check referencing this page) passes. (`tickler-crud` is pre-existing flaky on the *separate* `ticklerMain.jsp` — failed then passed on retry, unrelated.)

Out of scope, noted: `ticklerDemoMain.jsp:833` reads `d.getProviderNo()` before its own `if (d != null)` guard — separate latent NPE, worth a follow-up.

Pre-existing bug (null-handling dates to 2026-07-07), targeted at `release/2026.08` as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnov5ppnJbdnyEDMMAJMdm

## Summary by Sourcery

Handle invalid or missing demographic context safely in the tickler demo view while preserving behavior for valid patients.

Bug Fixes:
- Prevent ViewTicklerDemoMain from returning HTTP 500 for absent, invalid, zero, negative, or nonexistent demographic values.
- Render demographic ticklers as an empty list when no valid patient context is available.
- Show the Add-Tickler button only when a valid demographic is found.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors on the tickler demo main page when `demoview` is `0`, absent, or non-numeric, by treating those as "no patient context" instead of crashing.

**Bug Fixes**
- `demoview=0` (from an appointment with no linked patient), absent, and non-numeric values now render a clean page with an empty tickler list and no Add-Tickler button.
- The `demoview=<real demographic>` path is unchanged: list and Add-Tickler button still render as before.
- A separate latent NPE on line 833 (`d.getProviderNo()` before its null guard) is noted but left out of scope.

<sup>Written for commit 143534f18e0c32f7dd9807ec76b70ce7c187fd7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

