### PR TITLE
fix(release): remediate 2026.08 promotion findings

### DIFF
--- a/.github/workflows/maven-project.yml
+++ b/.github/workflows/maven-project.yml
@@ -330,6 +330,11 @@ jobs:
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
           persist-credentials: false
+      - name: Set up JDK 21 for hermetic source checks
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: Run encoder null-safety lint
         run: bash scripts/lint/check-encoder-null-safety.sh
       - name: Run encoder null-safety lint fixtures
@@ -338,6 +343,8 @@ jobs:
         run: bash scripts/lint/check-security-exception-message-convention.sh
       - name: Run SecurityException message convention lint fixtures
         run: bash scripts/lint/test-security-exception-message-convention.sh
+      - name: Run Struts DTD validation
+        run: bash scripts/lint/check-struts-dtd.sh
   jspc:
     needs: build
     runs-on: ubuntu-latest

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,8 @@ carlos-emr (2026.09.0~snapshot18) resolute; urgency=medium
     validation also waits for tickler deletion to commit before asserting it.
   * Enforce the hermetic Struts DTD validation in CI and clean up the snapshot
     changelog metadata used by Debian package linting.
+  * Exclude transient eChart note locks from the optional demonstration dataset
+    and reject them at package-build time.
 
  -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Mon, 31 Aug 2026 17:56:11 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+carlos-emr (2026.09.0~snapshot18) resolute; urgency=medium
+
+  * Document upload name collisions retain their recoverable JSON response but
+    never attach the path-bearing exception to a log event. The packaged UI
+    validation also waits for tickler deletion to commit before asserting it.
+  * Enforce the hermetic Struts DTD validation in CI and clean up the snapshot
+    changelog metadata used by Debian package linting.
+
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Mon, 31 Aug 2026 17:56:11 +0000
+
 carlos-emr (2026.09.0~snapshot17) resolute; urgency=medium
 
   * A tainted error body that cannot be replaced is now discarded instead of
@@ -8,7 +18,7 @@ carlos-emr (2026.09.0~snapshot17) resolute; urgency=medium
     as a container 500. The captured body is dropped instead: nothing unsafe
     reaches the client, and the client keeps the response it was already sent.
 
- -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sat, 30 Aug 2026 21:15:00 +0000
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sun, 30 Aug 2026 21:15:00 +0000
 
 carlos-emr (2026.09.0~snapshot16) resolute; urgency=medium
 
@@ -27,7 +37,7 @@ carlos-emr (2026.09.0~snapshot16) resolute; urgency=medium
     destination path, which ends in the uploader's filename, and scanned
     clinical documents are routinely named after the patient.
 
- -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sat, 30 Aug 2026 19:30:00 +0000
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sun, 30 Aug 2026 19:30:00 +0000
 
 carlos-emr (2026.09.0~snapshot15) resolute; urgency=medium
 
@@ -46,7 +56,7 @@ carlos-emr (2026.09.0~snapshot15) resolute; urgency=medium
     and its passthrough streams shield the real response from a mid-chain
     close.
 
- -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sat, 30 Aug 2026 16:00:00 +0000
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sun, 30 Aug 2026 16:00:00 +0000
 
 carlos-emr (2026.09.0~snapshot14) resolute; urgency=medium
 
@@ -122,7 +132,7 @@ carlos-emr (2026.09.0~snapshot14) resolute; urgency=medium
     at the start of the argument and cannot match an eForm document, so the
     exclusion only widened the rule surface. attack-lfi, which does fire, stays.
 
- -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sat, 30 Aug 2026 03:30:00 +0000
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sun, 30 Aug 2026 03:30:00 +0000
 
 carlos-emr (2026.09.0~snapshot5) resolute; urgency=medium
 

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -8,8 +8,8 @@ bare Tomcat.
 
 It is the procedure that first surfaced the WAF false positives on note-saving
 and eForm saves, the add-patient validation regression, and the nullable-column
-500s on the consultation surfaces. Last validated end-to-end 2026-08-29 with
-**37/37 scripts passing** on 2026.09.0~snapshot4.
+500s on the consultation surfaces. Last validated end-to-end 2026-08-31 with
+**41/41 scripts passing** on 2026.09.0~snapshot18.
 
 That 37/37 is also the cautionary tale for this document. A tester found six
 defects on the build that produced it — an eForm editor save 403, an eForm

--- a/scripts/check-demo-additive.sh
+++ b/scripts/check-demo-additive.sh
@@ -10,6 +10,7 @@
 #     Flyway owns;
 #   * every insert target exists in the target province's Flyway schema and
 #     is not on the exclusion list;
+#   * transient eChart note-lock state is never shipped;
 #   * the known real-person names are gone;
 #   * (with the source snapshot given) every table development.sql inserts
 #     into is either transformable or consciously excluded — a snapshot
@@ -76,6 +77,13 @@ plain_inserts=$(grep -E '^[[:space:]]*INSERT[[:space:]]' "$ARTIFACT" \
   | grep -cvE '^[[:space:]]*INSERT[[:space:]]+IGNORE[[:space:]]+INTO[[:space:]]' || true)
 if [ "${plain_inserts}" -gt 0 ]; then
   err "artifact contains ${plain_inserts} plain INSERT statement(s) (must be INSERT IGNORE so Flyway rows win)"
+fi
+
+# Chart-note locks represent live browser sessions, not demonstration data.
+# Keep this invariant explicit so a misplaced exclusion-list entry cannot
+# silently package stale locks that make an eChart unusable after install.
+if grep -qE '^[[:space:]]*INSERT[[:space:]]+IGNORE[[:space:]]+INTO[[:space:]]+`?casemgmt_note_lock`?([[:space:]]|$)' "$ARTIFACT"; then
+  err "artifact contains transient eChart note locks"
 fi
 
 # --- real-name blocklist ------------------------------------------------------

--- a/scripts/demo-additive-exclude.txt
+++ b/scripts/demo-additive-exclude.txt
@@ -109,6 +109,9 @@ ServiceAccessToken
 ServiceRequestToken
 
 # --- OPS: operational noise ---
+# Concurrent chart-note locks are session-scoped runtime state. Snapshot rows
+# point at long-expired sessions and make demo eCharts appear locked.
+casemgmt_note_lock
 log
 table_modification
 property

--- a/scripts/lint/check-struts-dtd.sh
+++ b/scripts/lint/check-struts-dtd.sh
@@ -6,11 +6,8 @@
 # accidentally landing at package level next to a self-closing <action/>, for
 # example -- passes every XML parse, compiles, packages, and then takes the
 # WHOLE application down at deploy with "Dispatcher initialization failed". That
-# exact failure shipped in a local build once; run this before pushing any
-# struts*.xml change. Wiring it into the CI lint job is a one-line follow-up a
-# maintainer must make (add a setup-java step + `bash scripts/lint/check-struts-dtd.sh`
-# to the lint job in .github/workflows/maven-project.yml) -- workflow files are
-# protected, so this commit ships the check and the vendored DTD, not the wiring.
+# exact failure shipped in a local build once. The CI source-lint job runs this
+# check with JDK 21, and it remains useful locally before pushing struts*.xml changes.
 #
 # The DTD is vendored under scripts/lint/dtd so the check is hermetic -- no jar
 # hunting, no Maven, no network -- and it validates with a tiny SAX program that

--- a/scripts/lint/dtd/struts-6.5.dtd
+++ b/scripts/lint/dtd/struts-6.5.dtd
@@ -155,4 +155,3 @@
 >
 
 <!-- END SNIPPET: strutsDtd -->
-

--- a/scripts/tickler-crud-playwright-checks.js
+++ b/scripts/tickler-crud-playwright-checks.js
@@ -214,19 +214,74 @@ async function waitForTicklerListReady(page) {
 }
 
 async function setTicklerListStatus(page, status) {
-  await page.locator('#ticklerview').selectOption(status);
-  await page.waitForFunction((expectedStatus) => {
+  const statusSelect = page.locator('#ticklerview');
+  const currentStatus = await statusSelect.inputValue();
+
+  // Selecting the current value still fires DataTables' change handler. A
+  // second ajax.reload() can replace a checkbox after Playwright checks it but
+  // before the form is submitted, producing a valid no-op POST. Do not create
+  // that reload when the requested filter is already active.
+  if (currentStatus === status) {
+    await page.waitForFunction(() => {
+      const table = window.jQuery && window.jQuery('#ticklerResults').DataTable();
+      if (!table) {
+        return false;
+      }
+      const settings = table.settings()[0];
+      return !settings.bDrawing && (!settings.jqXHR || settings.jqXHR.readyState === 4);
+    }, null, { timeout: 30000 });
+    return;
+  }
+
+  const previousDraw = await page.evaluate(() => (
+    window.jQuery('#ticklerResults').DataTable().settings()[0].iDraw
+  ));
+  const [listResponse] = await Promise.all([
+    page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return response.request().method() === 'GET'
+        && url.pathname.endsWith('/tickler/ListTicklers')
+        && url.searchParams.get('status') === status;
+    }, { timeout: 30000 }),
+    statusSelect.selectOption(status),
+  ]);
+  assert(listResponse.status() < 400, `tickler list reload returned HTTP ${listResponse.status()}`);
+
+  await page.waitForFunction(({ expectedStatus, previousDraw }) => {
     const table = window.jQuery && window.jQuery('#ticklerResults').DataTable();
-    return table && document.getElementById('ticklerview').value === expectedStatus;
-  }, status, { timeout: 30000 }).catch(() => {});
+    if (!table) {
+      return false;
+    }
+    const settings = table.settings()[0];
+    return document.getElementById('ticklerview').value === expectedStatus
+      && settings.iDraw > previousDraw
+      && !settings.bDrawing
+      && (!settings.jqXHR || settings.jqXHR.readyState === 4);
+  }, { expectedStatus: status, previousDraw }, { timeout: 30000 });
 }
 
 async function findRowInList(page, message, expectedStatus) {
   await page.locator('#ticklerResults_filter input[type="search"]').fill('');
+  const previousDraw = await page.evaluate(() => (
+    window.jQuery('#ticklerResults').DataTable().settings()[0].iDraw
+  ));
   await page.evaluate(() => {
     window.jQuery('#ticklerResults').DataTable().search('').order([4, 'desc']).draw();
   });
   try {
+    // DataTables keeps the old tbody visible while a server-side draw is in
+    // flight. Waiting only for a visible row can therefore return a checkbox
+    // that is about to be detached, losing its checked state at submit time.
+    await page.waitForFunction((previousDraw) => {
+      const table = window.jQuery && window.jQuery('#ticklerResults').DataTable();
+      if (!table) {
+        return false;
+      }
+      const settings = table.settings()[0];
+      return settings.iDraw > previousDraw
+        && !settings.bDrawing
+        && (!settings.jqXHR || settings.jqXHR.readyState === 4);
+    }, previousDraw, { timeout: 30000 });
     await page.locator('#ticklerResults tbody tr').filter({ hasText: message }).first().waitFor({
       state: 'visible',
       timeout: 30000,
@@ -364,7 +419,10 @@ async function deleteTicklerFromList(page, message) {
   await setTicklerListStatus(page, 'C');
   await findRowInList(page, message, 'C');
   const rowLocator = page.locator('#ticklerResults tbody tr').filter({ hasText: message }).first();
-  await rowLocator.locator('input[name="checkbox"]').check();
+  const checkbox = rowLocator.locator('input[name="checkbox"]');
+  const selectedTicklerNo = await checkbox.getAttribute('value');
+  assert(selectedTicklerNo, 'tickler delete checkbox had no tickler id');
+  await checkbox.check();
   const [deleteResponse] = await Promise.all([
     page.waitForResponse((response) => {
       const request = response.request();
@@ -375,6 +433,11 @@ async function deleteTicklerFromList(page, message) {
     page.locator("form[name='ticklerform'] input.btn-danger").click(),
   ]);
   assert(deleteResponse.status() < 400, `tickler delete returned HTTP ${deleteResponse.status()}`);
+  const deleteForm = new URLSearchParams(deleteResponse.request().postData() || '');
+  assert(deleteForm.getAll('checkbox').includes(selectedTicklerNo),
+    `tickler delete POST omitted selected id ${selectedTicklerNo}`);
+  assert(/^d/i.test(deleteForm.get('submit_form') || ''),
+    `tickler delete POST had unexpected submit_form=${deleteForm.get('submit_form')}`);
   await waitForTicklerListReady(page);
 
   await waitForTicklerStatus('D');

--- a/scripts/tickler-crud-playwright-checks.js
+++ b/scripts/tickler-crud-playwright-checks.js
@@ -139,6 +139,19 @@ function getTicklerRows() {
   });
 }
 
+async function waitForTicklerStatus(expectedStatus, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let rows = [];
+  while (Date.now() < deadline) {
+    rows = getTicklerRows();
+    if (rows.length === 1 && rows[0].status === expectedStatus) {
+      return rows[0];
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`tickler did not reach status ${expectedStatus}; last rows=${JSON.stringify(rows)}`);
+}
+
 function getCommentRows(ticklerNo) {
   const out = sql(
     `SELECT message FROM tickler_comments WHERE tickler_no=${Number(ticklerNo)} ORDER BY id`
@@ -352,14 +365,19 @@ async function deleteTicklerFromList(page, message) {
   await findRowInList(page, message, 'C');
   const rowLocator = page.locator('#ticklerResults tbody tr').filter({ hasText: message }).first();
   await rowLocator.locator('input[name="checkbox"]').check();
-  await Promise.all([
-    page.waitForLoadState('domcontentloaded').catch(() => {}),
+  const [deleteResponse] = await Promise.all([
+    page.waitForResponse((response) => {
+      const request = response.request();
+      return request.method() === 'POST'
+        && new URL(response.url()).pathname.endsWith('/tickler/DbTicklerMain');
+    }, { timeout: 30000 }),
+    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 30000 }),
     page.locator("form[name='ticklerform'] input.btn-danger").click(),
   ]);
+  assert(deleteResponse.status() < 400, `tickler delete returned HTTP ${deleteResponse.status()}`);
   await waitForTicklerListReady(page);
 
-  const rows = getTicklerRows();
-  assert(rows.length === 1 && rows[0].status === 'D', `deleted tickler status was ${rows[0] && rows[0].status}`);
+  await waitForTicklerStatus('D');
 }
 
 (async () => {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
@@ -373,7 +373,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
         }
     }
 
-    void recordDuplicateUploadError(HashMap<String, Object> map, ResourceBundle props) {
+    void recordDuplicateUploadError(java.util.Map<String, Object> map, ResourceBundle props) {
         // Keep this message constant and do not attach the collision exception: its message is the
         // destination path, which ends in the uploader-supplied clinical document filename.
         logger.warn("Uploaded document name already taken; asking the user to retry");

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
@@ -215,8 +215,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
                 newDoc.setNumberOfPages(numberOfPages);
                 doc_no = EDocUtil.addDocumentSQL(newDoc);
             } catch (FileAlreadyExistsException e) {
-                logger.warn("Uploaded document name already taken; asking the user to retry", e);
-                map.put("error", props.getString("dms.addDocument.errorDuplicate"));
+                recordDuplicateUploadError(map, props);
             } catch (Exception e) {
                 // If the write succeeded and only the insert failed, the file is left in
                 // the document store with no row pointing at it. That is litter rather
@@ -327,7 +326,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
      */
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
-    private void writeLocalFile(File docFile, String fileName) throws Exception {
+    void writeLocalFile(File docFile, String fileName) throws Exception {
         String documentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         if (!documentDir.endsWith(File.separator)) {
             documentDir += File.separator;
@@ -363,10 +362,22 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
             while ((i = fis.read(buf)) != -1) {
                 fos.write(buf, 0, i);
             }
+        } catch (FileAlreadyExistsException e) {
+            // FileAlreadyExistsException's message is the destination path. Uploaded scans are
+            // routinely named after patients, so let the caller translate this recoverable
+            // collision without attaching the exception to a log event.
+            throw e;
         } catch (Exception e) {
             logger.error("Error writing local file", e);
             throw e;
         }
+    }
+
+    void recordDuplicateUploadError(HashMap<String, Object> map, ResourceBundle props) {
+        // Keep this message constant and do not attach the collision exception: its message is the
+        // destination path, which ends in the uploader-supplied clinical document filename.
+        logger.warn("Uploaded document name already taken; asking the user to retry");
+        map.put("error", props.getString("dms.addDocument.errorDuplicate"));
     }
 
     private WriteToIncomingDocsResult writeToIncomingDocs(File docFile, File destinationFile) {

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
@@ -1,8 +1,10 @@
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.documentManager.IncomingDocUtil;
 import io.github.carlos_emr.carlos.managers.NioFileManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
@@ -18,11 +20,15 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.ResourceBundle;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -44,9 +50,15 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
     private File tempUploadDirectory;
     private File tempDestinationFile;
     private File tempDestinationDirectory;
+    private String originalDocumentDir;
+    private boolean originalDocumentDirPresent;
+    private boolean documentDirCaptured;
 
     @BeforeEach
     void setUp() {
+        originalDocumentDirPresent = CarlosProperties.getInstance().containsKey("DOCUMENT_DIR");
+        originalDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+        documentDirCaptured = true;
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
         servletActionContextMock = mockStatic(ServletActionContext.class);
@@ -70,6 +82,13 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
     void tearDown() throws Exception {
         Exception cleanupFailure = null;
 
+        if (documentDirCaptured) {
+            if (originalDocumentDirPresent) {
+                CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", originalDocumentDir);
+            } else {
+                CarlosProperties.getInstance().remove("DOCUMENT_DIR");
+            }
+        }
         cleanupFailure = deleteIfExists(tempDestinationFile, cleanupFailure);
         cleanupFailure = deleteIfExists(tempUploadFile, cleanupFailure);
         cleanupFailure = deleteIfExists(tempDestinationDirectory, cleanupFailure);
@@ -166,6 +185,60 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
                     .doesNotContain("error");
             assertThat(tempDestinationFile).exists();
             assertThat(tempUploadFile).doesNotExist();
+        }
+    }
+
+    @Test
+    @DisplayName("document upload collision should not log a patient-like filename or path")
+    void documentUploadCollisionShouldNotLogFilenameOrPath() throws Exception {
+        String patientLikeFilename = "DOE_JANE_123456.pdf";
+        tempUploadFile = File.createTempFile("document-upload", ".pdf");
+        Files.writeString(tempUploadFile.toPath(), "new scan");
+        tempDestinationDirectory = Files.createTempDirectory("document-store").toFile();
+        tempDestinationFile = tempDestinationDirectory.toPath().resolve(patientLikeFilename).toFile();
+        Files.writeString(tempDestinationFile.toPath(), "existing scan");
+        CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", tempDestinationDirectory.getPath());
+
+        DocumentUpload2Action action = new DocumentUpload2Action();
+        HashMap<String, Object> responseMap = new HashMap<>();
+        ResourceBundle props = ResourceBundle.getBundle("oscarResources");
+
+        try (LogCapture logs = LogCapture.forLogger(DocumentUpload2Action.class)) {
+            assertThatThrownBy(() -> action.writeLocalFile(tempUploadFile, patientLikeFilename))
+                    .isInstanceOf(FileAlreadyExistsException.class);
+            assertThat(logs.events()).isEmpty();
+
+            action.recordDuplicateUploadError(responseMap, props);
+
+            assertThat(responseMap.get("error"))
+                    .isEqualTo(props.getString("dms.addDocument.errorDuplicate"));
+            assertThat(logs.events()).singleElement().satisfies(event -> {
+                assertThat(event.getThrown()).isNull();
+                assertThat(event.getMessage().getFormattedMessage())
+                        .isEqualTo("Uploaded document name already taken; asking the user to retry")
+                        .doesNotContain(patientLikeFilename)
+                        .doesNotContain(tempDestinationFile.getPath());
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("document upload I/O failure should retain diagnostic exception logging")
+    void documentUploadIoFailureShouldRetainDiagnosticLogging() throws Exception {
+        tempUploadFile = File.createTempFile("document-upload-missing", ".pdf");
+        Files.delete(tempUploadFile.toPath());
+        tempDestinationDirectory = Files.createTempDirectory("document-store").toFile();
+        CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", tempDestinationDirectory.getPath());
+
+        DocumentUpload2Action action = new DocumentUpload2Action();
+        try (LogCapture logs = LogCapture.forLogger(DocumentUpload2Action.class)) {
+            assertThatThrownBy(() -> action.writeLocalFile(tempUploadFile, "diagnostic.pdf"))
+                    .isInstanceOf(IOException.class);
+
+            assertThat(logs.events()).singleElement().satisfies(event -> {
+                assertThat(event.getThrown()).isInstanceOf(IOException.class);
+                assertThat(event.getMessage().getFormattedMessage()).isEqualTo("Error writing local file");
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

Remediates the findings from the final `release/2026.08` promotion review:

- prevent a recoverable document-name collision from logging its path-bearing exception while retaining useful exception logging for genuine I/O failures;
- add regression coverage for both collision and I/O-error logging behavior;
- enforce hermetic Struts DTD validation in Maven CI and remove the stale byte from the pinned DTD;
- make the tickler Playwright flow wait for server-side DataTables redraws and committed deletion, avoiding detached-row and status-filter races;
- exclude transient `casemgmt_note_lock` rows from the optional demo dataset and make their presence a package-build failure;
- update snapshot18 release metadata and the Debian validation runbook.

The note-lock exclusion fixes a package defect reproduced on a fresh installation: the development snapshot contained eight locks from 2024, including one for demographic 1, which made the demo eChart report a competing editor and could produce a real 500.

## Source validation

- Full Maven suite: **10,086 tests**, 0 failures, 0 errors, 49 skipped.
- Focused document-upload suite: 8 tests passed.
- Repository lint scripts, Struts DTD check, Node syntax checks, Bash syntax checks, and `git diff --check` passed.
- Ontario and BC demo transforms passed the additive-data gate; an injected `casemgmt_note_lock` statement was rejected as expected.

## Debian package validation

Built exact commit `b69c2bda499e3fc7f8959488705ff1e18a40fc8b` as `2026.09.0~snapshot18`:

| Package | SHA-256 |
| --- | --- |
| `carlos-emr_2026.09.0~snapshot18_all.deb` | `4fb8552a2efe5540fd85adde483a2491faca4f2c1a8bb4003b2ac44f9b58901d` |
| `carlos-emr-drugref_2026.09.0~snapshot18_all.deb` | `3d9d928db7a52ef44b6c50195c5da7a3606728e85a9378409f7053f2ec6ff864` |
| `carlos-emr-eform-renderer_2026.09.0~snapshot18_amd64.deb` | `c56bfd60f621611c095d6b8643d494bf0b7351dd15a1561716ac4f904a2f1343` |

- `lintian --fail-on error` passed. Remaining output is the known manpage groff warning and systemctl maintainer-script warnings.
- The packaged WAR embeds the exact commit SHA above.
- Neither packaged province demo payload contains `casemgmt_note_lock`.

## Fresh Ubuntu 26.04 VM validation

The previous test VM was deleted and recreated from Ubuntu 26.04 before installation.

- Noninteractive fresh install of all three exact packages with the optional demo dataset enabled passed.
- `carlos-ctl check`: all checks passed.
- Installed package versions/architectures and embedded Git SHA matched the artifacts above.
- Immediately after demo installation: `SELECT COUNT(*) FROM casemgmt_note_lock` returned **0**.
- Repaired tickler CRUD Playwright check passed **5 consecutive runs**.
- The previously failing sequence passed: browser-surface check followed immediately by eChart check.
- Standard Playwright suite in `scripts/`: **41/41 passed** (excluding the separately provisioned eForm corpus soak, per the runbook).
- Same-version reinstall of all three exact package files passed; post-reinstall restart and `carlos-ctl check` passed.
- Validation VM was stopped after testing.

## Promotion recommendation

Ready for promotion to `main` after this PR's required GitHub checks pass and review is complete.

## Summary by Sourcery

Remediate release-promotion findings across document upload privacy, demo data integrity, CI validation, and tickler UI test reliability.

Bug Fixes:
- Prevent recoverable document-name collisions from logging path-bearing exceptions while preserving diagnostic logging for genuine I/O failures.
- Stabilize tickler Playwright CRUD validation by waiting for completed DataTables redraws and committed deletion state.
- Prevent transient eChart note-lock records from being included in optional demo datasets.

Enhancements:
- Add regression coverage for document-upload collision and I/O-error logging behavior.
- Enforce hermetic Struts DTD validation in the Maven CI source-check job.

Build:
- Reject demo package artifacts containing transient casemgmt_note_lock rows.
- Remove the stale byte from the vendored Struts DTD.

CI:
- Run the Struts DTD validation check in Maven CI with JDK 21.

Documentation:
- Update Debian installation validation documentation with snapshot18 metadata and the latest Playwright validation results.

Tests:
- Add document-upload logging regression tests and strengthen tickler CRUD synchronization checks.

Chores:
- Update snapshot18 Debian release metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remediates the final 2026.08 promotion review findings across document upload, demo data, and UI test stability.

**Changes**

- Document upload name collisions keep their recoverable JSON response but no longer attach the path-bearing exception to log events; regression tests cover both collision and I/O-error paths.
- CI now runs the hermetic Struts DTD check under JDK 21 and removes the stale trailing byte from the vendored DTD.
- The tickler Playwright flow now waits for server-side DataTables redraws and committed deletion, preventing detached-row and status-filter races.
- The optional demo dataset no longer includes transient `casemgmt_note_lock` rows, and their presence now fails the package build—these stale locks previously made demo eCharts appear locked by a competing editor.
- Updated snapshot18 release metadata and the Debian validation runbook.

<sup>Written for commit 97808269229dc36621d43e96cb33701e8ee21e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

