### PR TITLE
fix(documentManager): preserve submitted eDoc metadata on HTML/link validation retry

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
@@ -225,20 +225,45 @@ public class AddEditHtml2Action extends ActionSupport {
 
 
     /**
-     * The form bean addDocument.jsp re-renders a failed submission from.
+     * The form bean addedithtmldocument.jsp re-renders a failed submission from.
      *
-     * <p>Every validation-failure branch below used to put the empty STRING under this attribute,
-     * and the JSP casts it to {@link AddEditDocument2Form} — so a user who left the description,
-     * the type or the URL blank got a ClassCastException and a 500 instead of the field message
-     * the branch had just built. Populating it from the submitted values also means their typing
-     * survives the round trip rather than being silently cleared.</p>
+     * <p>Every validation-failure branch below stashes this under the {@code completedForm} request
+     * attribute, and the JSP casts it to {@link AddEditDocument2Form} — so a user who left the
+     * description, the type or the URL blank got a ClassCastException and a 500 instead of the field
+     * message the branch had just built. Populating it from the submitted values also means their
+     * typing survives the round trip rather than being silently cleared.</p>
+     *
+     * <p>The retry bean must carry <em>every</em> value the JSP reads back, not just the field the
+     * user was fixing. addedithtmldocument.jsp rebuilds the whole edit form — visible fields and
+     * hidden inputs alike — from this bean, re-POSTing {@code docCreator}, {@code responsibleId},
+     * {@code observationDate}, {@code source}, {@code sourceFacility}, {@code docClass},
+     * {@code docSubClass}, {@code docPublic} and the reviewer fields as form inputs. Any submitted
+     * field dropped here comes back blank, so the user's next (now valid) submission would persist
+     * the eDoc with a blank creator/date/source and lost classification or public-visibility
+     * metadata. Copying only function/type/description/html — as this method originally did —
+     * silently discarded the rest; keep this in sync with the inputs the JSP renders.</p>
+     *
+     * <p>Package-private, not private, so {@code AddEditHtml2ActionUnitTest} can pin the
+     * preserved-field set directly: {@code execute()} reaches static {@code EDocUtil} database calls
+     * before its validation branches, which a focused unit test should not have to stand up.</p>
      */
-    private AddEditDocument2Form submittedForm() {
+    AddEditDocument2Form submittedForm() {
         AddEditDocument2Form form = new AddEditDocument2Form();
         form.setFunction(this.getFunction());
         form.setFunctionId(this.getFunctionId());
         form.setDocType(this.getDocType());
+        form.setDocClass(this.getDocClass());
+        form.setDocSubClass(this.getDocSubClass());
         form.setDocDesc(this.getDocDesc());
+        form.setDocCreator(this.getDocCreator());
+        form.setResponsibleId(this.getResponsibleId());
+        form.setSource(this.getSource());
+        form.setSourceFacility(this.getSourceFacility());
+        form.setObservationDate(this.getObservationDate());
+        form.setContentDateTime(this.getContentDateTime());
+        form.setDocPublic(this.getDocPublic());
+        form.setReviewerId(this.getReviewerId());
+        form.setReviewDateTime(this.getReviewDateTime());
         form.setHtml(this.getHtml());
         return form;
     }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2ActionUnitTest.java
@@ -12,6 +12,7 @@
  */
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.carlos.documentManager.data.AddEditDocument2Form;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 
@@ -86,5 +87,50 @@ class AddEditHtml2ActionUnitTest extends CarlosUnitTestBase {
                 .isAnnotationPresent(StrutsParameter.class))
                 .as("setFunctionid must be @StrutsParameter-annotated or Struts will not bind it")
                 .isTrue();
+    }
+
+    @Test
+    @DisplayName("should preserve every submitted field the retry form re-renders")
+    void shouldPreserveSubmittedMetadata_whenBuildingRetryForm() {
+        AddEditHtml2Action action = new AddEditHtml2Action();
+        action.setFunction("demographic");
+        action.setFunctionId("42");
+        action.setDocType("Lab");
+        action.setDocClass("Consultant Report");
+        action.setDocSubClass("Cardiology");
+        action.setDocDesc("Echocardiogram");
+        action.setDocCreator("101");
+        action.setResponsibleId("202");
+        action.setSource("Referring MD");
+        action.setSourceFacility("General Hospital");
+        action.setObservationDate("2026/08/30");
+        action.setContentDateTime("2026/08/30 09:15:00");
+        action.setDocPublic("checked");
+        action.setReviewerId("303");
+        action.setReviewDateTime("2026-08-31 10:00:00");
+        action.setHtml("<p>report body</p>");
+
+        AddEditDocument2Form retry = action.submittedForm();
+
+        // addedithtmldocument.jsp rebuilds each of these as a visible or hidden form input on the
+        // validation-retry render, so a field dropped from the retry bean is re-POSTed blank and
+        // then persisted over the eDoc's real creator/date/source/classification/visibility.
+        // Assert the whole set, not just the field the user was fixing.
+        assertThat(retry.getFunction()).isEqualTo("demographic");
+        assertThat(retry.getFunctionId()).isEqualTo("42");
+        assertThat(retry.getDocType()).isEqualTo("Lab");
+        assertThat(retry.getDocClass()).isEqualTo("Consultant Report");
+        assertThat(retry.getDocSubClass()).isEqualTo("Cardiology");
+        assertThat(retry.getDocDesc()).isEqualTo("Echocardiogram");
+        assertThat(retry.getDocCreator()).isEqualTo("101");
+        assertThat(retry.getResponsibleId()).isEqualTo("202");
+        assertThat(retry.getSource()).isEqualTo("Referring MD");
+        assertThat(retry.getSourceFacility()).isEqualTo("General Hospital");
+        assertThat(retry.getObservationDate()).isEqualTo("2026/08/30");
+        assertThat(retry.getContentDateTime()).isEqualTo("2026/08/30 09:15:00");
+        assertThat(retry.getDocPublic()).isEqualTo("checked");
+        assertThat(retry.getReviewerId()).isEqualTo("303");
+        assertThat(retry.getReviewDateTime()).isEqualTo("2026-08-31 10:00:00");
+        assertThat(retry.getHtml()).isEqualTo("<p>report body</p>");
     }
 }


### PR DESCRIPTION
## Description

The Codex review on **PR #3569** (the 2026.08 alpha10 promotion) flagged a P1 data-integrity
issue in `AddEditHtml2Action`. This is the supported-release fix, landed on `release/2026.08` so the
alpha10 promotion carries it forward.

**Root cause:** `AddEditHtml2Action.submittedForm()` rebuilt the validation-retry bean
(`completedForm`) from only 5 fields — `function`, `functionId`, `docType`, `docDesc`, `html`. But
`addedithtmldocument.jsp` re-renders the **entire** edit form from that bean, reading back 16 fields
as visible and hidden inputs. The 11 dropped fields —

`docCreator`, `responsibleId`, `observationDate`, `source`, `sourceFacility`, `docClass`,
`docSubClass`, `docPublic`, `reviewerId`, `reviewDateTime`, `contentDateTime`

— came back blank. So when a user hit a validation error (e.g. blank description), fixed it, and
resubmitted, the now-valid submission persisted the eDoc with a **blank creator/date/source and lost
classification or public-visibility metadata**. `docPublic` in particular controls whether the
document is patient-visible, so silently clearing it is a privacy-relevant regression.

**Fix:** populate the retry bean from every field the JSP reads back, and pin it so it can't silently
regress again.

## Changes

- `AddEditHtml2Action.submittedForm()` now copies all 16 fields `addedithtmldocument.jsp` renders,
  not just 5. `docPublic` round-trips its `"checked"` submit value unchanged. Method made
  package-private (was `private`) with JavaDoc explaining the JSP coupling.
- `AddEditHtml2ActionUnitTest`: new `shouldPreserveSubmittedMetadata_whenBuildingRetryForm` asserts
  the full preserved-field set, so a future trim of `submittedForm()` breaks the build rather than
  the metadata.

No behavior change on the success path; only the validation-retry render is corrected.

## Related Issues

Addresses the Codex P1 finding on PR #3569 (`AddEditHtml2Action.java` retry bean). No separate issue
was filed.

## Target Branch

Targets `release/2026.08` per `docs/release-process.md`: a correctness fix for a supported release
starts from and targets its `release/YYYY.MM` branch, then is forward-merged (the in-flight alpha10
promotion picks it up). It intentionally does **not** touch the maintenance-branch `-SNAPSHOT`
version or its `HEAD` SCM tag.

## How Was This Tested?

- `mvn -Dtest=AddEditHtml2ActionUnitTest test` → `Tests run: 2, Failures: 0, Errors: 0` (the new
  metadata-preservation test plus the existing lowercase-`functionid` binding test).
- Verified against `addedithtmldocument.jsp`: the preserved set is exactly the fields the JSP
  re-renders (`getFunction`, `getFunctionId`, `getDocType`, `getDocClass`, `getDocSubClass`,
  `getDocDesc`, `getDocCreator`, `getResponsibleId`, `getSource`, `getSourceFacility`,
  `getObservationDate`, `getContentDateTime`, `getDocPublic`, `getReviewerId`, `getReviewDateTime`,
  `getHtml`).

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata (no `pom.xml` version/tag change here)
- [x] I did not modify a Flyway migration that exists in a published release tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1TeHoPz93ayfXGvPrEX2D)_

## Summary by Sourcery

Preserve submitted eDoc metadata across HTML document validation retries to prevent valid resubmissions from overwriting document details.

Bug Fixes:
- Preserve all submitted eDoc metadata when rebuilding the HTML document form after validation errors, preventing metadata loss on retry and resubmission.

Enhancements:
- Expose the retry-form builder for focused verification and document its required coupling with the edit form fields.

Tests:
- Add unit coverage confirming every field re-rendered by the retry form, including classification, creator, dates, source, reviewer, and visibility metadata, is preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data-integrity bug where a validation retry on the HTML/link edit form silently cleared the eDoc's creator, dates, source, classification, and `docPublic` visibility flag. The retry bean now carries all 16 fields `addedithtmldocument.jsp` re-renders instead of 5, so corrected resubmissions keep the metadata intact.

`submittedForm()` is now package-private with JavaDoc documenting the JSP coupling, and a new unit test pins the full preserved-field set so trimming it again breaks the build instead of the metadata.

<sup>Written for commit 72d1a42a22aacc0cddecdd437ddfafea00046dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

