### PR TITLE
fix(encounter): stop the eChart notes-pagination loop that never ends

### DIFF
--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -322,6 +322,16 @@ Notes on the contract:
   is not HTTPS. It creates its own timestamped probe eForm and deletes only
   that one; a failing run leaves the probe behind on purpose, so clear strays
   with `UPDATE eform SET status=0 WHERE form_name LIKE 'Playwright Admin CRUD %';`.
+- **`echart-new-patient-notes-playwright-checks.js` builds its own fixture** —
+  it creates a `PLAYWRIGHT-EC-<timestamp>` patient, books an appointment for
+  them, and opens the eChart from that appointment, which is the path the
+  notes-pagination loop was reported on. It deletes the patient, the
+  appointment and the note lock in its `finally`, including after a failure, so
+  repeat runs stay clean; clear strays from a killed run with
+  `SELECT demographic_no FROM demographic WHERE last_name LIKE 'PLAYWRIGHT-EC-%';`.
+  It shrinks the notes wrapper in the browser before watching the poll: the
+  pagination only fires when that pane overflows and sits at the top, which a
+  tall headless window never reproduces on its own.
 - **`error-sanitization-playwright-checks.js` provokes two real 500s on
   purpose**, and must also run through `:443`. It is the only check that
   exercises `ResponseSanitizationFilter`'s error-replacement path — every other

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -327,8 +327,20 @@ Notes on the contract:
   them, and opens the eChart from that appointment, which is the path the
   notes-pagination loop was reported on. It deletes the patient, the
   appointment and the note lock in its `finally`, including after a failure, so
-  repeat runs stay clean; clear strays from a killed run with
-  `SELECT demographic_no FROM demographic WHERE last_name LIKE 'PLAYWRIGHT-EC-%';`.
+  repeat runs stay clean. A run killed mid-flight (SIGINT/SIGKILL) skips that
+  `finally`; identify and remove any stray with
+
+  ```sql
+  SELECT demographic_no, last_name FROM demographic WHERE last_name LIKE 'PLAYWRIGHT-EC-%';
+  DELETE a, l, adm, arch, d
+    FROM demographic d
+    LEFT JOIN appointment a        ON a.demographic_no   = d.demographic_no
+    LEFT JOIN casemgmt_note_lock l ON l.demographic_no   = d.demographic_no
+    LEFT JOIN admission adm        ON adm.client_id      = d.demographic_no
+    LEFT JOIN demographicArchive arch ON arch.demographic_no = d.demographic_no
+   WHERE d.last_name LIKE 'PLAYWRIGHT-EC-%';
+  ```
+
   It shrinks the notes wrapper in the browser before watching the poll: the
   pagination only fires when that pane overflows and sits at the top, which a
   tall headless window never reproduces on its own.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:add-login-account-playwright": "node scripts/add-login-account-playwright-checks.js",
     "test:logout-broadcast-playwright": "node scripts/logout-broadcast-playwright-checks.js",
     "test:echart-playwright": "node scripts/echart-playwright-checks.js",
+    "test:echart-new-patient-playwright": "node scripts/echart-new-patient-notes-playwright-checks.js",
     "test:browser-surfaces-playwright": "node scripts/browser-surface-playwright-checks.js",
     "test:eform-admin-playwright": "node scripts/eform-admin-playwright-checks.js",
     "test:eform-admin-crud-playwright": "node scripts/eform-admin-crud-playwright-checks.js",

--- a/scripts/echart-new-patient-notes-playwright-checks.js
+++ b/scripts/echart-new-patient-notes-playwright-checks.js
@@ -280,36 +280,49 @@ async function openEchartFromAppointment(context, schedulePage, recorder, appoin
  * scrolled to the top — then waits for pagination to stop.
  */
 async function assertNotesPaginationSettles(echart) {
-  const geometry = await echart.locator('#encMainDivWrapper').first().evaluate((element) => {
+  const wrapper = echart.locator('#encMainDivWrapper').first();
+  const geometry = await wrapper.evaluate((element) => {
+    const original = { flex: element.style.flex, height: element.style.height };
     element.style.flex = 'none';
     element.style.height = '80px';
     element.scrollTop = 0;
-    return { scrollHeight: element.scrollHeight, clientHeight: element.clientHeight };
+    return { original, scrollHeight: element.scrollHeight, clientHeight: element.clientHeight };
   });
   assert(geometry.scrollHeight > geometry.clientHeight,
     `notes wrapper did not overflow, so the pagination poll was never armed: ${JSON.stringify(geometry)}`);
 
-  const deadline = Date.now() + POLL_TIMEOUT_MS;
-  let observed = notesRequests.length;
-  let stableSince = Date.now();
-  while (Date.now() < deadline) {
-    await echart.waitForTimeout(500);
-    if (notesRequests.length !== observed) {
-      observed = notesRequests.length;
-      stableSince = Date.now();
-    } else if (Date.now() - stableSince >= POLL_QUIET_MS) {
-      return;
+  try {
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    let observed = notesRequests.length;
+    let stableSince = Date.now();
+    while (Date.now() < deadline) {
+      await echart.waitForTimeout(500);
+      if (notesRequests.length !== observed) {
+        observed = notesRequests.length;
+        stableSince = Date.now();
+      } else if (Date.now() - stableSince >= POLL_QUIET_MS) {
+        return;
+      }
     }
+    throw new Error('notes pagination never stopped on a chart with no notes; '
+      + `${notesRequests.length} viewNotesOpt requests at offsets `
+      + `${notesRequests.map((r) => r.offset).join(', ')}`);
+  } finally {
+    // Give the chart its real size back before the throbber assertions and the
+    // settled screenshot, so neither is taken against an 80px pane.
+    await wrapper.evaluate((element, original) => {
+      element.style.flex = original.flex;
+      element.style.height = original.height;
+    }, geometry.original).catch(() => {});
   }
-  throw new Error('notes pagination never stopped on a chart with no notes; '
-    + `${notesRequests.length} viewNotesOpt requests at offsets `
-    + `${notesRequests.map((r) => r.offset).join(', ')}`);
 }
 
 (async () => {
   const recorder = createRecorder();
-  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  // Before the browser starts: a filesystem failure here would otherwise leave a
+  // launched Chromium with no finally to close it.
   initMysqlDefaults();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
   let demographicNo = null;
   try {
     const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1100 } });

--- a/scripts/echart-new-patient-notes-playwright-checks.js
+++ b/scripts/echart-new-patient-notes-playwright-checks.js
@@ -102,7 +102,13 @@ let mysqlDefaults = null;
 function initMysqlDefaults() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'echart-new-patient-'));
   const file = path.join(dir, 'mysql-defaults.cnf');
-  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  try {
+    fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  } catch (error) {
+    // Never leave a half-written file holding the database password behind.
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
   mysqlDefaults = { dir, file };
 }
 function cleanupMysqlDefaults() {
@@ -274,11 +280,14 @@ async function openEchartFromAppointment(context, schedulePage, recorder, appoin
  * scrolled to the top — then waits for pagination to stop.
  */
 async function assertNotesPaginationSettles(echart) {
-  await echart.locator('#encMainDivWrapper').first().evaluate((element) => {
+  const geometry = await echart.locator('#encMainDivWrapper').first().evaluate((element) => {
     element.style.flex = 'none';
     element.style.height = '80px';
     element.scrollTop = 0;
+    return { scrollHeight: element.scrollHeight, clientHeight: element.clientHeight };
   });
+  assert(geometry.scrollHeight > geometry.clientHeight,
+    `notes wrapper did not overflow, so the pagination poll was never armed: ${JSON.stringify(geometry)}`);
 
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   let observed = notesRequests.length;
@@ -366,7 +375,10 @@ async function assertNotesPaginationSettles(echart) {
         sql(`DELETE FROM demographic WHERE demographic_no=${leftover} AND last_name='${fixtureLastName}'`);
       }
     } catch (cleanupError) {
-      console.error(`WARN cleanup failed: ${cleanupError.message}`);
+      // A synthetic patient left in a clinical database is a failed run, not a warning:
+      // the next operator has no way to tell it apart from a real record at a glance.
+      console.error(`FAIL cleanup failed, fixture ${fixtureLastName} may remain: ${cleanupError.message}`);
+      process.exitCode = 1;
     }
     cleanupMysqlDefaults();
     await browser.close();

--- a/scripts/echart-new-patient-notes-playwright-checks.js
+++ b/scripts/echart-new-patient-notes-playwright-checks.js
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for the eChart notes-pagination loop, driven along
+ * the exact path it was reported on: create a demographic, book an appointment
+ * for it, open the eChart FROM that appointment, and watch the notes pane.
+ *
+ * The reported symptom was an eChart that "wants to keep loading notes" — the
+ * console filling with `loading: offset: 0 / 20 / 40 ...` at one request per
+ * second and a throbber that never cleared. A brand-new chart is what exposes
+ * it: there are no notes to scroll away from, so the notes wrapper stays at the
+ * top, which is the state that arms the 1s "load older notes" poll.
+ *
+ * The poll had no reachable stop condition. It decided "no more notes" by
+ * testing the response body for emptiness, but the notes fragment always emits
+ * bootstrap scripts, so an exhausted batch still came back non-empty; the one
+ * branch meant to break the loop cleared an interval handle that did not exist.
+ * The encounter layout also renders ChartNotes.jsp twice, which armed two polls
+ * and left the first one unstoppable — the pre-fix chart issued TWO pagination
+ * requests per second.
+ *
+ * What this check pins, in order:
+ *   1. a chart opened from an appointment renders its note editor at all
+ *      (the fix's first cut suppressed the second of the two initial loads and
+ *      produced an EMPTY notes pane — green pagination, no chart),
+ *   2. pagination settles instead of walking the offset forward forever,
+ *   3. the loading throbber clears,
+ *   4. only one poll is armed, so a settled chart makes no further requests.
+ *
+ * Step 2 is forced rather than hoped for: the poll only fires when the notes
+ * wrapper overflows AND sits at scrollTop 0. That is the state the reporter's
+ * window was in; a headless 1440x1100 window is not, so the check shrinks the
+ * wrapper to put the page in the reported state deterministically. Without that
+ * the check would pass on the broken build in a tall window.
+ *
+ * Requires the standard deb-install env contract (see
+ * docs/ui-tests/deb-install-validation.md §6):
+ *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN,
+ *   MYSQL_HOST/USER/PASSWORD/DATABASE (fixture lookup and cleanup)
+ * Optional: CHROME_PATH, ECHART_NEW_PATIENT_SCREENSHOT_DIR (default /tmp).
+ */
+
+const { chromium } = require('playwright');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  assert,
+  assertNotErrorPage,
+  buildFailureDetails,
+  createRecorder,
+  getLaunchOptions,
+  login,
+  screenshot,
+  validateBaseUrl,
+  wirePage,
+} = require('./eform-local-playwright-utils');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  screenshotDir: process.env.ECHART_NEW_PATIENT_SCREENSHOT_DIR || '/tmp',
+};
+const mysqlHost = process.env.MYSQL_HOST || '127.0.0.1';
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'carlos';
+
+// Unique, clearly synthetic name so a failed cleanup is identifiable and a
+// stray record can never be mistaken for a real patient. Kept short: the
+// column is varchar(30), and a name that gets truncated on save no longer
+// matches the lookup that finds (and later deletes) the fixture.
+const fixtureLastName = `PLAYWRIGHT-EC-${Date.now()}`;
+const fixtureFirstName = 'Notes';
+const appointmentReason = 'Notes pagination check';
+
+// The poll ticks once a second. Settled means no new fetch for several ticks;
+// the cap keeps a legitimately long chart from hanging the check while still
+// failing a loop that never ends.
+const POLL_QUIET_MS = 5000;
+const POLL_TIMEOUT_MS = 40000;
+
+const notesRequests = [];
+
+let mysqlDefaults = null;
+function initMysqlDefaults() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'echart-new-patient-'));
+  const file = path.join(dir, 'mysql-defaults.cnf');
+  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  mysqlDefaults = { dir, file };
+}
+function cleanupMysqlDefaults() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+function sql(query) {
+  assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', mysqlHost, '-u', mysqlUser, mysqlDatabase, '-N', '-B', '-e', query,
+  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000 }).trim();
+}
+
+/**
+ * Records every notes-pagination fetch the chart makes. The offset is what
+ * exposes a runaway: a settled chart stops, a broken one climbs 20 at a time.
+ */
+function recordNotesRequests(page, label) {
+  page.on('request', (request) => {
+    const body = request.postData() || '';
+    if (/(?:^|&)method=viewNotesOpt(?:&|$)/.test(body)) {
+      const offsetMatch = /(?:^|&)offset=(\d+)/.exec(body);
+      notesRequests.push({ label, offset: offsetMatch ? Number(offsetMatch[1]) : null });
+    }
+  });
+}
+
+/**
+ * Replaces the shared dialog handler for the eChart window. The default one
+ * dismisses, and the chart's note-lock confirm runs window.close() on dismiss —
+ * which would close the page under test rather than fail with a useful message.
+ */
+function acceptDialogs(page, label, recorder) {
+  page.removeAllListeners('dialog');
+  page.on('dialog', async (dialog) => {
+    recorder.dialogs.push({ label, type: dialog.type(), text: dialog.message() });
+    await dialog.accept().catch(() => {});
+  });
+}
+
+async function createDemographic(context, schedulePage, recorder) {
+  const searchPopup = context.waitForEvent('page');
+  await schedulePage.locator('a').filter({ hasText: /^Search$/ }).click();
+  const searchPage = await searchPopup;
+  wirePage(searchPage, 'search', recorder);
+  await searchPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+
+  // A no-match search renders the results page that carries "Create Demographic".
+  await searchPage.locator('#keyword, input[name="keyword"]').first().fill(fixtureLastName);
+  await Promise.all([
+    searchPage.waitForLoadState('domcontentloaded').catch(() => {}),
+    searchPage.locator("input[type='submit']").first().click(),
+  ]);
+  await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  await searchPage.locator("a[href*='ViewDemographicAddARecordHtm']").first().click();
+  await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  await assertNotErrorPage(searchPage, 'add-demographic form');
+
+  const form = searchPage.locator('form[name="adddemographic"]');
+  await form.locator('input[name="last_name"]').fill(fixtureLastName);
+  await form.locator('input[name="first_name"]').fill(fixtureFirstName);
+  await form.locator('select[name="sex"]').selectOption('F');
+  await form.locator('input[name="inputDOB"]').fill('1990-01-15');
+  // The save-path validator rejects an empty/invalid postal code with an alert.
+  await form.locator('input[name="postal"]').fill('M5W 1E6');
+  await Promise.all([
+    searchPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {}),
+    searchPage.locator('input[type="submit"][value="Add Record"]').first().click(),
+  ]);
+  await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  assert(recorder.dialogs.length === 0,
+    `add-form validation blocked the save with a dialog: ${JSON.stringify(recorder.dialogs)}`);
+  const savedBody = await searchPage.locator('body').innerText();
+  assert(/Successful Addition of a Demographic Record/i.test(savedBody),
+    `post-save page did not confirm the save: ${savedBody.replace(/\s+/g, ' ').slice(0, 300)}`);
+
+  // Continue the way a user does: "Go to record" opens the new master record.
+  // It is also what settles the save before the record is looked up below.
+  await Promise.all([
+    searchPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {}),
+    searchPage.locator('a').filter({ hasText: /Go to record/i }).first().click(),
+  ]);
+  await searchPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  await assertNotErrorPage(searchPage, 'new master record');
+  const masterBody = await searchPage.locator('body').innerText();
+  assert(masterBody.includes(fixtureLastName),
+    `master record does not show the new patient: ${masterBody.replace(/\s+/g, ' ').slice(0, 300)}`);
+
+  const created = sql(`SELECT demographic_no FROM demographic WHERE last_name='${fixtureLastName}' AND first_name='${fixtureFirstName}'`);
+  assert(/^\d+$/.test(created), `new patient not found in the database (got '${created}')`);
+  await searchPage.close();
+  return created;
+}
+
+async function bookAppointment(context, schedulePage, recorder, demographicNo) {
+  // Any open slot on the day sheet; the last one keeps the check clear of the
+  // demo data's morning bookings. Double booking only warns, so the exact slot
+  // does not matter to the outcome.
+  const slots = schedulePage.locator('a.adhour');
+  const slotCount = await slots.count();
+  assert(slotCount > 0, 'no bookable time slots on the schedule day sheet');
+
+  const apptPopup = context.waitForEvent('page');
+  await slots.nth(slotCount - 1).click();
+  const apptPage = await apptPopup;
+  wirePage(apptPage, 'appointment', recorder);
+  await apptPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+  await assertNotErrorPage(apptPage, 'add-appointment form');
+
+  // Patient selection is the jQuery UI autocomplete on #keyword, which is what
+  // sets the hidden demographic_no the save reads.
+  await apptPage.locator('#keyword').fill(fixtureLastName);
+  const suggestion = apptPage.locator('ul.ui-autocomplete li').first();
+  await suggestion.waitFor({ state: 'visible', timeout: 15000 });
+  await suggestion.click();
+  const selected = await apptPage.locator('#demographic_no').inputValue();
+  assert(selected === demographicNo,
+    `autocomplete selected demographic ${selected}, expected the new patient ${demographicNo}`);
+
+  await apptPage.locator('#reason').fill(appointmentReason);
+  await screenshot(apptPage, config.screenshotDir, 'echart-new-patient-appointment-form');
+
+  // The success page calls opener.refresh() and self.close(), so the popup
+  // closing is the signal that the booking went through.
+  const closed = apptPage.waitForEvent('close', { timeout: 30000 });
+  await apptPage.locator('#addButton').click();
+  await closed;
+
+  const appointmentNo = sql(`SELECT appointment_no FROM appointment WHERE demographic_no=${demographicNo} ORDER BY appointment_no DESC LIMIT 1`);
+  assert(/^\d+$/.test(appointmentNo), `appointment was not saved for demographic ${demographicNo} (got '${appointmentNo}')`);
+  return appointmentNo;
+}
+
+async function openEchartFromAppointment(context, schedulePage, recorder, appointmentNo) {
+  // The booking popup calls opener.refresh() on its way out, so the schedule is
+  // usually already reloading; only reload it here if that did not land.
+  await schedulePage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {});
+  await schedulePage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+  // The appointment's encounter ("E") link is what passes appointment_no into
+  // the chart — the reported path. Anchored on the appointment id rather than
+  // the patient name: the day sheet truncates long names in the cell.
+  const encounterLink = schedulePage
+    .locator(`a.encounterBtn[onclick*=",${appointmentNo});"]`).first();
+  try {
+    await encounterLink.waitFor({ state: 'visible', timeout: 15000 });
+  } catch (notThereYet) {
+    await schedulePage.reload({ waitUntil: 'domcontentloaded', timeout: 30000 });
+    await schedulePage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await encounterLink.waitFor({ state: 'visible', timeout: 15000 });
+  }
+
+  const echartPopup = context.waitForEvent('page');
+  await encounterLink.click();
+  const echart = await echartPopup;
+  wirePage(echart, 'echart', recorder);
+  acceptDialogs(echart, 'echart', recorder);
+  recordNotesRequests(echart, 'echart');
+  await echart.waitForLoadState('domcontentloaded', { timeout: 30000 });
+  await echart.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  return echart;
+}
+
+/**
+ * Puts the notes wrapper into the state that arms the poll — overflowing and
+ * scrolled to the top — then waits for pagination to stop.
+ */
+async function assertNotesPaginationSettles(echart) {
+  await echart.locator('#encMainDivWrapper').first().evaluate((element) => {
+    element.style.flex = 'none';
+    element.style.height = '80px';
+    element.scrollTop = 0;
+  });
+
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let observed = notesRequests.length;
+  let stableSince = Date.now();
+  while (Date.now() < deadline) {
+    await echart.waitForTimeout(500);
+    if (notesRequests.length !== observed) {
+      observed = notesRequests.length;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= POLL_QUIET_MS) {
+      return;
+    }
+  }
+  throw new Error('notes pagination never stopped on a chart with no notes; '
+    + `${notesRequests.length} viewNotesOpt requests at offsets `
+    + `${notesRequests.map((r) => r.offset).join(', ')}`);
+}
+
+(async () => {
+  const recorder = createRecorder();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  initMysqlDefaults();
+  let demographicNo = null;
+  try {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1100 } });
+    const schedulePage = await login(context, config, recorder);
+
+    demographicNo = await createDemographic(context, schedulePage, recorder);
+    const appointmentNo = await bookAppointment(context, schedulePage, recorder, demographicNo);
+    const echart = await openEchartFromAppointment(context, schedulePage, recorder, appointmentNo);
+
+    // A chart with no notes still renders the new-note editor. Asserting this
+    // BEFORE the pagination assertions matters: an empty notes pane also makes
+    // pagination trivially "settle", so the cheap green must not be reachable.
+    const editor = echart.locator('#encMainDiv textarea[name="caseNote_note"]').first();
+    await editor.waitFor({ state: 'attached', timeout: 30000 });
+    const noteChildren = await echart.locator('#encMainDiv').first()
+      .evaluate((element) => element.children.length);
+    assert(noteChildren > 0, 'the notes container came up empty on a chart opened from an appointment');
+    await screenshot(echart, config.screenshotDir, 'echart-new-patient-initial');
+
+    await assertNotesPaginationSettles(echart);
+
+    const throbber = await echart.locator('#notesLoading').first().evaluate((element) => ({
+      display: getComputedStyle(element).display,
+      visible: !!(element.getBoundingClientRect().height || element.getClientRects().length),
+    }));
+    assert(!throbber.visible && throbber.display === 'none',
+      `notes loading throbber stayed visible after pagination stopped: ${JSON.stringify(throbber)}`);
+
+    // An empty chart needs the initial load only. The encounter layout renders
+    // ChartNotes.jsp twice, so two are expected; anything beyond that means a
+    // poll walked the offset forward, or a second poll is still armed.
+    const paginationRequests = notesRequests.filter((r) => r.offset > 0);
+    assert(paginationRequests.length === 0,
+      `a chart with no notes paged for more: ${JSON.stringify(notesRequests)}`);
+    assert(notesRequests.length <= 2,
+      `unexpected number of notes fetches on an empty chart: ${JSON.stringify(notesRequests)}`);
+    await screenshot(echart, config.screenshotDir, 'echart-new-patient-settled');
+
+    const fatalConsole = recorder.consoleIssues.filter((issue) => /is not defined|SyntaxError|ReferenceError|Cannot read/i.test(issue.text || ''));
+    assert(fatalConsole.length === 0, `fatal console errors in the eChart: ${JSON.stringify(fatalConsole)}`);
+
+    await context.close();
+    console.log(`PASS new patient ${demographicNo}, appointment ${appointmentNo}: eChart rendered its note `
+      + `editor, pagination settled after ${notesRequests.length} fetch(es), throbber cleared`);
+  } catch (error) {
+    console.error('FAIL eChart new-patient notes Playwright check');
+    console.error(error.stack || error.message);
+    console.error(JSON.stringify({ notesRequests, ...buildFailureDetails(recorder) }, null, 2));
+    process.exitCode = 1;
+  } finally {
+    // Remove the fixture patient and everything the flow hung off it. Looked up
+    // by the unique per-run last name — never a bare number — so a bug can never
+    // delete a pre-existing record, and a run that failed before capturing the
+    // id still cleans up after itself.
+    try {
+      const leftover = demographicNo
+        || sql(`SELECT demographic_no FROM demographic WHERE last_name='${fixtureLastName}' AND first_name='${fixtureFirstName}'`);
+      if (/^\d+$/.test(leftover)) {
+        sql(`DELETE FROM appointment WHERE demographic_no=${leftover}`);
+        sql(`DELETE FROM casemgmt_note_lock WHERE demographic_no=${leftover}`);
+        sql(`DELETE FROM admission WHERE client_id=${leftover}`);
+        sql(`DELETE FROM demographicArchive WHERE demographic_no=${leftover}`);
+        sql(`DELETE FROM demographic WHERE demographic_no=${leftover} AND last_name='${fixtureLastName}'`);
+      }
+    } catch (cleanupError) {
+      console.error(`WARN cleanup failed: ${cleanupError.message}`);
+    }
+    cleanupMysqlDefaults();
+    await browser.close();
+  }
+})();

--- a/scripts/echart-playwright-checks.js
+++ b/scripts/echart-playwright-checks.js
@@ -216,34 +216,44 @@ async function assertNotesPaginationSettles(page) {
   // (or a tall window) an unforced check would report "settled" without ever arming the
   // pagination it exists to test.
   const geometry = await wrapper.evaluate((element) => {
+    const original = { flex: element.style.flex, height: element.style.height };
     element.style.flex = 'none';
     element.style.height = '80px';
     element.scrollTop = 0;
-    return { scrollHeight: element.scrollHeight, clientHeight: element.clientHeight };
+    return { original, scrollHeight: element.scrollHeight, clientHeight: element.clientHeight };
   });
   assert(geometry.scrollHeight > geometry.clientHeight,
     `notes wrapper did not overflow, so the pagination poll was never armed: ${JSON.stringify(geometry)}`);
 
-  const deadline = Date.now() + NOTES_POLL_TIMEOUT_MS;
-  let observed = notesLoadRequests.length;
-  let stableSince = Date.now();
-  while (Date.now() < deadline) {
-    await page.waitForTimeout(500);
-    if (notesLoadRequests.length !== observed) {
-      // A chart with many notes legitimately pages in several batches; restart the
-      // quiet window and keep waiting for the poll to run out of notes.
-      observed = notesLoadRequests.length;
-      stableSince = Date.now();
-    } else if (Date.now() - stableSince >= NOTES_POLL_QUIET_MS) {
-      const throbber = await elementState(page, '#notesLoading');
-      assert(!throbber.visible && throbber.display === 'none',
-        `notes loading throbber stayed visible after pagination stopped: ${JSON.stringify(throbber)}`);
-      return;
+  try {
+    const deadline = Date.now() + NOTES_POLL_TIMEOUT_MS;
+    let observed = notesLoadRequests.length;
+    let stableSince = Date.now();
+    while (Date.now() < deadline) {
+      await page.waitForTimeout(500);
+      if (notesLoadRequests.length !== observed) {
+        // A chart with many notes legitimately pages in several batches; restart the
+        // quiet window and keep waiting for the poll to run out of notes.
+        observed = notesLoadRequests.length;
+        stableSince = Date.now();
+      } else if (Date.now() - stableSince >= NOTES_POLL_QUIET_MS) {
+        const throbber = await elementState(page, '#notesLoading');
+        assert(!throbber.visible && throbber.display === 'none',
+          `notes loading throbber stayed visible after pagination stopped: ${JSON.stringify(throbber)}`);
+        return;
+      }
     }
-  }
 
-  throw new Error(`notes pagination never stopped while parked at the top of the chart; `
-    + `${notesLoadRequests.length} viewNotesOpt requests: ${JSON.stringify(notesLoadRequests)}`);
+    throw new Error(`notes pagination never stopped while parked at the top of the chart; `
+      + `${notesLoadRequests.length} viewNotesOpt requests: ${JSON.stringify(notesLoadRequests)}`);
+  } finally {
+    // Hand the chart back at its real size — the Social History steps and their
+    // screenshots come next, and an 80px notes pane is not the layout they mean to test.
+    await wrapper.evaluate((element, original) => {
+      element.style.flex = original.flex;
+      element.style.height = original.height;
+    }, geometry.original).catch(() => {});
+  }
 }
 
 async function screenshot(page, name) {

--- a/scripts/echart-playwright-checks.js
+++ b/scripts/echart-playwright-checks.js
@@ -42,6 +42,13 @@ if (!/^\d+$/.test(demographicNo)) {
 const captures = [];
 const badResponses = [];
 const consoleIssues = [];
+const notesLoadRequests = [];
+
+// The notes list pages in older notes from a 1s poll, so "settled" means no new fetch
+// for several poll ticks. The overall cap keeps a legitimately long chart from hanging
+// the check while still failing the runaway-pagination regression.
+const NOTES_POLL_QUIET_MS = 4000;
+const NOTES_POLL_TIMEOUT_MS = 30000;
 
 function validateBaseUrl(rawBaseUrl) {
   const parsed = new URL(rawBaseUrl);
@@ -92,6 +99,13 @@ function wirePage(page, label) {
   page.on('dialog', async (dialog) => {
     consoleIssues.push({ label, type: 'dialog', text: dialog.message() });
     await dialog.accept();
+  });
+  page.on('request', (request) => {
+    const postData = request.postData() || '';
+    if (/(?:^|&)method=viewNotesOpt(?:&|$)/.test(postData)) {
+      const offsetMatch = /(?:^|&)offset=(\d+)/.exec(postData);
+      notesLoadRequests.push({ label, offset: offsetMatch ? Number(offsetMatch[1]) : null });
+    }
   });
   page.on('response', async (response) => {
     const responseUrl = response.url();
@@ -186,6 +200,41 @@ async function assertVisible(page, selector, label) {
   return state;
 }
 
+/**
+ * Parks the notes list at the top of the chart and waits for note pagination to stop.
+ *
+ * Scrolling to the top arms the 1s poll that loads older notes. Once the server has no
+ * more notes to give, the poll must stop and the throbber must clear. The regression this
+ * guards let the poll run forever — offset 20, 40, 60, ... on an endless loop, with the
+ * loading throbber up for the life of the chart — because an exhausted batch still comes
+ * back as a non-empty response body.
+ */
+async function assertNotesPaginationSettles(page) {
+  const wrapper = page.locator('#encMainDivWrapper').first();
+  await wrapper.evaluate((element) => { element.scrollTop = 0; });
+
+  const deadline = Date.now() + NOTES_POLL_TIMEOUT_MS;
+  let observed = notesLoadRequests.length;
+  let stableSince = Date.now();
+  while (Date.now() < deadline) {
+    await page.waitForTimeout(500);
+    if (notesLoadRequests.length !== observed) {
+      // A chart with many notes legitimately pages in several batches; restart the
+      // quiet window and keep waiting for the poll to run out of notes.
+      observed = notesLoadRequests.length;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= NOTES_POLL_QUIET_MS) {
+      const throbber = await elementState(page, '#notesLoading');
+      assert(!throbber.visible && throbber.display === 'none',
+        `notes loading throbber stayed visible after pagination stopped: ${JSON.stringify(throbber)}`);
+      return;
+    }
+  }
+
+  throw new Error(`notes pagination never stopped while parked at the top of the chart; `
+    + `${notesLoadRequests.length} viewNotesOpt requests: ${JSON.stringify(notesLoadRequests)}`);
+}
+
 async function screenshot(page, name) {
   await page.screenshot({ path: buildArtifactPath(screenshotDir, name), fullPage: true }); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- buildArtifactPath constrains output to a validated local artifact directory with a sanitized basename
 }
@@ -235,6 +284,8 @@ function isExpectedNoteLockDialog(issue) {
     await assertVisible(echart, '#newNoteImg', 'new-note icon');
     await assertVisible(echart, "#divR1I1 a[title='Add Item']", 'Social History plus icon');
     await screenshot(echart, 'echart-initial');
+
+    await assertNotesPaginationSettles(echart);
 
     await echart.locator("#divR1I1 a[title='Add Item']").first().click();
     const editor = await assertVisible(echart, '#showEditNote', 'Social History editor');
@@ -288,7 +339,9 @@ function isExpectedNoteLockDialog(issue) {
     assert(fatalConsoleIssues.length === 0,
       `unexpected browser console failures: ${JSON.stringify(fatalConsoleIssues, null, 2)}`);
 
-    console.log('PASS eChart clinical notes rendered, Social History saved and archived, and Unresolved Issues refreshed');
+    console.log('PASS eChart clinical notes rendered, note pagination stopped at end of chart, '
+      + 'Social History saved and archived, and Unresolved Issues refreshed');
+    console.log(`Observed ${notesLoadRequests.length} note pagination requests`);
     console.log(`Observed ${captures.length} eChart-related responses`);
     if (consoleIssues.length) {
       console.log(`Non-blocking browser diagnostics: ${JSON.stringify(consoleIssues, null, 2)}`);

--- a/scripts/echart-playwright-checks.js
+++ b/scripts/echart-playwright-checks.js
@@ -211,7 +211,18 @@ async function assertVisible(page, selector, label) {
  */
 async function assertNotesPaginationSettles(page) {
   const wrapper = page.locator('#encMainDivWrapper').first();
-  await wrapper.evaluate((element) => { element.scrollTop = 0; });
+  // Constrain the pane rather than trusting the chart to overflow on its own: the poll
+  // only fires when the notes wrapper overflows AND sits at the top, so on a short chart
+  // (or a tall window) an unforced check would report "settled" without ever arming the
+  // pagination it exists to test.
+  const geometry = await wrapper.evaluate((element) => {
+    element.style.flex = 'none';
+    element.style.height = '80px';
+    element.scrollTop = 0;
+    return { scrollHeight: element.scrollHeight, clientHeight: element.clientHeight };
+  });
+  assert(geometry.scrollHeight > geometry.clientHeight,
+    `notes wrapper did not overflow, so the pagination poll was never armed: ${JSON.stringify(geometry)}`);
 
   const deadline = Date.now() + NOTES_POLL_TIMEOUT_MS;
   let observed = notesLoadRequests.length;

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp
@@ -210,6 +210,10 @@
 
     jQuery(document).ready(function () {
         notesLoader(0, notesIncrement, demographicNo);
+        // The encounter layout renders this page twice on open, and both copies run this
+        // handler in the same window. Without the stop, the first interval handle is
+        // overwritten here and its timer polls on, unstoppable, for the life of the chart.
+        stopNotesScrollCheck();
         notesScrollCheckInterval = setInterval('notesIncrementAndLoadMore()', 1000);
     });
 

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotesAjax.jsp
@@ -854,6 +854,11 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
 
 <script type="text/javascript">
     maxNcId = <%=maxId%>;
+    // Batch size for notesLoader() in newCaseManagementView.js.jsp. It is the only way the
+    // client can tell an exhausted chart from a full batch: this fragment always emits these
+    // bootstrap scripts, so even a zero-note response has a non-empty body. Without it the
+    // scroll poll keeps requesting higher and higher offsets and the throbber never clears.
+    notesLastBatchSize = <%=noteSize%>;
 </script>
 
 

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -576,8 +576,10 @@
      * Fetches a batch of clinical notes via AJAX and inserts them at the top of #encMainDiv.
      *
      * On initial load (offset === 0), scrolls to the bottom to show the most recent notes.
-     * On pagination loads (offset > 0), preserves the current scroll position so the user
-     * can continue reading older notes without being snapped away.
+     * Pagination loads (offset > 0) do not scroll at all — scrollTop is left untouched
+     * while the older batch is inserted above, so a reader parked at the top of the pane
+     * ends up looking at the notes that just arrived. (notesCurrentTop records the previous
+     * top note for a scroll restore that was never written; nothing reads it today.)
      *
      * Callers are never turned away: the encounter layout renders ChartNotes.jsp twice on
      * open (the second render replaces #encMainDiv), so both initial loads must run or the
@@ -626,8 +628,8 @@
                     if (!notesRetrieveOk) {
                         stopNotesScrollCheck();
                     }
-                    // Only scroll to bottom on initial load (most recent notes);
-                    // pagination loads (offset > 0) preserve scroll position
+                    // Only the initial load scrolls, to the newest notes at the bottom.
+                    // Pagination loads leave scrollTop alone (see the note above).
                     if (offset === 0) {
                         var wrapper = $("encMainDivWrapper");
                         if (wrapper) {

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -494,7 +494,17 @@
     var notesRetrieveOk = false;      // true when the last fetch returned at least one note
     var notesCurrentTop = null;       // ID of topmost note element before pagination insert
     var notesScrollCheckInterval = null;
-    var notesLoadInProgress = false;  // a fetch is in flight; holds off the scroll poll
+    /*
+     * Fetches still in flight, and the id of the most recent one. Both are needed because
+     * the encounter layout renders ChartNotes.jsp twice, so two offset-0 loads overlap on
+     * every chart open. The count holds off the scroll poll until BOTH have landed — a
+     * pagination fetch racing a pending initial load inserts its notes out of order. The
+     * id makes the older, superseded load a no-op at completion, so a first request that
+     * fails or gets redirected cannot stop the poll the second render just armed.
+     */
+    var notesLoadsInFlight = 0;
+    var notesLoadSequence = 0;
+    var notesActiveLoadId = 0;
     /*
      * Number of notes rendered by the fetch currently in flight. ChartNotesAjax.jsp sets
      * this while its response scripts run; notesLoader() resets it to -1 before every
@@ -523,7 +533,8 @@
      * (a brand-new chart renders only the new-note editor).
      */
     function notesTopElementId() {
-        var firstChild = $("encMainDiv").children[0];
+        var notesContainer = $("encMainDiv");
+        var firstChild = notesContainer && notesContainer.children[0];
         return firstChild ? firstChild.id : null;
     }
 
@@ -532,7 +543,7 @@
      * Loads the next batch of older notes (inserted at top of the list).
      */
     function notesIncrementAndLoadMore() {
-        if (notesLoadInProgress || !notesRetrieveOk) {
+        if (notesLoadsInFlight > 0 || !notesRetrieveOk) {
             return;
         }
         var wrapper = $("encMainDivWrapper");
@@ -570,15 +581,17 @@
      *
      * Callers are never turned away: the encounter layout renders ChartNotes.jsp twice on
      * open (the second render replaces #encMainDiv), so both initial loads must run or the
-     * surviving container is left empty. notesLoadInProgress only holds off the scroll
-     * poll, which would otherwise stack requests behind a slow batch.
+     * surviving container is left empty. The in-flight count only holds off the scroll
+     * poll, which would otherwise stack requests behind a pending batch.
      *
      * @param {number} offset - Zero-based offset into the patient's note list (0 = newest batch)
      * @param {number} numToReturn - Maximum number of notes to fetch in this batch
      * @param {number} demoNo - Demographic (patient) number to load notes for
      */
     function notesLoader(offset, numToReturn, demoNo) {
-        notesLoadInProgress = true;
+        var loadId = ++notesLoadSequence;
+        notesActiveLoadId = loadId;
+        notesLoadsInFlight++;
         notesLastBatchSize = -1;
         $("notesLoading").show();
         var params = "method=viewNotesOpt&offset=" + offset + "&numToReturn=" + numToReturn + "&demographicNo=" + demoNo;
@@ -594,8 +607,17 @@
                 evalScripts: true,
                 insertion: 'top',
                 onComplete: function () {
-                    notesLoadInProgress = false;
-                    $("notesLoading").hide();
+                    notesLoadsInFlight--;
+                    if (notesLoadsInFlight === 0) {
+                        $("notesLoading").hide();
+                    }
+                    if (loadId !== notesActiveLoadId) {
+                        // Superseded by a later load — its response owns the shared state
+                        // below. Without this an initial load that failed would stop the
+                        // poll the second chart render just armed, and no older note could
+                        // ever be paged in again.
+                        return;
+                    }
                     // The response scripts have already run (CarlosAjax updates the DOM
                     // between onSuccess and onComplete), so notesLastBatchSize now holds
                     // the count this fragment rendered. An empty batch means the chart is

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -494,7 +494,7 @@
     var notesRetrieveOk = false;      // true when the last fetch returned at least one note
     var notesCurrentTop = null;       // ID of topmost note element before pagination insert
     var notesScrollCheckInterval = null;
-    var notesLoadInProgress = false;  // guards against overlapping pagination fetches
+    var notesLoadInProgress = false;  // a fetch is in flight; holds off the scroll poll
     /*
      * Number of notes rendered by the fetch currently in flight. ChartNotesAjax.jsp sets
      * this while its response scripts run; notesLoader() resets it to -1 before every
@@ -568,17 +568,16 @@
      * On pagination loads (offset > 0), preserves the current scroll position so the user
      * can continue reading older notes without being snapped away.
      *
-     * Only one fetch runs at a time; the 1s scroll poll would otherwise stack requests
-     * while a slow batch is still in flight.
+     * Callers are never turned away: the encounter layout renders ChartNotes.jsp twice on
+     * open (the second render replaces #encMainDiv), so both initial loads must run or the
+     * surviving container is left empty. notesLoadInProgress only holds off the scroll
+     * poll, which would otherwise stack requests behind a slow batch.
      *
      * @param {number} offset - Zero-based offset into the patient's note list (0 = newest batch)
      * @param {number} numToReturn - Maximum number of notes to fetch in this batch
      * @param {number} demoNo - Demographic (patient) number to load notes for
      */
     function notesLoader(offset, numToReturn, demoNo) {
-        if (notesLoadInProgress) {
-            return;
-        }
         notesLoadInProgress = true;
         notesLastBatchSize = -1;
         $("notesLoading").show();

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -491,36 +491,73 @@
     // --- Notes pagination state ---
     var notesOffset = 0;              // current offset into the full notes list
     var notesIncrement = 20;          // batch size for each pagination fetch
-    var notesRetrieveOk = false;      // true when the last fetch returned non-empty results
+    var notesRetrieveOk = false;      // true when the last fetch returned at least one note
     var notesCurrentTop = null;       // ID of topmost note element before pagination insert
     var notesScrollCheckInterval = null;
+    var notesLoadInProgress = false;  // guards against overlapping pagination fetches
+    /*
+     * Number of notes rendered by the fetch currently in flight. ChartNotesAjax.jsp sets
+     * this while its response scripts run; notesLoader() resets it to -1 before every
+     * request. Never test the raw response body for emptiness instead: that fragment always
+     * emits bootstrap scripts (maxNcId, fullView listeners), so a batch with zero notes
+     * still comes back non-empty and the "no more notes" stop condition never fires.
+     * A response that leaves this at -1 (error page, redirect, aborted request) is treated
+     * as end-of-list so the poll stops rather than walking the offset forward forever.
+     */
+    var notesLastBatchSize = -1;
     const MAXNOTES = 1000000;         // upper bound to stop pagination
+
+    /**
+     * Stops the 1s poll that loads older notes when the user is at the top of the chart.
+     * Called once the server reports the chart is fully loaded; idempotent.
+     */
+    function stopNotesScrollCheck() {
+        if (notesScrollCheckInterval !== null) {
+            clearInterval(notesScrollCheckInterval);
+            notesScrollCheckInterval = null;
+        }
+    }
+
+    /**
+     * ID of the topmost note element, or null when the notes list is empty
+     * (a brand-new chart renders only the new-note editor).
+     */
+    function notesTopElementId() {
+        var firstChild = $("encMainDiv").children[0];
+        return firstChild ? firstChild.id : null;
+    }
 
     /**
      * Triggered when the user scrolls to the top of the notes wrapper.
      * Loads the next batch of older notes (inserted at top of the list).
      */
     function notesIncrementAndLoadMore() {
-        if (notesRetrieveOk && $("encMainDivWrapper").scrollTop === 0) {
-            if ($("encMainDivWrapper").scrollHeight > $("encMainDivWrapper").getHeight()) {
-                notesOffset += notesIncrement;
-                notesRetrieveOk = false;
-                notesCurrentTop = $("encMainDiv").children[0].id;
-                if (notesOffset < MAXNOTES) {
-                    notesLoader(notesOffset, notesIncrement, demographicNo);
-                }
-            }
+        if (notesLoadInProgress || !notesRetrieveOk) {
+            return;
+        }
+        var wrapper = $("encMainDivWrapper");
+        if (!wrapper || wrapper.scrollTop !== 0 || wrapper.scrollHeight <= wrapper.getHeight()) {
+            return;
+        }
+        notesOffset += notesIncrement;
+        notesRetrieveOk = false;
+        notesCurrentTop = notesTopElementId();
+        if (notesOffset < MAXNOTES) {
+            notesLoader(notesOffset, notesIncrement, demographicNo);
+        } else {
+            stopNotesScrollCheck();
         }
     }
 
     function notesLoadAll() {
         notesOffset += notesIncrement;
         notesRetrieveOk = false;
-        notesCurrentTop = $("encMainDiv").children[0].id;
-        console.log("loading all: " + " offset: " + notesOffset + " max notes: " + MAXNOTES);
+        notesCurrentTop = notesTopElementId();
         if (notesOffset < MAXNOTES) {
             notesLoader(notesOffset, MAXNOTES, demographicNo);
         }
+        // Park the offset past MAXNOTES so the scroll poll cannot re-request notes
+        // that this single full fetch already inserted.
         notesOffset += MAXNOTES;
     }
 
@@ -531,13 +568,20 @@
      * On pagination loads (offset > 0), preserves the current scroll position so the user
      * can continue reading older notes without being snapped away.
      *
+     * Only one fetch runs at a time; the 1s scroll poll would otherwise stack requests
+     * while a slow batch is still in flight.
+     *
      * @param {number} offset - Zero-based offset into the patient's note list (0 = newest batch)
      * @param {number} numToReturn - Maximum number of notes to fetch in this batch
      * @param {number} demoNo - Demographic (patient) number to load notes for
      */
     function notesLoader(offset, numToReturn, demoNo) {
+        if (notesLoadInProgress) {
+            return;
+        }
+        notesLoadInProgress = true;
+        notesLastBatchSize = -1;
         $("notesLoading").show();
-        console.log("loading: " + " offset: " + offset + " max notes: " + numToReturn + " demo: " + demoNo);
         var params = "method=viewNotesOpt&offset=" + offset + "&numToReturn=" + numToReturn + "&demographicNo=" + demoNo;
         var params2 = jQuery("input[name='filter_providers'],input[name='filter_roles'],input[name='issues'],input[name='note_sort']").serialize();
         if (params2.length > 0) {
@@ -550,14 +594,17 @@
                 postBody: params,
                 evalScripts: true,
                 insertion: 'top',
-                onSuccess: function (data) {
-                    notesRetrieveOk = (data.responseText.replace(/\s+/g, '').length > 0);
-                    if (!notesRetrieveOk) {
-                        clearInterval(scrollCheckInterval);
-                    }
-                },
                 onComplete: function () {
+                    notesLoadInProgress = false;
                     $("notesLoading").hide();
+                    // The response scripts have already run (CarlosAjax updates the DOM
+                    // between onSuccess and onComplete), so notesLastBatchSize now holds
+                    // the count this fragment rendered. An empty batch means the chart is
+                    // fully loaded: stop the poll instead of requesting ever-higher offsets.
+                    notesRetrieveOk = notesLastBatchSize > 0;
+                    if (!notesRetrieveOk) {
+                        stopNotesScrollCheck();
+                    }
                     // Only scroll to bottom on initial load (most recent notes);
                     // pagination loads (offset > 0) preserve scroll position
                     if (offset === 0) {

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -618,10 +618,10 @@
                         // ever be paged in again.
                         return;
                     }
-                    // The response scripts have already run (CarlosAjax updates the DOM
-                    // between onSuccess and onComplete), so notesLastBatchSize now holds
-                    // the count this fragment rendered. An empty batch means the chart is
-                    // fully loaded: stop the poll instead of requesting ever-higher offsets.
+                    // CarlosAjax.updater inserts the fragment and runs its scripts before
+                    // it calls onComplete, so notesLastBatchSize already holds the count
+                    // this response rendered. An empty batch means the chart is fully
+                    // loaded: stop the poll instead of requesting ever-higher offsets.
                     notesRetrieveOk = notesLastBatchSize > 0;
                     if (!notesRetrieveOk) {
                         stopNotesScrollCheck();


### PR DESCRIPTION
## Description

An alpha tester reported that the eChart "wants to keep loading notes": on a
brand-new demographic with an appointment, the console filled with

```
loading:  offset: 0 max notes: 20 demo: 3001
loading:  offset: 20 max notes: 20 demo: 3001
loading:  offset: 40 ...
```

and the loading throbber never cleared. Reproduced in Firefox and Chromium.

**The pagination poll had no reachable stop condition.** `ChartNotes.jsp` arms a
1-second poll that loads the next batch of older notes whenever the notes
wrapper is scrolled to the top. It decided "there are no more notes" by testing
whether the response body was blank:

```js
notesRetrieveOk = (data.responseText.replace(/\s+/g, '').length > 0);
if (!notesRetrieveOk) { clearInterval(scrollCheckInterval); }
```

Two defects, either one fatal:

1. **`ChartNotesAjax.jsp` never returns an empty body.** It always emits
   bootstrap scripts (`maxNcId`, the `fullView` click-listener block) *outside*
   the note-rendering block, so an exhausted batch still comes back non-empty
   and `notesRetrieveOk` stayed `true` forever.
2. **`scrollCheckInterval` is not a variable** — the interval handle is
   `notesScrollCheckInterval`. That line would have thrown a `ReferenceError`
   (swallowed by `CarlosAjax`'s callback try/catch), so the poll could not have
   been stopped even if the branch were reached.

A third defect surfaced only when running the packaged build: the encounter
layout renders `ChartNotes.jsp` **twice** on open, and each copy assigned over
`notesScrollCheckInterval`. The first handle was lost, so its timer could never
be cleared — the pre-fix chart issued **two** pagination requests per second,
one per orphaned timer.

A brand-new chart is what makes it obvious: with no notes there is nothing to
scroll away from, so the wrapper stays at the top and the poll fires on every
tick. Any chart left scrolled to the top after its notes are exhausted issues
the same request storm.

### The fix

- `ChartNotesAjax.jsp` reports how many notes it rendered
  (`notesLastBatchSize`) — the only signal that distinguishes an exhausted
  chart from a full batch.
- `notesLoader()` resets that marker before each request and, in `onComplete`
  (after `CarlosAjax` has run the response scripts), stops the poll when the
  batch is empty. A response that never sets it (error page, redirect) is also
  treated as end-of-list rather than looping.
- `ChartNotes.jsp` stops any existing poll before arming its own, so the second
  render cannot orphan the first timer.
- **Note-load state is per-request, not shared** (`d85ee5a`, from review): the
  two overlapping initial loads are tracked by an in-flight *count*, so the poll
  cannot fire a pagination fetch while either offset-0 response is still
  pending; and each request carries an id, so a superseded completion returns
  before touching the stop condition. Without the id, a first load that failed
  or was redirected stopped the interval the second render had just armed —
  killing automatic pagination for the rest of the session.
- Removed the per-fetch `console.log` that printed the demographic number to
  the browser console on every chart open.

## Related Issues

No tracking issue — reported directly by an alpha tester against
2026.08.0-alpha10. Related to the eChart notes surface generally.

## Target Branch

Supported fix targeting `release/2026.08`, the oldest affected release line —
`clearInterval(scrollCheckInterval)` is present on that branch. The topic branch
was cut from `release/2026.08`, and the diff touches no version or SCM metadata
(`pom.xml` and `debian/changelog` are untouched). Maintainers forward-merge from
here; no duplicate PR has been opened against `develop`.

## How Was This Tested?

Built the `carlos-emr` .deb from this branch's source and installed it into an
Ubuntu 26.04 systemd container (MariaDB provisioned, 18 Flyway migrations
applied, schema validated against the WAR, demo dataset loaded, nginx +
ModSecurity/CRS front door). Both directions were verified against that
packaged deployment, not the devcontainer — and re-verified after the review
fixes in `d85ee5a`:

| deployed code | new-patient check | existing eChart check |
|---|---|---|
| pre-fix | **FAIL** — 82 `viewNotesOpt` fetches walking to offset 1600, still climbing | **FAIL** — 55 fetches, offset 1060 |
| this branch | **PASS** — settles after the two initial loads, throbber cleared | **PASS** — pages the whole 289-note chart, stops at 16 |

Two regression checks are included:

- **`scripts/echart-new-patient-notes-playwright-checks.js`** (new) drives the
  reported path through the UI — create a demographic, book an appointment for
  it, open the eChart from that appointment's encounter link. It asserts the
  note editor renders **before** it asserts anything about pagination: an empty
  notes pane also makes pagination trivially settle, and that false green is
  exactly what an early cut of this fix would have earned. It creates and
  deletes its own fixture patient, appointment and note lock, and fails the run
  if that cleanup fails.
- **`scripts/echart-playwright-checks.js`** (extended) parks the existing
  demo chart at the top of the notes list and fails if pagination does not
  settle or the throbber stays up.

Both checks constrain the notes pane and assert it actually overflows before
watching the poll: the poll only arms when the pane overflows *and* sits at the
top, so an unforced check would report "settled" on a tall window without ever
exercising the bug.

## Screenshots

Not applicable — no visual change. The observable difference is the absence of a
request storm and a throbber that now clears.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR — the fixture patient is synthetic (`PLAYWRIGHT-EC-<timestamp>`) and deleted by the check
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FukqkkYrwGKF5whiAWdUoL

## Summary by Sourcery

Prevent eChart notes pagination from looping indefinitely and add browser coverage for both new and existing patient charts.

Bug Fixes:
- Stop eChart notes pagination when no more notes are available, preventing runaway requests and leaving the loading indicator cleared.
- Prevent duplicate encounter renders from orphaning notes pagination timers and preserve correct behavior while overlapping initial note loads complete.

Enhancements:
- Remove repetitive per-request notes logging from the browser console.

Documentation:
- Document the new synthetic-patient eChart regression check, including fixture cleanup and deterministic notes-pane sizing.

Tests:
- Add a Playwright regression check covering the new-patient appointment-to-eChart path and verifying note rendering, pagination settlement, throbber clearance, and cleanup.
- Extend the existing eChart Playwright check to exercise pagination on an overflowing notes pane and verify it stops.