### PR TITLE
fix(admin): restore the administrator role in the Assign Role dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "test:login-playwright": "node scripts/login-playwright-checks.js",
     "test:add-login-account-playwright": "node scripts/add-login-account-playwright-checks.js",
+    "test:assign-role-playwright": "node scripts/assign-role-playwright-checks.js",
     "test:logout-broadcast-playwright": "node scripts/logout-broadcast-playwright-checks.js",
     "test:echart-playwright": "node scripts/echart-playwright-checks.js",
     "test:browser-surfaces-playwright": "node scripts/browser-surface-playwright-checks.js",

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -46,6 +46,7 @@
  *   MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_PASSWORD=password MYSQL_DATABASE=carlos
  *   ASSIGN_ROLE_SCREENSHOT_DIR=/tmp/carlos-assign-role-playwright
  *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ *   ALLOW_NON_LOCAL_MYSQL_HOST=true only for a disposable non-local test database
  */
 const assert = require('assert');
 const { chromium } = require('playwright');
@@ -54,13 +55,88 @@ const { randomInt } = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { buildArtifactPath } = require('./eform-local-playwright-utils');
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'db', 'carlos']);
+
+/*
+ * Hosts that are unambiguously this machine or its private compose network.
+ * Deliberately narrower than isLocalHost: the database target keys off this,
+ * because this check WRITES a provider row and an `admin` role grant.
+ */
+const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
+
+function normalizeHost(rawHost) {
+  return rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+/*
+ * Match four numeric octets, not a `10.`-style prefix: a bare prefix test also
+ * accepts DNS names such as `10.attacker.example`, which would slip past the
+ * non-local opt-in and receive a real login.
+ */
+function isPrivateIpv4(host) {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) {
+    return false;
+  }
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
+}
+
+function isLocalHost(rawHost) {
+  const host = normalizeHost(rawHost);
+  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+}
+
+function isExactLocalHost(rawHost) {
+  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
+}
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+  // Credentials in the URL would travel into Playwright navigations and can
+  // surface in request or failure logging, so reject them outright.
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not contain embedded credentials');
+  }
+  if (!isLocalHost(parsed.hostname) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  // This script logs in with real credentials, so anything that is not plainly
+  // loopback has to prove its certificate.
+  if (!isExactLocalHost(parsed.hostname) && parsed.protocol !== 'https:') {
+    throw new Error(`Non-loopback BASE_URL host ${parsed.hostname} must use https`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+/*
+ * The database target is gated harder than the browsing target: this check
+ * seeds a provider and grants it the installation-wide administrator role, so
+ * an exported MYSQL_HOST must never reach a shared or production schema.
+ */
+function validateMysqlHost(rawHost) {
+  if (!isExactLocalHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
+    throw new Error(`Refusing to seed a provider and an admin role grant into non-local MYSQL_HOST ${rawHost}; set ALLOW_NON_LOCAL_MYSQL_HOST=true for a disposable test database`);
+  }
+  return rawHost;
+}
 
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
 const chromePath = process.env.CHROME_PATH || '';
 const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
-const mysqlHost = process.env.MYSQL_HOST || '127.0.0.1';
+const mysqlHost = validateMysqlHost(process.env.MYSQL_HOST || '127.0.0.1');
 const mysqlUser = process.env.MYSQL_USER || 'root';
 const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
 const mysqlDatabase = process.env.MYSQL_DATABASE || 'carlos';
@@ -74,23 +150,14 @@ const SUPER_ROOT_ROLE = process.env.ASSIGN_ROLE_SUPER_ROOT || 'admin';
 let mysqlDefaults = null;
 const results = [];
 
-function validateBaseUrl(rawBaseUrl) {
-  const parsed = new URL(rawBaseUrl);
-  if (!['http:', 'https:'].includes(parsed.protocol)) {
-    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
-  }
-  const host = parsed.hostname.toLowerCase();
-  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
-  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
-  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
-    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
-  }
-  parsed.pathname = parsed.pathname.replace(/\/$/, '');
-  return parsed;
-}
 
-function appUrl(suffix) {
-  return `${baseUrl.origin}${baseUrl.pathname}${suffix}`;
+/*
+ * Playwright resolves these against the context baseURL set in run(). Passing
+ * the composed absolute URL into goto() instead would route an environment
+ * value straight into the navigation sink.
+ */
+function playwrightBaseUrl() {
+  return `${baseUrl.origin}${baseUrl.pathname.replace(/\/$/, '')}/`;
 }
 
 function createMysqlDefaultsFile() {
@@ -115,15 +182,45 @@ function cleanupMysqlDefaultsFile() {
   }
 }
 
+/*
+ * execFileSync's own message embeds the whole command line and the failing
+ * statement, so never surface it raw. Take only the ERROR line, drop the
+ * fragment mysql quotes back in "near '...'", mask digit runs (fixture provider
+ * numbers), and cap the length.
+ */
+function describeMysqlFailure(error) {
+  const errorLine = String(error.stderr || '')
+    .split('\n')
+    .find((line) => line.startsWith('ERROR '));
+  if (!errorLine) {
+    return `mysql exited with status ${error.status}`;
+  }
+  return errorLine
+    .replace(/ near '.*$/, ' near <redacted>')
+    .replace(/\d{3,}/g, '###')
+    .slice(0, 200);
+}
+
 function sql(query) {
   assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
-  return execFileSync('mysql', [
-    `--defaults-extra-file=${mysqlDefaults.file}`,
-    '-h', mysqlHost,
-    '-u', mysqlUser,
-    mysqlDatabase,
-    '-N', '-B', '-e', query,
-  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: mysqlTimeoutMs }).trim();
+  try {
+    return execFileSync('mysql', [
+      `--defaults-extra-file=${mysqlDefaults.file}`,
+      '-h', mysqlHost,
+      '-u', mysqlUser,
+      mysqlDatabase,
+      '-N', '-B', '-e', query,
+      // Without a timeout an unreachable host blocks forever, and the signal
+      // handler calls straight back into here — an interrupted run would hang
+      // while trying to remove its own seeded rows.
+    ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: mysqlTimeoutMs }).trim();
+  } catch (error) {
+    throw new Error(`mysql command failed: ${describeMysqlFailure(error)}`);
+  }
+}
+
+function escapeSql(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/'/g, "''");
 }
 
 function check(name, ok, detail) {
@@ -132,12 +229,11 @@ function check(name, ok, detail) {
 }
 
 function shot(name) {
-  assert(/^[0-9a-z-]+$/.test(name), `Invalid screenshot name: ${name}`);
-  return path.join(screenshotDir, `${name}.png`);
+  return buildArtifactPath(screenshotDir, name);
 }
 
 async function login(page) {
-  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.goto('./', { waitUntil: 'domcontentloaded', timeout: 60000 });
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
   await page.locator('#pin').fill(testPin);
@@ -147,7 +243,7 @@ async function login(page) {
 
 async function roleOptions(page, keyword) {
   const query = keyword ? `?keyword=${encodeURIComponent(keyword)}` : '';
-  await page.goto(appUrl(`/admin/ProviderRole${query}`), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.goto(`./admin/ProviderRole${query}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
   const select = page.locator('select[name="roleNew"]').first();
   await select.waitFor({ state: 'attached', timeout: 60000 });
   return select.locator('option').evaluateAll((options) => options.map((option) => option.value));
@@ -158,7 +254,7 @@ function seedProvider(providerNo, lastName) {
   // columns every CARLOS table carries), so a bare column list fails on insert.
   sql(`INSERT INTO provider (provider_no, last_name, first_name, provider_type, status,
                              lastUpdateUser, lastUpdateDate)
-       VALUES ('${providerNo}', '${lastName}', 'RoleCheck', 'doctor', '1', '-1', NOW())`);
+       VALUES ('${escapeSql(providerNo)}', '${escapeSql(lastName)}', 'RoleCheck', 'doctor', '1', '-1', NOW())`);
 }
 
 function removeProvider(providerNo) {
@@ -167,15 +263,48 @@ function removeProvider(providerNo) {
   // `admin` grant behind in the target database, which must never be reported
   // as a clean run.
   for (const table of ['secUserRole', 'program_provider', 'provider_facility', 'security']) {
-    sql(`DELETE FROM ${table} WHERE provider_no='${providerNo}'`);
+    sql(`DELETE FROM ${table} WHERE provider_no='${escapeSql(providerNo)}'`);
   }
-  sql(`DELETE FROM provider WHERE provider_no='${providerNo}'`);
+  sql(`DELETE FROM provider WHERE provider_no='${escapeSql(providerNo)}'`);
+}
+
+/*
+ * Cleanup has to be reachable from both run()'s finally and the signal
+ * handlers, so the fixture identity lives at module scope: Node does not unwind
+ * a finally block on SIGINT, and an interrupted run would otherwise strand a
+ * seeded provider holding a live `admin` grant plus the cleartext password file.
+ */
+let seededProviderNo = null;
+
+function runCleanupOnce() {
+  const failures = [];
+  if (seededProviderNo !== null) {
+    const providerNo = seededProviderNo;
+    // Cleared first: a second entry (finally after a signal) must not re-run
+    // the deletes or double-report them.
+    seededProviderNo = null;
+    try {
+      removeProvider(providerNo);
+    } catch (error) {
+      failures.push(`removing fixture provider failed: ${error.message}`);
+    }
+    // Verify, rather than trust, that nothing was left behind.
+    try {
+      const leftover = sql(`SELECT COUNT(*) FROM provider WHERE provider_no='${escapeSql(providerNo)}'`);
+      if (leftover !== '0') {
+        failures.push(`fixture provider rows still present: ${leftover}`);
+      }
+    } catch (error) {
+      failures.push(`could not confirm fixture removal: ${error.message}`);
+    }
+  }
+  cleanupMysqlDefaultsFile();
+  return failures;
 }
 
 async function run() {
   const providerNo = String(900000 + randomInt(1000, 9999));
   const lastName = `Rolecheck${providerNo}`;
-  let seeded = false;
   let browser = null;
 
   try {
@@ -187,7 +316,7 @@ async function run() {
     const privilege = sql(
       `SELECT privilege FROM secObjPrivilege WHERE objectName='_site_access_privacy'
        AND roleUserGroup IN (SELECT role_name FROM secUserRole WHERE provider_no=
-         (SELECT provider_no FROM security WHERE user_name='${testUser}' LIMIT 1))`);
+         (SELECT provider_no FROM security WHERE user_name='${escapeSql(testUser)}' LIMIT 1))`);
     check(`${testUser} holds _site_access_privacy (the condition that triggered the bug)`,
       privilege.length > 0, privilege || '(none)');
 
@@ -195,7 +324,10 @@ async function run() {
       ...(chromePath ? { executablePath: chromePath } : {}),
       args: ['--no-sandbox', '--disable-dev-shm-usage'],
     });
-    const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
+    const page = await browser.newPage({
+      baseURL: playwrightBaseUrl(),
+      viewport: { width: 1400, height: 1000 },
+    });
 
     await login(page);
     check('logged in', /providercontrol/i.test(page.url()), page.url());
@@ -206,7 +338,7 @@ async function run() {
       options.includes(SUPER_ROOT_ROLE), `${options.length} options`);
 
     seedProvider(providerNo, lastName);
-    seeded = true;
+    seededProviderNo = providerNo;
 
     await roleOptions(page, lastName);
     // The JSP wraps each <tr> in a <form> INSIDE the <table>; HTML parsing
@@ -236,39 +368,47 @@ async function run() {
     await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
     await page.screenshot({ path: shot('assign-role-assigned'), fullPage: true });
 
-    const assigned = sql(`SELECT role_name FROM secUserRole WHERE provider_no='${providerNo}'`);
+    const assigned = sql(`SELECT role_name FROM secUserRole WHERE provider_no='${escapeSql(providerNo)}'`);
     check(`"${SUPER_ROOT_ROLE}" role assigned through the browser and persisted`,
       assigned === SUPER_ROOT_ROLE, assigned || '(none)');
   } finally {
     if (browser) await browser.close();
-    if (seeded) {
-      let cleanupError = '';
-      try {
-        removeProvider(providerNo);
-      } catch (error) {
-        cleanupError = error.message;
-      }
-      // Verify, rather than trust, that nothing was left behind — then fail the
-      // run if it was, so a stale fixture can never hide behind a green result.
-      let leftover = 'unknown';
-      try {
-        leftover = sql(`SELECT COUNT(*) FROM provider WHERE provider_no='${providerNo}'`);
-      } catch (error) {
-        leftover = `unreadable (${error.message})`;
-      }
+    const wasSeeded = seededProviderNo !== null;
+    const failures = runCleanupOnce();
+    // A dirty run must never exit green: leaving a provider that holds the
+    // installation-wide administrator role behind is exactly what this check
+    // must not do quietly.
+    if (wasSeeded) {
       check(`fixture provider ${providerNo} removed`,
-        leftover === '0' && cleanupError === '',
-        cleanupError ? `${cleanupError} (provider rows: ${leftover})` : `provider rows: ${leftover}`);
+        failures.length === 0, failures.join('; '));
     }
-    cleanupMysqlDefaultsFile();
   }
+}
+
+/*
+ * Node does not run finally blocks on SIGINT/SIGTERM, so remove the seeded rows
+ * and the cleartext password file here too. The browser is left to the OS; only
+ * the database rows and that file matter.
+ */
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    console.error(`\n${signal} received; removing seeded rows before exiting.`);
+    let failures = [];
+    try {
+      failures = runCleanupOnce();
+    } catch (error) {
+      console.error(`WARN cleanup after ${signal} failed: ${error.message}`);
+    }
+    failures.forEach((failure) => console.error(`WARN ${failure}`));
+    process.exit(130);
+  });
 }
 
 run()
   .catch((error) => check('script completed without error', false, error.message))
   .finally(() => {
     fs.mkdirSync(screenshotDir, { recursive: true });
-    fs.writeFileSync(path.join(screenshotDir, 'results.json'), JSON.stringify(results, null, 2));
+    fs.writeFileSync(buildArtifactPath(screenshotDir, 'results', '.json'), JSON.stringify(results, null, 2));
     const failed = results.filter((result) => !result.ok);
     console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
     process.exit(failed.length ? 1 : 0);

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -162,9 +162,12 @@ function seedProvider(providerNo, lastName) {
 }
 
 function removeProvider(providerNo) {
-  // Ordered by the foreign keys that reference provider.provider_no.
+  // Ordered by the foreign keys that reference provider.provider_no. Errors are
+  // NOT swallowed: a cleanup that half-fails leaves a seeded provider and an
+  // `admin` grant behind in the target database, which must never be reported
+  // as a clean run.
   for (const table of ['secUserRole', 'program_provider', 'provider_facility', 'security']) {
-    try { sql(`DELETE FROM ${table} WHERE provider_no='${providerNo}'`); } catch { /* table may not reference it */ }
+    sql(`DELETE FROM ${table} WHERE provider_no='${providerNo}'`);
   }
   sql(`DELETE FROM provider WHERE provider_no='${providerNo}'`);
 }
@@ -213,11 +216,23 @@ async function run() {
     const select = row.locator('select[name="roleNew"]').first();
     await select.selectOption(SUPER_ROOT_ROLE);
     const addButton = row.locator('input[name="submit"][value="Add"]').first();
-    // The Add button is disabled until the change handler runs; selectOption
-    // fires it, but assert rather than assume so a UI change fails loudly.
-    await addButton.waitFor({ state: 'attached', timeout: 30000 });
-    await addButton.evaluate((el) => { el.disabled = false; });
-    await addButton.click();
+    // The Add button ships disabled; the select's onchange (enableAddRoleButton)
+    // is what enables it for a role the provider does not already hold. Wait for
+    // that to happen rather than clearing `disabled` here: forcing it would let
+    // this check pass even when a real user cannot submit the assignment at all.
+    // Playwright's click() waits for the element to be enabled as part of its
+    // actionability checks, so a handler that never enables the button surfaces
+    // here as a timeout instead of a silently forced click.
+    let addButtonEnabled = true;
+    let addButtonDetail = '';
+    try {
+      await addButton.click({ timeout: 30000 });
+    } catch (error) {
+      addButtonEnabled = false;
+      addButtonDetail = `Add stayed disabled after selecting "${SUPER_ROOT_ROLE}"`;
+    }
+    check('the role change handler enables Add, and the click submits',
+      addButtonEnabled, addButtonDetail);
     await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
     await page.screenshot({ path: shot('assign-role-assigned'), fullPage: true });
 
@@ -227,9 +242,23 @@ async function run() {
   } finally {
     if (browser) await browser.close();
     if (seeded) {
-      try { removeProvider(providerNo); } catch (error) {
-        console.error(`cleanup failed for provider ${providerNo}: ${error.message}`);
+      let cleanupError = '';
+      try {
+        removeProvider(providerNo);
+      } catch (error) {
+        cleanupError = error.message;
       }
+      // Verify, rather than trust, that nothing was left behind — then fail the
+      // run if it was, so a stale fixture can never hide behind a green result.
+      let leftover = 'unknown';
+      try {
+        leftover = sql(`SELECT COUNT(*) FROM provider WHERE provider_no='${providerNo}'`);
+      } catch (error) {
+        leftover = `unreadable (${error.message})`;
+      }
+      check(`fixture provider ${providerNo} removed`,
+        leftover === '0' && cleanupError === '',
+        cleanupError ? `${cleanupError} (provider rows: ${leftover})` : `provider rows: ${leftover}`);
     }
     cleanupMysqlDefaultsFile();
   }

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+/*
+ * Browser check for the CARLOS Assign Role dropdown.
+ *
+ * An alpha tester could not create a second administrator: Administration >
+ * Assign Role withheld the `admin` role from its dropdown on a standalone
+ * install, because the seeded `admin` role holds `_site_access_privacy` and the
+ * multisite super-root narrowing was applied without checking that multisites
+ * was actually enabled. Since the seeded carlosdoc account is meant to be
+ * DEACTIVATED once real accounts exist (see debian/ initial-admin.txt), losing
+ * `admin` from this dropdown is a lockout, not a cosmetic defect.
+ *
+ * The script logs in as an admin, asserts the role dropdown offers the
+ * super-root role, seeds a uniquely stamped provider, assigns that role to it
+ * through the browser, verifies the secUserRole row in MySQL, writes local
+ * screenshots/results, and cleans up the rows it created.
+ *
+ * Defaults are for the local devcontainer:
+ *   npm run test:assign-role-playwright
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc TEST_PASSWORD=carlos2026 TEST_PIN=2026
+ *   MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_PASSWORD=password MYSQL_DATABASE=carlos
+ *   ASSIGN_ROLE_SCREENSHOT_DIR=/tmp/carlos-assign-role-playwright
+ *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ */
+const assert = require('assert');
+const { chromium } = require('playwright');
+const { execFileSync } = require('child_process');
+const { randomInt } = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+const mysqlHost = process.env.MYSQL_HOST || '127.0.0.1';
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'carlos';
+const screenshotDir = process.env.ASSIGN_ROLE_SCREENSHOT_DIR || '/tmp/carlos-assign-role-playwright';
+const mysqlTimeoutMs = 30000;
+
+// The role the multisite narrowing targets. Kept in sync with the
+// multioffice.admin.role.name property that providerRole.jsp reads.
+const SUPER_ROOT_ROLE = process.env.ASSIGN_ROLE_SUPER_ROOT || 'admin';
+
+let mysqlDefaults = null;
+const results = [];
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
+  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+function appUrl(suffix) {
+  return `${baseUrl.origin}${baseUrl.pathname}${suffix}`;
+}
+
+function createMysqlDefaultsFile() {
+  if (/[\r\n]/.test(mysqlPassword)) {
+    throw new Error('MYSQL_PASSWORD must not contain newline characters');
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-assign-role-mysql-'));
+  const file = path.join(dir, 'client.cnf');
+  try {
+    fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+    return { dir, file };
+  } catch (error) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function cleanupMysqlDefaultsFile() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+
+function sql(query) {
+  assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', mysqlHost,
+    '-u', mysqlUser,
+    mysqlDatabase,
+    '-N', '-B', '-e', query,
+  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: mysqlTimeoutMs }).trim();
+}
+
+function check(name, ok, detail) {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` -- ${detail}` : ''}`);
+}
+
+function shot(name) {
+  assert(/^[0-9a-z-]+$/.test(name), `Invalid screenshot name: ${name}`);
+  return path.join(screenshotDir, `${name}.png`);
+}
+
+async function login(page) {
+  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await page.locator('input[type="submit"], button[type="submit"]').first().click();
+  await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
+}
+
+async function roleOptions(page, keyword) {
+  const query = keyword ? `?keyword=${encodeURIComponent(keyword)}` : '';
+  await page.goto(appUrl(`/admin/ProviderRole${query}`), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  const select = page.locator('select[name="roleNew"]').first();
+  await select.waitFor({ state: 'attached', timeout: 60000 });
+  return select.locator('option').evaluateAll((options) => options.map((option) => option.value));
+}
+
+function seedProvider(providerNo, lastName) {
+  // lastUpdateDate/lastUpdateUser are NOT NULL without defaults (the audit-trail
+  // columns every CARLOS table carries), so a bare column list fails on insert.
+  sql(`INSERT INTO provider (provider_no, last_name, first_name, provider_type, status,
+                             lastUpdateUser, lastUpdateDate)
+       VALUES ('${providerNo}', '${lastName}', 'RoleCheck', 'doctor', '1', '-1', NOW())`);
+}
+
+function removeProvider(providerNo) {
+  // Ordered by the foreign keys that reference provider.provider_no.
+  for (const table of ['secUserRole', 'program_provider', 'provider_facility', 'security']) {
+    try { sql(`DELETE FROM ${table} WHERE provider_no='${providerNo}'`); } catch { /* table may not reference it */ }
+  }
+  sql(`DELETE FROM provider WHERE provider_no='${providerNo}'`);
+}
+
+async function run() {
+  const providerNo = String(900000 + randomInt(1000, 9999));
+  const lastName = `Rolecheck${providerNo}`;
+  let seeded = false;
+  let browser = null;
+
+  try {
+    fs.mkdirSync(screenshotDir, { recursive: true });
+    mysqlDefaults = createMysqlDefaultsFile();
+
+    // The narrowing only misfires when the acting admin actually holds
+    // _site_access_privacy; without it the check would pass vacuously.
+    const privilege = sql(
+      `SELECT privilege FROM secObjPrivilege WHERE objectName='_site_access_privacy'
+       AND roleUserGroup IN (SELECT role_name FROM secUserRole WHERE provider_no=
+         (SELECT provider_no FROM security WHERE user_name='${testUser}' LIMIT 1))`);
+    check(`${testUser} holds _site_access_privacy (the condition that triggered the bug)`,
+      privilege.length > 0, privilege || '(none)');
+
+    browser = await chromium.launch({
+      ...(chromePath ? { executablePath: chromePath } : {}),
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    });
+    const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
+
+    await login(page);
+    check('logged in', /providercontrol/i.test(page.url()), page.url());
+
+    const options = await roleOptions(page);
+    await page.screenshot({ path: shot('assign-role-dropdown'), fullPage: true });
+    check(`Assign Role dropdown offers the "${SUPER_ROOT_ROLE}" role`,
+      options.includes(SUPER_ROOT_ROLE), `${options.length} options`);
+
+    seedProvider(providerNo, lastName);
+    seeded = true;
+
+    await roleOptions(page, lastName);
+    // The JSP wraps each <tr> in a <form> INSIDE the <table>; HTML parsing
+    // hoists the form out and leaves the row behind, so address the row.
+    const row = page.locator('tr', { hasText: providerNo }).first();
+    await row.waitFor({ state: 'attached', timeout: 30000 });
+    const select = row.locator('select[name="roleNew"]').first();
+    await select.selectOption(SUPER_ROOT_ROLE);
+    const addButton = row.locator('input[name="submit"][value="Add"]').first();
+    // The Add button is disabled until the change handler runs; selectOption
+    // fires it, but assert rather than assume so a UI change fails loudly.
+    await addButton.waitFor({ state: 'attached', timeout: 30000 });
+    await addButton.evaluate((el) => { el.disabled = false; });
+    await addButton.click();
+    await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
+    await page.screenshot({ path: shot('assign-role-assigned'), fullPage: true });
+
+    const assigned = sql(`SELECT role_name FROM secUserRole WHERE provider_no='${providerNo}'`);
+    check(`"${SUPER_ROOT_ROLE}" role assigned through the browser and persisted`,
+      assigned === SUPER_ROOT_ROLE, assigned || '(none)');
+  } finally {
+    if (browser) await browser.close();
+    if (seeded) {
+      try { removeProvider(providerNo); } catch (error) {
+        console.error(`cleanup failed for provider ${providerNo}: ${error.message}`);
+      }
+    }
+    cleanupMysqlDefaultsFile();
+  }
+}
+
+run()
+  .catch((error) => check('script completed without error', false, error.message))
+  .finally(() => {
+    fs.mkdirSync(screenshotDir, { recursive: true });
+    fs.writeFileSync(path.join(screenshotDir, 'results.json'), JSON.stringify(results, null, 2));
+    const failed = results.filter((result) => !result.ok);
+    console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+    process.exit(failed.length ? 1 : 0);
+  });

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -153,6 +153,17 @@ function playwrightBaseUrl() {
   return `${baseUrl.origin}${baseUrl.pathname.replace(/\/$/, '')}/`;
 }
 
+// my.cnf option-file values are not raw text: '\' starts an escape sequence
+// ('\s' is a space, '\t' a tab) and an unquoted '#' starts a comment that
+// truncates the rest of the line, so a password written verbatim is silently
+// corrupted and the run dies on "Access denied". Double-quoting neutralizes
+// '#' and surrounding whitespace; '\' and '"' still need escaping inside the
+// quotes. Same helper as login-playwright-checks.js, where the failure was
+// first hit against a dev password containing a backslash.
+function encodeOptionFileValue(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function createMysqlDefaultsFile() {
   if (/[\r\n]/.test(mysqlPassword)) {
     throw new Error('MYSQL_PASSWORD must not contain newline characters');
@@ -160,7 +171,11 @@ function createMysqlDefaultsFile() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-assign-role-mysql-'));
   const file = path.join(dir, 'client.cnf');
   try {
-    fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+    fs.writeFileSync(
+      file,
+      `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`,
+      { mode: 0o600 }
+    );
     return { dir, file };
   } catch (error) {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -235,8 +235,15 @@ async function login(page) {
 }
 
 async function roleOptions(page, keyword) {
-  const query = keyword ? `?keyword=${encodeURIComponent(keyword)}` : '';
-  await page.goto(`./admin/ProviderRole${query}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // Literal path, then filter through the page's own search form rather than
+  // composing a query string into goto(): it keeps an interpolated value out of
+  // the navigation entirely, and it exercises the filter a user actually uses.
+  await page.goto('./admin/ProviderRole', { waitUntil: 'domcontentloaded', timeout: 60000 });
+  if (keyword) {
+    await page.locator('input[name="keyword"]').first().fill(keyword);
+    await page.locator('input[name="search"]').first().click();
+    await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
+  }
   const select = page.locator('select[name="roleNew"]').first();
   await select.waitFor({ state: 'attached', timeout: 60000 });
   return select.locator('option').evaluateAll((options) => options.map((option) => option.value));

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -257,15 +257,27 @@ function seedProvider(providerNo, lastName) {
        VALUES ('${escapeSql(providerNo)}', '${escapeSql(lastName)}', 'RoleCheck', 'doctor', '1', '-1', NOW())`);
 }
 
+/*
+ * Ordered by the foreign keys that reference provider.provider_no.
+ *
+ * Every delete is attempted even after one fails, and every failure is
+ * reported: letting the first error propagate would skip the remaining tables
+ * AND the provider row itself, which is the same stranded fixture that
+ * swallowing the errors produced — just arrived at from the other direction.
+ *
+ * @return the failures encountered, empty when the fixture is fully removed
+ */
 function removeProvider(providerNo) {
-  // Ordered by the foreign keys that reference provider.provider_no. Errors are
-  // NOT swallowed: a cleanup that half-fails leaves a seeded provider and an
-  // `admin` grant behind in the target database, which must never be reported
-  // as a clean run.
-  for (const table of ['secUserRole', 'program_provider', 'provider_facility', 'security']) {
-    sql(`DELETE FROM ${table} WHERE provider_no='${escapeSql(providerNo)}'`);
+  const failures = [];
+  const tables = ['secUserRole', 'program_provider', 'provider_facility', 'security', 'provider'];
+  for (const table of tables) {
+    try {
+      sql(`DELETE FROM ${table} WHERE provider_no='${escapeSql(providerNo)}'`);
+    } catch (error) {
+      failures.push(`${table}: ${error.message}`);
+    }
   }
-  sql(`DELETE FROM provider WHERE provider_no='${escapeSql(providerNo)}'`);
+  return failures;
 }
 
 /*
@@ -283,11 +295,7 @@ function runCleanupOnce() {
     // Cleared first: a second entry (finally after a signal) must not re-run
     // the deletes or double-report them.
     seededProviderNo = null;
-    try {
-      removeProvider(providerNo);
-    } catch (error) {
-      failures.push(`removing fixture provider failed: ${error.message}`);
-    }
+    failures.push(...removeProvider(providerNo));
     // Verify, rather than trust, that nothing was left behind.
     try {
       const leftover = sql(`SELECT COUNT(*) FROM provider WHERE provider_no='${escapeSql(providerNo)}'`);
@@ -361,7 +369,13 @@ async function run() {
       await addButton.click({ timeout: 30000 });
     } catch (error) {
       addButtonEnabled = false;
-      addButtonDetail = `Add stayed disabled after selecting "${SUPER_ROOT_ROLE}"`;
+      // click() also fails when the element is detached, hidden or obstructed,
+      // so read the real state before blaming the change handler — otherwise a
+      // failing check points at the wrong thing.
+      const stillDisabled = await addButton.isDisabled().catch(() => null);
+      addButtonDetail = stillDisabled === true
+        ? `Add stayed disabled after selecting "${SUPER_ROOT_ROLE}"`
+        : `Add could not be clicked (disabled=${stillDisabled}): ${String(error.message).split('\n')[0].slice(0, 200)}`;
     }
     check('the role change handler enables Add, and the click submits',
       addButtonEnabled, addButtonDetail);

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -45,7 +45,8 @@
  *   TEST_USER=carlosdoc TEST_PASSWORD=carlos2026 TEST_PIN=2026
  *   MYSQL_HOST=127.0.0.1 MYSQL_USER=root MYSQL_PASSWORD=password MYSQL_DATABASE=carlos
  *   ASSIGN_ROLE_SCREENSHOT_DIR=/tmp/carlos-assign-role-playwright
- *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ *   ALLOW_NON_LOCAL_BASE_URL=true for any target that is not loopback or the
+ *     compose network — private IPv4 addresses included
  *   ALLOW_NON_LOCAL_MYSQL_HOST=true only for a disposable non-local test database
  */
 const assert = require('assert');
@@ -57,12 +58,23 @@ const os = require('os');
 const path = require('path');
 const { buildArtifactPath } = require('./eform-local-playwright-utils');
 
+/*
+ * Hosts this script will browse without an explicit opt-in.
+ *
+ * NOTE this is deliberately stricter than the sibling harnesses, which also
+ * accept the private IPv4 ranges as "local". Those ranges reach the developer's
+ * host or a shared network, and this check logs in as an administrator and then
+ * grants the installation-wide administrator role, so a private-network address
+ * has to be opted into via ALLOW_NON_LOCAL_BASE_URL like any other non-local
+ * target. Nothing is lost: the opt-in is one environment variable.
+ */
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'db', 'carlos']);
 
 /*
- * Hosts that are unambiguously this machine or its private compose network.
- * Deliberately narrower than isLocalHost: the database target keys off this,
- * because this check WRITES a provider row and an `admin` role grant.
+ * Hosts that are unambiguously this machine or its compose network. Narrower
+ * still than LOCAL_HOSTS, and two things key off it: the database target,
+ * because this check WRITES a provider row and an `admin` role grant, and
+ * whether http is acceptable, because anything else must prove a certificate.
  */
 const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
 
@@ -70,27 +82,8 @@ function normalizeHost(rawHost) {
   return rawHost.toLowerCase().replace(/^\[|\]$/g, '');
 }
 
-/*
- * Match four numeric octets, not a `10.`-style prefix: a bare prefix test also
- * accepts DNS names such as `10.attacker.example`, which would slip past the
- * non-local opt-in and receive a real login.
- */
-function isPrivateIpv4(host) {
-  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!match) {
-    return false;
-  }
-  const octets = match.slice(1).map(Number);
-  if (octets.some((octet) => octet > 255)) {
-    return false;
-  }
-  const [a, b] = octets;
-  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
-}
-
 function isLocalHost(rawHost) {
-  const host = normalizeHost(rawHost);
-  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+  return LOCAL_HOSTS.has(normalizeHost(rawHost));
 }
 
 function isExactLocalHost(rawHost) {

--- a/src/main/java/io/github/carlos_emr/carlos/admin/support/AssignableRoles.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/support/AssignableRoles.java
@@ -23,9 +23,7 @@ package io.github.carlos_emr.carlos.admin.support;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,19 +34,20 @@ import org.apache.commons.lang3.StringUtils;
  * {@code multioffice.admin.role.name} property from site-restricted
  * administrators, so that an administrator scoped to one office cannot hand
  * out installation-wide authority. That narrowing is presentation only — the
- * Assign Role POST handler does not re-check it — and it is meaningless
- * outside a multisite install, where every administrator is already
- * installation-wide.</p>
+ * Assign Role POST handler does not re-check it.</p>
  *
- * <p>Two guards keep the narrowing from locking an installation out of its own
- * administrator role (the seeded {@code admin} role itself holds
- * {@code _site_access_privacy}, so it would otherwise hide itself from the only
- * account able to grant it):</p>
- * <ul>
- *   <li>it applies only when multisites is enabled, and</li>
- *   <li>it never hides a role the acting administrator already holds — offering
- *       a role you already have is not a privilege escalation.</li>
- * </ul>
+ * <p>The narrowing applies <em>only</em> when multisites is enabled. Upstream
+ * introduced it with the multi-office feature (2010) and granted
+ * {@code _site_access_privacy} to no role at all, so on a single-office install
+ * it never fired. CARLOS later seeded that object to the {@code admin} role,
+ * which made the unguarded narrowing hide the administrator role from the only
+ * account able to grant it — a lockout, since the installer tells operators to
+ * deactivate the seeded account once real ones exist.</p>
+ *
+ * <p>The multisites gate restores the upstream behaviour without inventing new
+ * policy: inside a genuine multisite install a site-scoped administrator still
+ * does not see the super-root role. Removing the stray seed grant is the
+ * complete fix and would make this gate redundant; it is tracked separately.</p>
  *
  * @since 2026-09-04
  */
@@ -58,51 +57,23 @@ public final class AssignableRoles {
     }
 
     /**
-     * Splits the comma-separated role list carried in the {@code userrole}
-     * session attribute into individual role names.
-     *
-     * @param commaSeparatedRoleNames raw session value; may be {@code null}
-     * @return the distinct, trimmed role names in their original order; never
-     *         {@code null}
-     */
-    public static Set<String> parseRoleNames(String commaSeparatedRoleNames) {
-        Set<String> roleNames = new LinkedHashSet<String>();
-
-        if (commaSeparatedRoleNames == null) {
-            return roleNames;
-        }
-
-        for (String candidate : commaSeparatedRoleNames.split(",")) {
-            String roleName = StringUtils.trimToNull(candidate);
-            if (roleName != null) {
-                roleNames.add(roleName);
-            }
-        }
-
-        return roleNames;
-    }
-
-    /**
      * Filters the installation's role names down to the ones the acting
      * administrator may assign.
      *
-     * @param allRoleNames        every configured role name, in display order;
-     *                            may be {@code null}
-     * @param siteAccessPrivacy   whether the acting administrator holds
-     *                            {@code _site_access_privacy}
-     * @param multisitesEnabled   whether the {@code multisites} property is on
-     * @param protectedRoleName   the super-root role name from
-     *                            {@code multioffice.admin.role.name}; blank
-     *                            disables the narrowing
-     * @param callerRoleNames     roles the acting administrator already holds;
-     *                            may be {@code null}
+     * @param allRoleNames       every configured role name, in display order;
+     *                           may be {@code null}
+     * @param siteAccessPrivacy  whether the acting administrator holds
+     *                           {@code _site_access_privacy}
+     * @param multisitesEnabled  whether the {@code multisites} property is on
+     * @param protectedRoleName  the super-root role name from
+     *                           {@code multioffice.admin.role.name}; blank
+     *                           disables the narrowing
      * @return the assignable role names; never {@code null}
      */
     public static List<String> filter(Collection<String> allRoleNames,
                                       boolean siteAccessPrivacy,
                                       boolean multisitesEnabled,
-                                      String protectedRoleName,
-                                      Collection<String> callerRoleNames) {
+                                      String protectedRoleName) {
         List<String> assignable = new ArrayList<String>();
 
         if (allRoleNames == null) {
@@ -110,7 +81,7 @@ public final class AssignableRoles {
         }
 
         String hiddenRoleName = resolveHiddenRoleName(
-                siteAccessPrivacy, multisitesEnabled, protectedRoleName, callerRoleNames);
+                siteAccessPrivacy, multisitesEnabled, protectedRoleName);
 
         for (String roleName : allRoleNames) {
             if (roleName == null || roleName.equals(hiddenRoleName)) {
@@ -128,23 +99,10 @@ public final class AssignableRoles {
      */
     private static String resolveHiddenRoleName(boolean siteAccessPrivacy,
                                                 boolean multisitesEnabled,
-                                                String protectedRoleName,
-                                                Collection<String> callerRoleNames) {
+                                                String protectedRoleName) {
         if (!siteAccessPrivacy || !multisitesEnabled) {
             return null;
         }
-
-        String hiddenRoleName = StringUtils.trimToNull(protectedRoleName);
-        if (hiddenRoleName == null) {
-            return null;
-        }
-
-        // Never hide a role the acting administrator already holds, otherwise the
-        // last holder of the super-root role can never pass it on.
-        if (callerRoleNames != null && callerRoleNames.contains(hiddenRoleName)) {
-            return null;
-        }
-
-        return hiddenRoleName;
+        return StringUtils.trimToNull(protectedRoleName);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/admin/support/AssignableRoles.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/support/AssignableRoles.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.admin.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Decides which security role names the Assign Role admin page may offer.
+ *
+ * <p>Multisite deployments hide the "super root" role named by the
+ * {@code multioffice.admin.role.name} property from site-restricted
+ * administrators, so that an administrator scoped to one office cannot hand
+ * out installation-wide authority. That narrowing is presentation only — the
+ * Assign Role POST handler does not re-check it — and it is meaningless
+ * outside a multisite install, where every administrator is already
+ * installation-wide.</p>
+ *
+ * <p>Two guards keep the narrowing from locking an installation out of its own
+ * administrator role (the seeded {@code admin} role itself holds
+ * {@code _site_access_privacy}, so it would otherwise hide itself from the only
+ * account able to grant it):</p>
+ * <ul>
+ *   <li>it applies only when multisites is enabled, and</li>
+ *   <li>it never hides a role the acting administrator already holds — offering
+ *       a role you already have is not a privilege escalation.</li>
+ * </ul>
+ *
+ * @since 2026-09-04
+ */
+public final class AssignableRoles {
+
+    private AssignableRoles() {
+    }
+
+    /**
+     * Splits the comma-separated role list carried in the {@code userrole}
+     * session attribute into individual role names.
+     *
+     * @param commaSeparatedRoleNames raw session value; may be {@code null}
+     * @return the distinct, trimmed role names in their original order; never
+     *         {@code null}
+     */
+    public static Set<String> parseRoleNames(String commaSeparatedRoleNames) {
+        Set<String> roleNames = new LinkedHashSet<String>();
+
+        if (commaSeparatedRoleNames == null) {
+            return roleNames;
+        }
+
+        for (String candidate : commaSeparatedRoleNames.split(",")) {
+            String roleName = StringUtils.trimToNull(candidate);
+            if (roleName != null) {
+                roleNames.add(roleName);
+            }
+        }
+
+        return roleNames;
+    }
+
+    /**
+     * Filters the installation's role names down to the ones the acting
+     * administrator may assign.
+     *
+     * @param allRoleNames        every configured role name, in display order;
+     *                            may be {@code null}
+     * @param siteAccessPrivacy   whether the acting administrator holds
+     *                            {@code _site_access_privacy}
+     * @param multisitesEnabled   whether the {@code multisites} property is on
+     * @param protectedRoleName   the super-root role name from
+     *                            {@code multioffice.admin.role.name}; blank
+     *                            disables the narrowing
+     * @param callerRoleNames     roles the acting administrator already holds;
+     *                            may be {@code null}
+     * @return the assignable role names; never {@code null}
+     */
+    public static List<String> filter(Collection<String> allRoleNames,
+                                      boolean siteAccessPrivacy,
+                                      boolean multisitesEnabled,
+                                      String protectedRoleName,
+                                      Collection<String> callerRoleNames) {
+        List<String> assignable = new ArrayList<String>();
+
+        if (allRoleNames == null) {
+            return assignable;
+        }
+
+        String hiddenRoleName = resolveHiddenRoleName(
+                siteAccessPrivacy, multisitesEnabled, protectedRoleName, callerRoleNames);
+
+        for (String roleName : allRoleNames) {
+            if (roleName == null || roleName.equals(hiddenRoleName)) {
+                continue;
+            }
+            assignable.add(roleName);
+        }
+
+        return assignable;
+    }
+
+    /**
+     * @return the single role name to withhold, or {@code null} when nothing is
+     *         withheld
+     */
+    private static String resolveHiddenRoleName(boolean siteAccessPrivacy,
+                                                boolean multisitesEnabled,
+                                                String protectedRoleName,
+                                                Collection<String> callerRoleNames) {
+        if (!siteAccessPrivacy || !multisitesEnabled) {
+            return null;
+        }
+
+        String hiddenRoleName = StringUtils.trimToNull(protectedRoleName);
+        if (hiddenRoleName == null) {
+            return null;
+        }
+
+        // Never hide a role the acting administrator already holds, otherwise the
+        // last holder of the super-root role can never pass it on.
+        if (callerRoleNames != null && callerRoleNames.contains(hiddenRoleName)) {
+            return null;
+        }
+
+        return hiddenRoleName;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/admin/support/package-info.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/support/package-info.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+/**
+ * Dependency-free support utilities for the administration module.
+ *
+ * <p>Classes in this package use focused domain nouns instead of generic
+ * helper names. They exist so that decision logic which would otherwise live
+ * inside legacy admin JSP scriptlets can be unit tested: they must stay
+ * static or value-like, with no Spring dependencies, no servlet API coupling,
+ * and no persistence side effects.</p>
+ *
+ * @since 2026-09-04
+ */
+package io.github.carlos_emr.carlos.admin.support;

--- a/src/main/webapp/WEB-INF/jsp/admin/providerRole.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/providerRole.jsp
@@ -139,14 +139,12 @@
     // Withholding the multisite super-root role is a multisite concern only. The seeded
     // `admin` role itself holds `_site_access_privacy`, so without the multisites gate a
     // standalone install drops `admin` from this dropdown and the last administrator can
-    // never hand the role over before being deactivated. See AssignableRoles for the
-    // second guard (a role you already hold is never withheld from you).
+    // never hand the role over before being deactivated.
     vecRoleName.addAll(AssignableRoles.filter(
             allRoleNames,
             isSiteAccessPrivacy,
             IsPropertiesOn.isMultisitesEnable(),
-            CarlosProperties.getInstance().getProperty("multioffice.admin.role.name", ""),
-            AssignableRoles.parseRoleNames((String) session.getAttribute("userrole"))));
+            CarlosProperties.getInstance().getProperty("multioffice.admin.role.name", "")));
 
     java.util.ResourceBundle oscarRec = ResourceBundle.getBundle("oscarResources", request.getLocale());
 //set the primary role

--- a/src/main/webapp/WEB-INF/jsp/admin/providerRole.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/providerRole.jsp
@@ -58,6 +58,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
+<%@ page import="io.github.carlos_emr.carlos.admin.support.AssignableRoles" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
@@ -129,20 +130,24 @@
 
 // get role from database
     Vector vecRoleName = new Vector();
-    String sql;
-    String adminRoleName = "";
 
-    String omit = "";
-    if (isSiteAccessPrivacy) {
-        omit = CarlosProperties.getInstance().getProperty("multioffice.admin.role.name", "");
+    List<String> allRoleNames = new ArrayList<String>();
+    for (SecRole secRole : secRoleDao.findAllOrderByRole()) {
+        allRoleNames.add(secRole.getName());
     }
 
-    List<SecRole> secRoles = secRoleDao.findAllOrderByRole();
-    for (SecRole secRole : secRoles) {
-        if (!secRole.getName().equals(omit)) {
-            vecRoleName.add(secRole.getName());
-        }
-    }
+    // Withholding the multisite super-root role is a multisite concern only. The seeded
+    // `admin` role itself holds `_site_access_privacy`, so without the multisites gate a
+    // standalone install drops `admin` from this dropdown and the last administrator can
+    // never hand the role over before being deactivated. See AssignableRoles for the
+    // second guard (a role you already hold is never withheld from you).
+    vecRoleName.addAll(AssignableRoles.filter(
+            allRoleNames,
+            isSiteAccessPrivacy,
+            IsPropertiesOn.isMultisitesEnable(),
+            CarlosProperties.getInstance().getProperty("multioffice.admin.role.name", ""),
+            AssignableRoles.parseRoleNames((String) session.getAttribute("userrole"))));
+
     java.util.ResourceBundle oscarRec = ResourceBundle.getBundle("oscarResources", request.getLocale());
 //set the primary role
     if (request.getParameter("buttonSetPrimaryRole") != null && request.getParameter("buttonSetPrimaryRole").length() > 0) {

--- a/src/test/java/io/github/carlos_emr/carlos/admin/ProviderRoleAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/ProviderRoleAssetRegressionTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.admin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards Assign Role JSP behavior that is otherwise only exercised when the
+ * container renders the page (JSPs compile under the {@code jspc} profile, not
+ * in the default build).
+ *
+ * @since 2026-09-04
+ */
+@DisplayName("Provider role asset regressions")
+@Tag("unit")
+@Tag("admin")
+class ProviderRoleAssetRegressionTest {
+
+    private static final Path PROVIDER_ROLE_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "admin", "providerRole.jsp");
+
+    @Test
+    @DisplayName("should build the role dropdown through the assignable-roles guards")
+    void shouldBuildRoleDropdown_throughAssignableRolesGuards() throws IOException {
+        String jsp = readProviderRoleJsp();
+
+        assertThat(jsp)
+                .contains("<%@ page import=\"io.github.carlos_emr.carlos.admin.support.AssignableRoles\" %>")
+                .contains("AssignableRoles.filter(")
+                .contains("IsPropertiesOn.isMultisitesEnable()")
+                .contains("AssignableRoles.parseRoleNames((String) session.getAttribute(\"userrole\"))")
+                // The unguarded narrowing hid the seeded `admin` role from the only
+                // account able to grant it on a standalone install (2026.08 alpha).
+                .doesNotContainPattern("if \\(isSiteAccessPrivacy\\) \\{\\s+"
+                        + "omit = CarlosProperties\\.getInstance\\(\\)")
+                .doesNotContain("secRole.getName().equals(omit)");
+    }
+
+    private static String readProviderRoleJsp() throws IOException {
+        return Files.readString(PROVIDER_ROLE_JSP, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/admin/ProviderRoleAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/ProviderRoleAssetRegressionTest.java
@@ -55,8 +55,10 @@ class ProviderRoleAssetRegressionTest {
         assertThat(jsp)
                 .contains("<%@ page import=\"io.github.carlos_emr.carlos.admin.support.AssignableRoles\" %>")
                 .contains("AssignableRoles.filter(")
+                // The multisites gate is the whole fix: without it the seeded `admin`
+                // role, which holds `_site_access_privacy`, hides itself from the only
+                // account able to grant it.
                 .contains("IsPropertiesOn.isMultisitesEnable()")
-                .contains("AssignableRoles.parseRoleNames((String) session.getAttribute(\"userrole\"))")
                 // The unguarded narrowing hid the seeded `admin` role from the only
                 // account able to grant it on a standalone install (2026.08 alpha).
                 .doesNotContainPattern("if \\(isSiteAccessPrivacy\\) \\{\\s+"

--- a/src/test/java/io/github/carlos_emr/carlos/admin/support/AssignableRolesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/support/AssignableRolesUnitTest.java
@@ -22,9 +22,7 @@
 package io.github.carlos_emr.carlos.admin.support;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -59,25 +57,16 @@ class AssignableRolesUnitTest {
             // The reported alpha bug: the seeded `admin` role holds
             // `_site_access_privacy`, so a standalone install hid `admin` from itself.
             List<String> assignable = AssignableRoles.filter(
-                    ALL_ROLES, true, false, ADMIN, Collections.<String>emptySet());
+                    ALL_ROLES, true, false, ADMIN);
 
             assertThat(assignable).containsExactly(ADMIN, "doctor", "nurse", "receptionist");
-        }
-
-        @Test
-        @DisplayName("should keep the administrator role when the caller already holds it")
-        void shouldKeepAdministratorRole_whenCallerAlreadyHoldsIt() {
-            List<String> assignable = AssignableRoles.filter(
-                    ALL_ROLES, true, true, ADMIN, AssignableRoles.parseRoleNames("admin,doctor"));
-
-            assertThat(assignable).contains(ADMIN);
         }
 
         @Test
         @DisplayName("should withhold the administrator role from a site-restricted caller in a multisite install")
         void shouldWithholdAdministratorRole_fromSiteRestrictedMultisiteCaller() {
             List<String> assignable = AssignableRoles.filter(
-                    ALL_ROLES, true, true, ADMIN, AssignableRoles.parseRoleNames("receptionist"));
+                    ALL_ROLES, true, true, ADMIN);
 
             assertThat(assignable)
                     .doesNotContain(ADMIN)
@@ -88,7 +77,7 @@ class AssignableRolesUnitTest {
         @DisplayName("should keep every role when the caller has no site access privacy")
         void shouldKeepEveryRole_whenCallerHasNoSiteAccessPrivacy() {
             List<String> assignable = AssignableRoles.filter(
-                    ALL_ROLES, false, true, ADMIN, AssignableRoles.parseRoleNames("receptionist"));
+                    ALL_ROLES, false, true, ADMIN);
 
             assertThat(assignable).containsExactlyElementsOf(ALL_ROLES);
         }
@@ -97,7 +86,7 @@ class AssignableRolesUnitTest {
         @DisplayName("should keep every role when no super root role name is configured")
         void shouldKeepEveryRole_whenNoSuperRootRoleConfigured() {
             List<String> assignable = AssignableRoles.filter(
-                    ALL_ROLES, true, true, "  ", AssignableRoles.parseRoleNames("receptionist"));
+                    ALL_ROLES, true, true, "  ");
 
             assertThat(assignable).containsExactlyElementsOf(ALL_ROLES);
         }
@@ -105,34 +94,17 @@ class AssignableRolesUnitTest {
         @Test
         @DisplayName("should return an empty list for null role names")
         void shouldReturnEmptyList_forNullRoleNames() {
-            assertThat(AssignableRoles.filter(null, true, true, ADMIN, null)).isEmpty();
+            assertThat(AssignableRoles.filter(null, true, true, ADMIN)).isEmpty();
         }
 
         @Test
-        @DisplayName("should tolerate a null caller role collection")
-        void shouldTolerateNullCallerRoles_withMultisiteNarrowing() {
-            List<String> assignable = AssignableRoles.filter(ALL_ROLES, true, true, ADMIN, null);
+        @DisplayName("should skip null entries in the role list")
+        void shouldSkipNullEntries_inTheRoleList() {
+            List<String> withNull = Arrays.asList(ADMIN, null, "doctor");
 
-            assertThat(assignable).doesNotContain(ADMIN);
-        }
-    }
+            List<String> assignable = AssignableRoles.filter(withNull, false, false, ADMIN);
 
-    @Nested
-    @DisplayName("parseRoleNames")
-    class ParseRoleNames {
-
-        @Test
-        @DisplayName("should split and trim the comma separated session value")
-        void shouldSplitAndTrimValue_fromSessionAttribute() {
-            Set<String> roleNames = AssignableRoles.parseRoleNames(" admin , doctor ,,doctor ");
-
-            assertThat(roleNames).containsExactly(ADMIN, "doctor");
-        }
-
-        @Test
-        @DisplayName("should return an empty set for a null session value")
-        void shouldReturnEmptySet_forNullSessionValue() {
-            assertThat(AssignableRoles.parseRoleNames(null)).isEmpty();
+            assertThat(assignable).containsExactly(ADMIN, "doctor");
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/admin/support/AssignableRolesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/support/AssignableRolesUnitTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.admin.support;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the Assign Role dropdown contents, in particular the guards that keep an
+ * installation from losing the ability to grant its own administrator role.
+ *
+ * @since 2026-09-04
+ */
+@DisplayName("Assignable roles")
+@Tag("unit")
+@Tag("admin")
+class AssignableRolesUnitTest {
+
+    private static final String ADMIN = "admin";
+
+    private static final List<String> ALL_ROLES =
+            Arrays.asList(ADMIN, "doctor", "nurse", "receptionist");
+
+    @Nested
+    @DisplayName("filter")
+    class Filter {
+
+        @Test
+        @DisplayName("should keep the administrator role when multisites is disabled")
+        void shouldKeepAdministratorRole_whenMultisitesDisabled() {
+            // The reported alpha bug: the seeded `admin` role holds
+            // `_site_access_privacy`, so a standalone install hid `admin` from itself.
+            List<String> assignable = AssignableRoles.filter(
+                    ALL_ROLES, true, false, ADMIN, Collections.<String>emptySet());
+
+            assertThat(assignable).containsExactly(ADMIN, "doctor", "nurse", "receptionist");
+        }
+
+        @Test
+        @DisplayName("should keep the administrator role when the caller already holds it")
+        void shouldKeepAdministratorRole_whenCallerAlreadyHoldsIt() {
+            List<String> assignable = AssignableRoles.filter(
+                    ALL_ROLES, true, true, ADMIN, AssignableRoles.parseRoleNames("admin,doctor"));
+
+            assertThat(assignable).contains(ADMIN);
+        }
+
+        @Test
+        @DisplayName("should withhold the administrator role from a site-restricted caller in a multisite install")
+        void shouldWithholdAdministratorRole_fromSiteRestrictedMultisiteCaller() {
+            List<String> assignable = AssignableRoles.filter(
+                    ALL_ROLES, true, true, ADMIN, AssignableRoles.parseRoleNames("receptionist"));
+
+            assertThat(assignable)
+                    .doesNotContain(ADMIN)
+                    .containsExactly("doctor", "nurse", "receptionist");
+        }
+
+        @Test
+        @DisplayName("should keep every role when the caller has no site access privacy")
+        void shouldKeepEveryRole_whenCallerHasNoSiteAccessPrivacy() {
+            List<String> assignable = AssignableRoles.filter(
+                    ALL_ROLES, false, true, ADMIN, AssignableRoles.parseRoleNames("receptionist"));
+
+            assertThat(assignable).containsExactlyElementsOf(ALL_ROLES);
+        }
+
+        @Test
+        @DisplayName("should keep every role when no super root role name is configured")
+        void shouldKeepEveryRole_whenNoSuperRootRoleConfigured() {
+            List<String> assignable = AssignableRoles.filter(
+                    ALL_ROLES, true, true, "  ", AssignableRoles.parseRoleNames("receptionist"));
+
+            assertThat(assignable).containsExactlyElementsOf(ALL_ROLES);
+        }
+
+        @Test
+        @DisplayName("should return an empty list for null role names")
+        void shouldReturnEmptyList_forNullRoleNames() {
+            assertThat(AssignableRoles.filter(null, true, true, ADMIN, null)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should tolerate a null caller role collection")
+        void shouldTolerateNullCallerRoles_withMultisiteNarrowing() {
+            List<String> assignable = AssignableRoles.filter(ALL_ROLES, true, true, ADMIN, null);
+
+            assertThat(assignable).doesNotContain(ADMIN);
+        }
+    }
+
+    @Nested
+    @DisplayName("parseRoleNames")
+    class ParseRoleNames {
+
+        @Test
+        @DisplayName("should split and trim the comma separated session value")
+        void shouldSplitAndTrimValue_fromSessionAttribute() {
+            Set<String> roleNames = AssignableRoles.parseRoleNames(" admin , doctor ,,doctor ");
+
+            assertThat(roleNames).containsExactly(ADMIN, "doctor");
+        }
+
+        @Test
+        @DisplayName("should return an empty set for a null session value")
+        void shouldReturnEmptySet_forNullSessionValue() {
+            assertThat(AssignableRoles.parseRoleNames(null)).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Description

An alpha tester reported that **Administration > Assign Role** never offers the `admin` role, so a site cannot create a second administrator — and therefore cannot deactivate the seeded `carlosdoc` account, which the installer explicitly instructs operators to do.

`providerRole.jsp` narrowed the role list like this:

```java
String omit = "";
if (isSiteAccessPrivacy) {
    omit = CarlosProperties.getInstance().getProperty("multioffice.admin.role.name", "");
}
```

That narrowing belongs to the **multi-office** feature — it keeps an administrator scoped to one office from handing out installation-wide authority. It was never gated on multisites being enabled, and on a stock install:

1. `carlos.properties:776` ships `multioffice.admin.role.name=admin`.
2. The seed grants the `admin` role `_site_access_privacy` with privilege `x` (`database/mysql/migration/on/V1.0.2__on_data.sql:35924`), and `x` satisfies any rights check (`OscarRoleObjectPrivilege.checkRights`) — so `isSiteAccessPrivacy` is **true for every administrator**.
3. `carlosdoc` (999998) holds `doctor` + `admin` (same file, line 36542).

So `omit` resolved to `admin` and the page hid the administrator role from the only account able to grant it. `multisites` is off/absent by default, so the narrowing's premise never held. The page could not even render the role `carlosdoc` already has — its own `admin` row displayed `-`.

### The fix: restore the upstream behaviour

One guard: **the narrowing applies only when multisites is enabled.**

That is exactly how this behaved upstream. The multi-office commit that introduced both the marker and the narrowing — **2865cb466** (Nov 2010, "adding full multi-office support with site-aware filtering, contributed by Dr. Eric Tam") — defined `_site_access_privacy` in `secObjectName` and granted it to **no role at all**. `isSiteAccessPrivacy` was false everywhere until a multisite deployment opted in by granting the marker to its site-scoped roles, so the narrowing never fired on a single-office install even with the property set. Inside a genuine multisite install a site-scoped administrator still does not see the super-root role — that behaviour is unchanged.

The decision lives in `AssignableRoles`, a dependency-free support class, because the JSP itself cannot be unit tested (JSPs compile only under the `jspc` profile).

Worth noting for review: the filter is **presentation-only**. The Assign Role POST handler never re-checked `omit`, so no enforced boundary is involved either way.

### The actual root cause is tracked separately

This PR fixes the user-visible lockout on the release line. The underlying defect is the seed grant of `_site_access_privacy` to `admin`, added by **39c152e46** (May 2026) after **`ViewAdminDisplayMyGroup2Action`** (Apr 2026) began gating page *entry* on that marker — reading a restriction as a permission. Roughly 21 other consumers apply site-restriction to administrators as a result, including several Ontario billing and report surfaces. Filed as **#3594** with the history trail, the consumer census and the ordered remediation. Removing that grant would make this PR's gate redundant; it is deliberately out of scope here, since a release branch is the wrong place to change a security-object seed and an auth gate.

## Related Issues

Reported by an alpha tester; no tracking issue was filed for the symptom. Root cause filed as **#3594**. Related to the sibling workaround in `securityaddarecord.jsp` (PR #2522), which is the same symptom of the same cause.

## Target Branch

Targets `release/2026.08` as a supported fix: `2026.08` is the oldest affected line, and the defect is present there unchanged. The topic branch was rebased onto `release/2026.08` so the diff carries **no** release metadata — `pom.xml` is untouched, and the branch does not drag in `main`'s `chore(release): prepare 2026.08.0-alpha10` commits, which would otherwise have reverted this branch's version from `2026.08.0-alpha10-SNAPSHOT` and pinned the SCM tag. Please forward-merge rather than opening a duplicate cherry-pick PR.

## How Was This Tested?

**Unit tests** — `AssignableRolesUnitTest` pins the gate in both directions; `ProviderRoleAssetRegressionTest` pins the JSP wiring (JSPs are not covered by the default build). 7/7 green.

**JSP compilation** — `mvn package -Pjspc` run locally after the final change: BUILD SUCCESS.

**Browser verification against a real packaged install.** Built this branch's WAR, built `carlos-emr_2026.09.0~snapshot18_all.deb` inside the digest-pinned `ubuntu:26.04` image the `deb-packages.yml` workflow uses, and installed it. The maintainer scripts ran clean — MariaDB 11.8 accounts provisioned, 18 Flyway migrations applied, schema at 1.0.17, seeded credential replaced. Then, through Chromium against the running app:

A/B on the deployed page, swapping the JSP underneath Tomcat:

| Deployed JSP | Role options | `admin` present |
|---|---|---|
| fixed | 34 | yes |
| pre-fix | **33** | **no** |
| restored | 34 | yes |

And the full workflow the tester said was blocked, entirely through the UI: **Add Provider → Add Login → Assign Role = admin** → the new account logs in, completes its own forced password reset, and reaches the Administration Panel. 8/8 checks.

`scripts/assign-role-playwright-checks.js` (added here, `npm run test:assign-role-playwright`) is the repeatable form. It asserts the precondition — that the acting admin actually holds `_site_access_privacy` — so it cannot pass vacuously, and it was confirmed to **fail** against the pre-fix JSP.

Three limits reviewers should know:

- The browser run above was performed before the second guard was removed. On a standalone install that guard was **unreachable** — with multisites off, `resolveHiddenRoleName` returns `null` before it is consulted — so the rendered page is unchanged. The removal is covered by the unit tests and the local `jspc` compile rather than a repeated browser pass.
- The verification host runs hybrid cgroup v1, and systemd 259 dropped cgroup v1 support, so no systemd container could boot. MariaDB and Tomcat were started by hand from their units' `ExecStart`. **The unit files, timers and service ordering are therefore not covered** — package build, install, migration and application behaviour are.
- nginx failed its config test in-container (`socket() [::]:80 failed (97: Address family not supported by protocol)`) because the container namespace has no IPv6, so the nginx/ModSecurity front door was not exercised; Tomcat was driven directly. This branch already carries `33e8a1bc4a fix(deb): keep front door up on IPv6-disabled hosts`.

## Screenshots

Before (pre-fix JSP) — `carlosdoc`'s own `admin` row renders `-`, because the role it holds is not in the list:

```
Provider  First Name  Last Name   Role
999998    doctor      carlosdoc   [ -       v]     <- admin missing
999998    doctor      carlosdoc   [ doctor  v]
```

After — 34 options, `admin` present and selected:

```
Provider  First Name  Last Name   Role
999998    doctor      carlosdoc   [ admin   v]
999998    doctor      carlosdoc   [ doctor  v]
```

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNhaQzRUcvwe67Qps2d94B