### PR TITLE
fix(prevention): make About/License popup links work on prevention dialogs

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
@@ -326,6 +326,7 @@
 
         <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
 
+        <script type="text/javascript" src="<%= request.getContextPath() %>/share/javascript/popupLink.js"></script>
         <script type="text/javascript" src="<%= request.getContextPath() %>/share/calendar/calendar.js"></script>
         <script type="text/javascript"
                 src="<%= request.getContextPath() %>/share/calendar/lang/<fmt:message key="global.javascript.calendar"/>"></script>
@@ -632,8 +633,8 @@
                         </td>
                         <td style="text-align:right; background-color:silver;">
                             <a
-                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
+                                href="<%=request.getContextPath()%>/encounter/ViewAbout" class="js-popup" data-popup-width="400" data-popup-height="300"><fmt:message key="global.about"/></a>
+                            | <a href="<%=request.getContextPath()%>/encounter/ViewLicense" class="js-popup" data-popup-width="400" data-popup-height="300"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionDataDisambiguate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionDataDisambiguate.jsp
@@ -110,6 +110,7 @@
 
         <script type="text/javascript" src="<%=request.getContextPath() %>/library/jquery/jquery-3.7.1.min.js"></script>
         <script src="<%=request.getContextPath() %>/library/jquery/jquery-compat.js"></script>
+        <script type="text/javascript" src="<%= request.getContextPath() %>/share/javascript/popupLink.js"></script>
         <script type="text/javascript" src="<%= request.getContextPath() %>/share/calendar/calendar.js"></script>
         <script type="text/javascript"
                 src="<%= request.getContextPath() %>/share/calendar/lang/<fmt:message key="global.javascript.calendar"/>"></script>
@@ -280,8 +281,8 @@
                         </td>
                         <td style="text-align:right">
                             <a
-                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
+                                href="<%=request.getContextPath()%>/encounter/ViewAbout" class="js-popup" data-popup-width="400" data-popup-height="300"><fmt:message key="global.about"/></a>
+                            | <a href="<%=request.getContextPath()%>/encounter/ViewLicense" class="js-popup" data-popup-width="400" data-popup-height="300"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/share/javascript/popupLink.js
+++ b/src/main/webapp/share/javascript/popupLink.js
@@ -42,7 +42,9 @@ document.addEventListener('click', function (event) {
     var link = event.target.closest('a.js-popup');
     if (!link) return;
 
-    event.preventDefault();
+    // Leave modified clicks (open in new tab/window, etc.) to native
+    // browser handling instead of forcing them through the popup.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 
     var width = link.getAttribute('data-popup-width') || 400;
     var height = link.getAttribute('data-popup-height') || 300;
@@ -50,7 +52,12 @@ document.addEventListener('click', function (event) {
         ',location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=0,screenY=0,top=0,left=0';
 
     var popup = window.open(link.href, '', windowProps);
-    if (popup && popup.opener == null) {
+    // window.open() can return null if the popup was blocked; fall back
+    // to the link's real href instead of leaving the click inert.
+    if (!popup) return;
+
+    event.preventDefault();
+    if (popup.opener == null) {
         popup.opener = window;
     }
 });

--- a/src/main/webapp/share/javascript/popupLink.js
+++ b/src/main/webapp/share/javascript/popupLink.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/**
+ * Opens links marked with the "js-popup" class in a small, script-opened
+ * popup window instead of navigating normally.
+ *
+ * A script-opened window is required because some popup target pages
+ * (e.g. encounter/About, encounter/License) close themselves via
+ * window.close(). Browsers only honor window.close() on windows opened
+ * by script — not on a window/tab reached through a normal navigation
+ * or target="_blank" — so the link must stay real (for middle-click,
+ * copy-link, and no-JS fallback) while still being opened via
+ * window.open() when JS is available.
+ *
+ * Usage:
+ *   <a href="/some/path" class="js-popup"
+ *      data-popup-width="400" data-popup-height="300">Link text</a>
+ *
+ * @since 2026-08-31
+ */
+document.addEventListener('click', function (event) {
+    var link = event.target.closest('a.js-popup');
+    if (!link) return;
+
+    event.preventDefault();
+
+    var width = link.getAttribute('data-popup-width') || 400;
+    var height = link.getAttribute('data-popup-height') || 300;
+    var windowProps = 'height=' + height + ',width=' + width +
+        ',location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=0,screenY=0,top=0,left=0';
+
+    var popup = window.open(link.href, '', windowProps);
+    if (popup && popup.opener == null) {
+        popup.opener = window;
+    }
+});


### PR DESCRIPTION
Description:
The About and License footer links on the prevention data popups called popupStart(), a function that lives only in encounter.js, which neither AddPreventionData.jsp nor AddPreventionDataDisambiguate.jsp include. Clicking them did nothing but throw a silent ReferenceError in the console, so the links appeared completely dead with no visible error to the user.

Two obvious fixes were ruled out. Including all of encounter.js is not viable because it runs top-level initialization code on load that references a global encounterConfig object these two pages never define, which would throw errors immediately rather than fix anything. Replacing the links with a plain target="_blank" anchor is also not viable because License.jsp closes itself with window.close(), and browsers only honor that on windows that were actually opened by script, not on a normal navigation or a new tab.

The fix adds one small shared script, popupLink.js, that listens for clicks on any link tagged with a js-popup class and opens it with window.open() using the same window size and feature string popupStart() already uses everywhere else in the app, then prevents the default navigation. The links themselves keep real hrefs pointing at the actual routes, so they still work without JavaScript, support copy-link and middle-click, and degrade gracefully instead of relying entirely on script execution.

I tested this locally in the CARLOS devcontainer on both affected JSPs. On both pages, About and License now open a real script-opened popup window, and Close inside each popup actually closes it, confirming the window.close() requirement still holds. I also confirmed two popups can be open at the same time without interfering with each other, that right-click Copy Link gives the real URL rather than a javascript: string, and that Cmd+click opens the link in a normal browser tab. The browser console no longer shows the popupStart error, and no new console errors were introduced.

Related Issues

Closes #3437

How Was This Tested?
Manually verified in a local CARLOS devcontainer build against both AddPreventionData.jsp and AddPreventionDataDisambiguate.jsp: clicked About and License from each page, confirmed a script-opened popup appears, confirmed the Close link inside each popup actually closes the window, confirmed two popups can be open simultaneously without conflict, confirmed Copy Link yields the real route URL, confirmed Cmd+click opens a normal tab, and confirmed the console shows no popupStart error and no new errors from this change.

Checklist
Tick: commits are DCO signed off, commit follows Conventional Commits format, no PHI included, no new automated tests added since this is a small client-side JS fix verified manually in-browser (leave the "added tests" box as you see fit based on your judgment), and read the contributing guide.

## Summary by Sourcery

Fix dead About/License popup links on prevention data dialogs by opening them via script instead of a missing popupStart() function.

New Features:
- Added a shared popupLink.js script that opens links tagged with a js-popup class in a properly sized popup window while keeping real hrefs for copy-link, middle-click, and no-JS fallback support.

Bug Fixes:
- Fixed About and License footer links on AddPreventionData.jsp and AddPreventionDataDisambiguate.jsp that silently failed because they relied on popupStart(), a function not loaded on those pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the About and License footer links on the prevention data dialogs so clicking them opens a popup instead of failing silently because they called `popupStart()`, which those pages never load.

- Adds a shared `popupLink.js` script that opens any link tagged `js-popup` via `window.open()` using the same sizing as the rest of the app.
- Replaces dead `javascript:` hrefs with real URLs on `AddPreventionData.jsp` and `AddPreventionDataDisambiguate.jsp`.
- Real hrefs keep copy-link, middle-click, and no-JS navigation working; modified clicks (Cmd/Ctrl/Shift/Alt) fall through to native handling, and blocked popups fall back to normal navigation.
- Closes #3437.

<sup>Written for commit 8220a458ddc559169a370d6001483f7039a51818. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

