### PR TITLE
perf(db): add index migrations V1.0.18/V1.0.19 from database index review

### DIFF
--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -21,6 +21,8 @@ migration/
            V1.0.14__widen_faxes_jobid_to_bigint.sql
            V1.0.15__add_faxes_direction.sql
            V1.0.16__add_faxes_jobid_index.sql
+           V1.0.17__enable_digital_signatures_by_default.sql
+           V1.0.18__performance_indexes_2.sql  # forward delta: second DAO-justified index pass
   on/      V1.0.1__on_schema.sql            # Ontario-only tables (structure)
            V1.0.2__on_data.sql              # Ontario reference data (rows)
            V1.0.4__on_performance_indexes.sql
@@ -30,17 +32,20 @@ migration/
   bc/      V1.0.1__bc_schema.sql            # British Columbia-only tables (structure)
            V1.0.2__bc_data.sql              # British Columbia reference data (rows)
            V1.0.6__restore_live_legacy_bc_tables_and_reference_data.sql
+           V1.0.19__bc_billingmaster_indexes.sql
 ```
 
 The **genesis baseline** is `V1` + the province `V1.0.1`/`V1.0.2` files (frozen). Everything from
-`V1.0.3` onward is a forward delta. The highest version currently in use is `V1.0.16`, and the
-next free number for ANY location — shared or province — is `V1.0.17`. The version line is global:
+`V1.0.3` onward is a forward delta. The highest version currently in use is `V1.0.19`
+(`bc/V1.0.19`; the highest shared one is `common/V1.0.18`), and the next free number for ANY
+location — shared or province — is `V1.0.20`. The version line is global:
 the shared `common/` line is in EVERY database's path, and on an **already-migrated database**
 Flyway (no `outOfOrder`) never applies a new migration numbered below the highest it has already
-run — `common/V1.0.16` today. A hypothetical new `bc/V1.0.11` would apply fine on a fresh install
-(version order places it before `common/V1.0.16`) but would silently never run on existing BC
-databases and would fail `flyway validate` there — so never number a new migration at or below the
-global high-water mark, even if that number was only ever used under the other province.
+run — `common/V1.0.18` today (`bc/V1.0.19` on BC databases). A hypothetical new `bc/V1.0.11` would
+apply fine on a fresh install (version order places it before `common/V1.0.18`) but would silently
+never run on existing BC databases and would fail `flyway validate` there — so never number a new
+migration at or below the global high-water mark, even if that number was only ever used under the
+other province.
 
 A database applies **`common` + exactly one province** location, selected by `flyway.locations`:
 

--- a/database/mysql/migration/bc/README.md
+++ b/database/mysql/migration/bc/README.md
@@ -6,8 +6,9 @@ The frozen British Columbia slice of the V1 genesis baseline:
 
 Forward deltas (not part of the frozen baseline):
 - `V1.0.6__restore_live_legacy_bc_tables_and_reference_data.sql` — restored live BC legacy tables/reference data and corrected reporting grants
+- `V1.0.19__bc_billingmaster_indexes.sql` — `billingmaster` indexes for the BC billing DAO query shapes (see `docs/database-index-review-2026-09-04.md`)
 
 Applied together with `common/` for a BC install (`flyway.locations=filesystem:.../migration/common,filesystem:.../migration/bc` (see `flyway.conf` for the real paths)). New BC-only
 changes go here as `V1.0.N__short_description.sql` (sequential, next free version number). The
-version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.14` — see
+version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.20` — see
 `../README.md` for why a lower number must never be reused.

--- a/database/mysql/migration/bc/V1.0.19__bc_billingmaster_indexes.sql
+++ b/database/mysql/migration/bc/V1.0.19__bc_billingmaster_indexes.sql
@@ -1,0 +1,17 @@
+-- V1.0.19 — performance indexes for British Columbia billing (`billingmaster`).
+-- See common/V1.0.3 and common/V1.0.18 for the rationale: forward migration so both fresh installs
+-- and baseline-stamped OpenO conversions receive it; idempotent because converted datadirs vary.
+-- NOTE: `CREATE INDEX IF NOT EXISTS` is MariaDB-only DDL; CARLOS targets MariaDB 11.8
+-- (see docs/database-schema-management.md). Both statements are online InnoDB index adds.
+-- NUMBERING: the version line is global across common + the applied province; V1.0.17 is
+-- common/V1.0.17__enable_digital_signatures_by_default.sql and V1.0.18 is
+-- common/V1.0.18__performance_indexes_2.sql, so this file takes V1.0.19 and the next free number
+-- for ANY location is V1.0.20.
+
+-- `billingmaster` shipped with only its PK and `wcb_id` indexed. The BC billing DAO joins and
+-- filters it by billing_no (with an optional billingstatus filter) and by demographic_no:
+--   billing_no [+ billingstatus]  BillingmasterDAO.java:73,85,182,190(WCB),202,298 and the
+--                                 BillingDaoImpl reconcile join (b.billing_no = bm.billing_no)
+--   demographic_no                BillingmasterDAO.java:308 (+ billingCode/status), :333
+CREATE INDEX IF NOT EXISTS `idx_billingmaster_billing_no_status` ON `billingmaster` (`billing_no`,`billingstatus`);
+CREATE INDEX IF NOT EXISTS `idx_billingmaster_demographic_no` ON `billingmaster` (`demographic_no`);

--- a/database/mysql/migration/common/README.md
+++ b/database/mysql/migration/common/README.md
@@ -17,9 +17,16 @@ non-general_ci session collation caused V1.0.7 to abort and an operator bypassed
 normal fail-fast CLI loop cannot reach V1.0.13 after that failure; use the
 [same-session V1.0.7 recovery procedure](../README.md#mariadb-cli-recovery-for-v107), then continue
 in version order.
+`V1.0.14__widen_faxes_jobid_to_bigint.sql`, `V1.0.15__add_faxes_direction.sql` and
+`V1.0.16__add_faxes_jobid_index.sql` evolve the `faxes` table for the SRFax importer.
+`V1.0.17__enable_digital_signatures_by_default.sql` turns digital signatures on for the seeded
+Default Facility (a deliberate one-time default change; see the file header).
+`V1.0.18__performance_indexes_2.sql` is the second DAO-justified index pass (a delta on V1.0.3;
+rationale in `docs/database-index-review-2026-09-04.md`).
 
 Applied together with the selected province (`common` + `on`, or `common` + `bc`). Put **genuinely
 shared future schema changes** here as `V1.0.N__short_description.sql` (sequential, next free version number) so one migration
 covers both provinces. The version line is global across `common` + the selected province, so the
-next free number accounts for province deltas too. The highest version in use is the shared
-`V1.0.13`, so the next shared (or Ontario) version is `V1.0.14` (see `../README.md`).
+next free number accounts for province deltas too. The highest version in use is `bc/V1.0.19`
+(the highest shared one is `V1.0.18`), so the next free version for ANY location is `V1.0.20`
+(see `../README.md`).

--- a/database/mysql/migration/common/V1.0.18__performance_indexes_2.sql
+++ b/database/mysql/migration/common/V1.0.18__performance_indexes_2.sql
@@ -1,0 +1,66 @@
+-- V1.0.18 — performance indexes, second pass (common schema).
+--
+-- Delta review on top of V1.0.3. Every index below is justified by an actual DAO predicate
+-- (WHERE/JOIN/ORDER BY mined from the code; the full justification table, the candidates that
+-- were evaluated and rejected, and the query-shape findings that indexes cannot fix are in
+-- docs/database-index-review-2026-09-04.md). Same shape and safety rules as V1.0.3:
+--   * Forward migration so BOTH populations receive it: fresh installs (V1 executes, then this
+--     applies) and OpenO/oscar19 conversions (V1 is baseline-STAMPED without executing, then this
+--     applies). Converted datadirs are heterogeneous, hence every statement is idempotent.
+--   * `CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF EXISTS` are MariaDB-only DDL; CARLOS targets
+--     MariaDB 11.8 (see docs/database-schema-management.md).
+--   * Covering composites are created BEFORE the shadow drops that depend on them: MariaDB DDL is
+--     not transactional, so drop-first would leave a crash window with the column unindexed.
+--   * Every statement is an InnoDB secondary-index add/drop — online (INPLACE, no table rebuild).
+-- CAVEAT (shared with V1.0.3): `CREATE INDEX IF NOT EXISTS` is a no-op when an index of the SAME
+-- NAME already exists, even with different columns. All names below are new `idx_*` names verified
+-- absent from every migration in the repo; a site-local index reusing one of them would silently
+-- win. Check `SHOW INDEX` after migrating a converted datadir.
+
+-- ---- Guard composites BEFORE the shadow drops. Each is a real query shape in its own right (see
+-- ---- the per-line notes) AND the superset of a single-column index dropped below.
+-- BC/legacy billing: provider_no + billing_date BETWEEN, ORDER BY billing_date
+-- (BillingDaoImpl.java:525,563,582,601). `billing` carried 8 single-column indexes but no
+-- composite for the range shape the DAO actually issues.
+CREATE INDEX IF NOT EXISTS `idx_billing_provider_date` ON `billing` (`provider_no`,`billing_date`);
+-- Note-count reports: provider_no + observation_date BETWEEN (CaseManagementNoteDAOImpl.java:585,621).
+CREATE INDEX IF NOT EXISTS `idx_casemgmt_note_provider_observation` ON `casemgmt_note` (`provider_no`,`observation_date`);
+-- Messenger inbox / unread badge: provider_no + status (MessageListDaoImpl.java:111,119).
+CREATE INDEX IF NOT EXISTS `idx_messagelisttbl_provider_status` ON `messagelisttbl` (`provider_no`,`status`);
+
+-- ---- Drop redundant indexes (left-prefix shadows of a composite created above, or an exact PK
+-- ---- duplicate). InnoDB secondary indexes carry the PK implicitly, so these drops are
+-- ---- read-equivalent and save pure write amplification.
+ALTER TABLE `billing` DROP INDEX IF EXISTS `provider_no`;                    -- prefix of idx_billing_provider_date (created above)
+ALTER TABLE `casemgmt_note` DROP INDEX IF EXISTS `FKA8D537806CCA0FC`;        -- Hibernate-named (provider_no); prefix of idx_casemgmt_note_provider_observation (created above). casemgmt_note declares no FOREIGN KEY on provider_no, so no constraint depends on it.
+ALTER TABLE `messagelisttbl` DROP INDEX IF EXISTS `provider_no`;             -- prefix of idx_messagelisttbl_provider_status (created above)
+ALTER TABLE `eform` DROP INDEX IF EXISTS `id`;                               -- UNIQUE duplicate of the PK (fid); sibling of the eform_data.id drop in V1.0.3
+
+-- ---- Patient record history: demographicArchive was PK-only, so every demographic edit /
+-- ---- history view scanned the whole (ever-growing) archive
+-- ---- (DemographicArchiveDaoImpl.java:59,75,114,128 — all four queries filter demographic_no).
+CREATE INDEX IF NOT EXISTS `idx_demographicArchive_demographic_no` ON `demographicArchive` (`demographic_no`);
+
+-- ---- Patient search by chart number: chart_no LIKE (DemographicDaoImpl.java:1377,1887,1996 and the
+-- ---- wildcard branch of the main search, :2774/:2813) plus the chart_no sort mode (:2861).
+-- ---- The default main-search operator is REGEXP, which no B-tree index can serve — see the review.
+CREATE INDEX IF NOT EXISTS `idx_demographic_chart_no` ON `demographic` (`chart_no`);
+
+-- ---- Provider signature lookups: providerExt has no PRIMARY KEY and no index at all, yet the
+-- ---- ProviderExt entity maps provider_no as @Id (find() on every signature render).
+-- ---- A plain index rather than a PK: provider_no is nullable and converted datadirs may carry
+-- ---- duplicate rows; adding a PK needs a data-quality pass first (tracked in the review doc).
+CREATE INDEX IF NOT EXISTS `idx_providerExt_provider_no` ON `providerExt` (`provider_no`);
+
+-- ---- Integrator remote attachments per patient: demographic_no [+ messageid]
+-- ---- (RemoteAttachmentsDaoImpl.java:51,58); table was PK-only.
+CREATE INDEX IF NOT EXISTS `idx_remoteAttachments_demo_message` ON `remoteAttachments` (`demographic_no`,`messageid`);
+
+-- ---- Lab inbox: obr_date range predicates and ORDER BY obr_date DESC with offset pagination
+-- ---- (Hl7TextInfoDaoImpl, inbox builder ~lines 320-500). obr_date is varchar(20) holding HL7
+-- ---- timestamps, which sort lexically, so the index is valid as-is.
+CREATE INDEX IF NOT EXISTS `idx_hl7TextInfo_obr_date` ON `hl7TextInfo` (`obr_date`);
+
+-- ---- Documents: patient document list ORDER BY observationdate DESC (DocumentDaoImpl.java:527)
+-- ---- and the per-provider observationdate BETWEEN report (:206).
+CREATE INDEX IF NOT EXISTS `idx_document_observationdate` ON `document` (`observationdate`);

--- a/database/mysql/migration/on/README.md
+++ b/database/mysql/migration/on/README.md
@@ -12,5 +12,6 @@ Forward deltas (not part of the frozen baseline):
 
 Applied together with `common/` for an Ontario install (`flyway.locations=filesystem:.../migration/common,filesystem:.../migration/on` (see `flyway.conf` for the real paths)). New
 Ontario-only changes go here as `V1.0.N__short_description.sql` (sequential, next free version number).
-The version line is global across `common` + `on`, so the next free number is `V1.0.14` (see
-`../README.md`).
+The version line is global across `common` + `on`, so the next free number is `V1.0.20` (the
+highest version in use is `bc/V1.0.19`; the highest on the Ontario path is `common/V1.0.18` — see
+`../README.md` for why a number at or below the global high-water mark must never be reused).

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ Key testing resources:
 | [Runtime Directories](runtime-directories.md) | Required filesystem directories and permissions |
 | [Resources Directory](resources-directory.md) | Application resources structure |
 | [GitHub Issue Management](github-issue-management.md) | Issue tracking and workflow |
+| [Database Schema Management](database-schema-management.md) | Flyway baseline, forward migrations, where migrations run |
+| [Database Index Review (2026-09-04)](database-index-review-2026-09-04.md) | Index state vs. DAO query patterns; rationale for the V1.0.18/V1.0.19 index migrations |
 | [Testing Exclusions](Testing_Exclusion_of_MCEDT_and_HinValidator_tests.md) | Excluded test documentation |
 
 ## Quick Links

--- a/docs/database-index-review-2026-09-04.md
+++ b/docs/database-index-review-2026-09-04.md
@@ -1,0 +1,198 @@
+# Database index review (2026-09-04)
+
+A review of the state of the CARLOS `oscar` schema's indexes against the query patterns the
+application actually issues, with the resulting changes shipped as two forward migrations:
+
+- `database/mysql/migration/common/V1.0.18__performance_indexes_2.sql`
+- `database/mysql/migration/bc/V1.0.19__bc_billingmaster_indexes.sql`
+
+Target engine: MariaDB 11.8.x (what dev, CI `db-schema-verify.yml`, and the container/podman
+production stack run — see `database-schema-management.md`).
+
+## TL;DR
+
+The schema was already in good shape. `common/V1.0.3__performance_indexes.sql` (plus
+`on/V1.0.4`, `bc/V1.0.6`, `on/V1.0.11`/`V1.0.12`, `common/V1.0.16`) had done a DAO-justified index
+pass with the right engineering discipline: composite-first design, documented redundancy drops,
+idempotent MariaDB DDL, and a guard-before-drop ordering that keeps every queried column indexed
+even if a migration dies mid-way. This review is therefore a **delta**: it cross-checked all 389
+baseline tables and every forward migration against the hot DAO predicates and found a short list
+of real gaps (tables that are still PK-only despite being queried by a non-PK column), a few
+left-over redundant indexes, and a set of query shapes that no index can help.
+
+## Method
+
+1. Inventoried every `PRIMARY KEY` / `KEY` / `UNIQUE KEY` / `CREATE INDEX` / `DROP INDEX` in
+   `common/V1__baseline_schema.sql`, `on/V1.0.1__on_schema.sql`, `bc/V1.0.1__bc_schema.sql` and all
+   `V1.0.N` forward migrations.
+2. Mined the WHERE / JOIN / ORDER BY column sets from the hottest DAOs (appointments, demographic
+   search, clinical notes, prescriptions, labs, documents, ticklers, measurements, ON and BC
+   billing, audit log, messaging). DAOs are ~9:1 JPQL to native SQL, so entity property names were
+   mapped back to real column names through the `@Column` mappings before comparing to the DDL.
+3. Verified every proposed table/column/index name directly against the DDL, checked that no
+   proposed index name exists anywhere under `database/`, and confirmed no `FOREIGN KEY` depends on
+   any index being dropped.
+
+## Current state (before this change)
+
+| Metric | Value |
+|---|---|
+| Tables in the common baseline | 389 (ON adds 21, BC adds 8) |
+| Storage engine / charset | 100% InnoDB, `utf8mb4` / `utf8mb4_general_ci` (one accepted legacy Aria table in ON forms) |
+| Tables with at least one secondary index | 130 |
+| Tables with a PK only | 250 |
+| Tables with no key at all | 9 (all small config/link tables — `providerExt` is the one that matters, see below) |
+| Secondary `KEY` lines in the baseline | 262, of which 179 (68%) are composites |
+| `UNIQUE` indexes in the baseline | 16 (business uniqueness is mostly enforced in Java) |
+| FULLTEXT / SPATIAL indexes | none |
+
+The dominant pattern is "auto-increment surrogate PK, secondary indexes only on the ~130 hot
+tables inherited from OSCAR", with the `*_ikey` / `*_integrator` names marking indexes added for
+the Integrator sync paths. The coverage on the truly hot tables after V1.0.3 is good: appointment
+(provider day sheet and patient history), tickler (best-covered domain in the schema), drugs,
+measurements, casemgmt_note, patientLabRouting/providerLabRouting and ON billing all have an index
+matching their dominant DAO shape.
+
+## Changes made
+
+### `common/V1.0.18__performance_indexes_2.sql`
+
+New indexes (each justified by an actual DAO predicate):
+
+| Index | Table (columns) | Justification |
+|---|---|---|
+| `idx_demographicArchive_demographic_no` | `demographicArchive` (`demographic_no`) | `DemographicArchiveDaoImpl` lines 57, 73, 112, 126 — all four queries filter `demographicNo`; runs on every demographic edit/history view. Table was PK-only, so each call scanned the whole ever-growing archive. |
+| `idx_demographic_chart_no` | `demographic` (`chart_no`) | `chart_no LIKE` searches (`DemographicDaoImpl` 1377, 1887, 1996, and the wildcard branch of the main search at 2774/2813) plus the chart-number sort mode (2861). The main search's default operator is `REGEXP`, which no B-tree index can serve (see "Query shapes"). |
+| `idx_providerExt_provider_no` | `providerExt` (`provider_no`) | Table has no PK and no index; the `ProviderExt` entity maps `provider_no` as `@Id` and `providerExtDao.find()` runs on signature renders (`CaseManagementManagerImpl:2054`, `ProSignatureData`). |
+| `idx_remoteAttachments_demo_message` | `remoteAttachments` (`demographic_no`, `messageid`) | `RemoteAttachmentsDaoImpl` 51, 58 — `demographicNo [+ messageId]`; PK-only table. |
+| `idx_billing_provider_date` | `billing` (`provider_no`, `billing_date`) | `BillingDaoImpl` 525, 563, 582, 601 — `provider_no + billing_date BETWEEN ... ORDER BY billing_date`. The table had eight single-column indexes but no composite for this range shape. |
+| `idx_casemgmt_note_provider_observation` | `casemgmt_note` (`provider_no`, `observation_date`) | Note-count reports `CaseManagementNoteDAOImpl` 585, 621 — `provider_no AND observation_date BETWEEN`. |
+| `idx_messagelisttbl_provider_status` | `messagelisttbl` (`provider_no`, `status`) | Messenger inbox / unread badge `MessageListDaoImpl` 111, 119 — `providerNo + status`. |
+| `idx_hl7TextInfo_obr_date` | `hl7TextInfo` (`obr_date`) | Lab inbox date-range predicates and `ORDER BY info.obr_date DESC` with offset pagination (`Hl7TextInfoDaoImpl` inbox builder, ~320–500). The column is `varchar(20)` holding HL7 timestamps; they sort lexically so the index is valid (see hygiene note). |
+| `idx_document_observationdate` | `document` (`observationdate`) | Patient document list `ORDER BY observationdate DESC` (`DocumentDaoImpl:527`) and the per-provider `observationdate BETWEEN` report (`:206`). |
+
+Redundant indexes dropped (each is a strict left-prefix of a composite created earlier in the same
+file, or an exact duplicate of the PK, so the drop is read-equivalent and saves write
+amplification on every INSERT/UPDATE):
+
+| Dropped | Why |
+|---|---|
+| `billing`.`provider_no` | left-prefix of `idx_billing_provider_date` |
+| `casemgmt_note`.`FKA8D537806CCA0FC` | Hibernate-named `(provider_no)` index; left-prefix of `idx_casemgmt_note_provider_observation`. `casemgmt_note` declares no `FOREIGN KEY` on `provider_no`, so no constraint depends on it. |
+| `messagelisttbl`.`provider_no` | left-prefix of `idx_messagelisttbl_provider_status` |
+| `eform`.`id` (UNIQUE) | exact duplicate of the PK `fid` — the sibling of the `eform_data.id` drop V1.0.3 already made |
+
+### `bc/V1.0.19__bc_billingmaster_indexes.sql`
+
+`billingmaster` shipped with only its PK and `wcb_id` indexed, yet the BC billing DAO joins and
+filters it by other columns on every reconcile / claim lookup:
+
+| Index | Justification |
+|---|---|
+| `idx_billingmaster_billing_no_status` (`billing_no`, `billingstatus`) | `BillingmasterDAO` 73, 85, 182, 190 (WCB), 202, 298 and the `BillingDaoImpl` reconcile join `b.billing_no = bm.billing_no [AND bm.billingstatus ...]` |
+| `idx_billingmaster_demographic_no` (`demographic_no`) | `BillingmasterDAO` 309 (`demographicNo + billingCode + billingstatus NOT IN`), 333 (`demographicNo ORDER BY billingmaster_no DESC`) |
+
+No Ontario migration was needed: `billing_on_cheader1` / `billing_on_item` query shapes are covered
+by the V1.0.1 keys plus `on/V1.0.4` (`billing_on_item` has no demographic column; all its DAO
+queries are `ch1_id`-based).
+
+### Numbering
+
+The version line is global across `common` + the applied province and must never go at or below
+the high-water mark (`migration/README.md`). On the `release/2026.08` line the previous high-water
+mark is `common/V1.0.17` (`V1.0.17__enable_digital_signatures_by_default.sql`, published in
+`2026.08.0-alpha9` and therefore checksum-frozen), so this change takes `common/V1.0.18` and
+`bc/V1.0.19`; the next free number for **any** location is now `V1.0.20`.
+`database/mysql/migration/README.md` and `common/README.md` (the migration registry and high-water
+mark) were updated in the same change. When this line is forward-merged into `develop`, these
+numbers must stay as they are: `develop` has no V1.0.17 yet, and the release policy says only an
+unreleased migration on the newer line may be renumbered.
+
+## Evaluated and rejected
+
+Candidates that looked like gaps but are not, recorded so the next reviewer does not redo the work:
+
+| Candidate | Verdict |
+|---|---|
+| `measurementsExt (keyval, val)` | Already indexed: `measurements_ext_keyval_val (keyval, val(100))` — a prefix index on the `TEXT` column; the DAO's `keyVal = ? AND val = ?` lookups use it. |
+| `demographicExt (demographic_no, key_val, date_time)` covering index for the four correlated `max(date_time)` subqueries in `OscarAppointmentDaoImpl:900-906` | `uk_demo_ext` is UNIQUE on `(demographic_no, key_val)`, so each subquery is a single-row lookup already; a covering index would only save one row fetch per key. |
+| Dropping `demographicExt`.`demographic_no` (left-prefix of `uk_demo_ext`) | Technically redundant, but the guard-before-drop rule would require creating a UNIQUE index first, which can fail on a converted datadir with duplicate rows. Recommend-only; drop it once `uk_demo_ext` is confirmed present on every managed database. |
+| `dxresearch_integrator (demographic_no, update_date)` vs `dxresearch_ikey (demographic_no, status, update_date)` | Not redundant — the second column differs; the integrator index serves `demographic_no + update_date >` range scans that the `_ikey` cannot. |
+| `patientLabRouting`.`lab_no_index` | Not a prefix of `all_index (lab_type, lab_no, demographic_no)`; legitimately kept. |
+| `messagetbl`.`date` / `type` (`MsgDemoMapDaoImpl:82,90` ORDER BY) | Per-patient message threads are small result sets; the sort cost is negligible. |
+| `billinglocation`, `billingvisit`, `specialty`, `custom_filter_*`, `ProviderPreferenceAppointmentScreen*`, `InstitutionDepartment`, `serviceSpecialists` (no keys at all) | Tiny configuration / link tables; a full scan is cheaper than index maintenance. |
+| Anything on the `log` audit table | `log` already has `(dateTime, provider_no)`, `(provider_no, dateTime)`, `demographic_no`, `action`, `content`, `contentId`. `OscarLogDaoImpl:250` carries a `FORCE INDEX (datetime)` hint precisely because the optimizer once mis-chose a provider-leading index on large audit tables — the table is deliberately left untouched. |
+| Descending indexes (MariaDB 10.8+) | Evaluated for every `ORDER BY … DESC` path. All hot DESC sorts are uniform-direction (e.g. `billingDate DESC, billingTime DESC, id DESC`), which MariaDB serves with a backward index scan; DESC indexes only pay off for mixed-direction composites, which no CARLOS query uses. |
+| `ALGORITHM=INPLACE, LOCK=NONE` clauses | Every statement is an InnoDB secondary-index add/drop, which MariaDB already executes INPLACE; the clauses were omitted to stay in the established V1.0.3 idiom (migrations run in operator-gated upgrade windows). |
+
+## Query shapes that indexes cannot fix
+
+These need query changes, not indexes, and are listed for follow-up issues (no Java was changed in
+this review):
+
+| Location | Shape | Why it defeats indexing |
+|---|---|---|
+| `DemographicDaoImpl:2771-2774, 2812-2833` | Main patient search uses `REGEXP` unless the keyword contains `*` / `%`, and wraps names in `lower(d.last_name)` / `lower(d.first_name)` | `REGEXP` and a function on the column both force a scan of `demographic`, so the `name(last_name, first_name)` index is bypassed on the most common search. `utf8mb4_general_ci` is already case-insensitive, so the `lower()` is unnecessary; a prefix `LIKE` would use the index. |
+| `DemographicDaoImpl:628, 677` | DOB search as three separate `varchar` `LIKE`s (`year_of_birth`, `month_of_birth`, `date_of_birth`) | No single index can serve three independent LIKE predicates. |
+| `DemographicDaoImpl:773` | `(d.phone LIKE ? OR d.phone2 LIKE ?)` | OR across two columns; would need two indexes and an index-merge, and the LIKE is typically leading-wildcard. |
+| `BillingDaoImpl:312, 318` | `to_days(service_date) >= to_days(?)` | Function on the column; rewrite as `service_date >= ?`. |
+| `OscarAppointmentDaoImpl:861` | `BINARY status NOT LIKE 'B%'` | `BINARY` cast makes the predicate non-sargable. |
+| `DocumentDaoImpl:461, 495` | `d.status NOT LIKE 'D'`, `c.module LIKE 'demographic'` on constants | Harmless but should be `=` / `<>`. |
+| `Hl7TextInfoDaoImpl` inbox (~320–500) | `LIMIT page*pageSize, pageSize` over a joined, filtered result ordered by `obr_date` / `created` | Offset pagination re-sorts and discards rows on every page; keyset pagination on `(obr_date, lab_no)` would make deep pages O(page) instead of O(offset). |
+| Text search generally | `LIKE '%…%'` on notes, document descriptions, drug names | Leading-wildcard LIKE cannot use a B-tree. InnoDB FULLTEXT indexes are available in MariaDB 11.8 if the team ever wants indexed text search; it requires query changes (`MATCH … AGAINST`). |
+
+## MariaDB 11.8 features considered
+
+- **Online DDL** — used implicitly: all adds/drops are InnoDB secondary-index operations (INPLACE,
+  no table copy). The migration headers state this so operators can size the upgrade window.
+- **`IGNORED` indexes** (`ALTER TABLE … ALTER INDEX … IGNORED`, MariaDB 10.6+) — not needed here
+  because every drop is provably plan-equivalent (strict left-prefix or exact duplicate). It is the
+  right tool for any *future* drop where equivalence is not provable: mark the index `IGNORED`,
+  watch the slow log for a release, then drop. The `log.datetime` `FORCE INDEX` incident is the
+  cautionary example.
+- **Descending indexes** — evaluated, not needed (see the rejected table).
+- **InnoDB FULLTEXT** — available; noted above as the engine-level option for text search.
+
+## Hygiene findings (not changed here)
+
+| Finding | Recommendation |
+|---|---|
+| `providerExt` has no PRIMARY KEY (`provider_no` is nullable) while the entity maps it as `@Id` | A plain index was added now. Add `PRIMARY KEY (provider_no)` in a later migration after a data-quality check for NULL/duplicate rows on converted datadirs. |
+| `hl7TextInfo.obr_date` is `varchar(20)` | The index works because HL7 timestamps sort lexically, but a typed `DATETIME` column would make range predicates robust and cheaper. Entity + DAO change plus a backfill. |
+| `DemographicDaoImpl` search wraps columns in `lower()` | Redundant under `utf8mb4_general_ci`; removing it (and preferring prefix `LIKE` over `REGEXP` for plain keywords) is the single biggest win available for patient search. |
+| `demographicExt`.`demographic_no` shadows `uk_demo_ext` | Drop once `uk_demo_ext` is confirmed present on all managed databases (see rejected table). |
+| `CREATE INDEX IF NOT EXISTS` no-ops on a same-name, different-column index | Shared caveat of the whole idiom. All names in V1.0.18/V1.0.19 are new and repo-unique; after migrating a converted datadir, spot-check `SHOW INDEX` for the tables above. |
+
+## Sibling repositories
+
+- **drugref2026** rebuilds its `cd_*` tables on every DPD import (`DPDImport.java`) and indexes
+  `drug_code` on all of them plus the `cd_drug_search` columns — adequately indexed for its access
+  pattern. Its `LIKE '%…%'` name searches are the same B-tree limitation noted above.
+- **carlos-podman** carries no schema.
+
+## Verification performed
+
+Run locally on 2026-09-04, mirroring `db-schema-verify.yml` (same image, server config and Flyway
+CLI version):
+
+1. `mariadb:11.8.8` started with the CARLOS `my.cnf` (`innodb_page_size` asserted = 32768).
+2. Flyway CLI 11.14.0 (SHA-256 pinned as in CI) `migrate` + `validate` with
+   `filesystem:migration/common,filesystem:migration/<province>` for both provinces:
+   Ontario — 19 migrations applied, schema at v1.0.18, validated; British Columbia — 17 migrations
+   applied, schema at v1.0.19, validated.
+3. `information_schema.statistics` assertions in both databases: all 9 common indexes (and both
+   `billingmaster` indexes in BC) present with the intended column order; `billing.provider_no`,
+   `casemgmt_note.FKA8D537806CCA0FC`, `messagelisttbl.provider_no` and `eform.id` absent; every
+   PRIMARY KEY and every other pre-existing index on the touched tables intact.
+4. Idempotency: V1.0.18 re-applied to both databases and V1.0.19 re-applied to BC through the
+   `mariadb` client — all three runs completed with exit status 0. With `--show-warnings` the only
+   output is `Note 1061 Duplicate key name` / `Note 1091 Can't DROP INDEX` for every statement,
+   i.e. the `IF NOT EXISTS` / `IF EXISTS` no-op path; index counts were unchanged.
+5. `EXPLAIN` spot-checks: `demographicArchive WHERE demographic_no`, `billing WHERE provider_no AND
+   billing_date BETWEEN`, `messagelisttbl WHERE provider_no AND status`, `billingmaster WHERE
+   billing_no AND billingstatus`, `providerExt WHERE provider_no` and `demographic WHERE chart_no
+   LIKE 'prefix%'` each chose the new index (`key:` column). On empty tables this proves the index
+   is selectable for the shape; production plan choice depends on statistics.
+
+The `db-schema-verify` workflow re-runs `flyway migrate` + `validate` for both provinces on every
+`database/mysql/**` change and is the authoritative gate.


### PR DESCRIPTION
## Description

A review of the `oscar` schema's indexes against the query shapes the DAOs actually issue, with the verified gaps shipped as two forward migrations plus a review document. **Supersedes #3591** (the same change against `develop`), retargeted to the 2026.08 release line at the maintainer's request.

**Headline:** the schema was already in good shape — `common/V1.0.3` (and `on/V1.0.4`, `bc/V1.0.6`, `on/V1.0.11`/`.12`, `common/V1.0.16`) had done a DAO-justified pass with the right discipline (composite-first, documented redundancy drops, idempotent MariaDB DDL, guard-before-drop ordering). This PR is a **delta** on top of that: all 389 baseline tables and every forward migration were cross-checked against the hot DAO `WHERE`/`JOIN`/`ORDER BY` predicates (JPQL mapped back to real columns through `@Column`).

### `database/mysql/migration/common/V1.0.18__performance_indexes_2.sql`

New indexes, each citing the DAO predicate it serves:

| Index | Why |
|---|---|
| `demographicArchive (demographic_no)` | PK-only table; every demographic edit/history view scanned the whole archive (`DemographicArchiveDaoImpl` ×4) |
| `demographic (chart_no)` | `chart_no LIKE` searches + chart-number sort mode |
| `providerExt (provider_no)` | table had **no keys at all** while the entity maps `provider_no` as `@Id` |
| `remoteAttachments (demographic_no, messageid)` | PK-only table |
| `billing (provider_no, billing_date)` | 8 single-column indexes but no composite for the `provider + date BETWEEN` range the DAO issues |
| `casemgmt_note (provider_no, observation_date)` | note-count reports |
| `messagelisttbl (provider_no, status)` | inbox / unread badge |
| `hl7TextInfo (obr_date)` | lab inbox range + `ORDER BY obr_date DESC` |
| `document (observationdate)` | patient document list ordering + provider report range |

Redundant indexes dropped (strict left-prefix of a composite created earlier in the same file, or a PK duplicate — read-equivalent, saves write amplification): `billing.provider_no`, `casemgmt_note.FKA8D537806CCA0FC` (no FK constraint depends on it — verified), `messagelisttbl.provider_no`, `eform.id` (UNIQUE dup of PK, sibling of the V1.0.3 `eform_data.id` drop).

### `database/mysql/migration/bc/V1.0.19__bc_billingmaster_indexes.sql`

`billingmaster` had only its PK and `wcb_id` indexed; the BC DAO joins/filters it by `billing_no [+ billingstatus]` and `demographic_no`. No Ontario migration was needed.

### `docs/database-index-review-2026-09-04.md`

Current-state metrics, per-index justification with file:line references (verified against this branch), candidates **evaluated and rejected**, query shapes that indexes cannot fix (`REGEXP`/`lower()` in patient search, `to_days()`, `BINARY … NOT LIKE`, offset pagination in the lab inbox — follow-up issues, **no Java changed here**), MariaDB 11.8 features considered (descending and `IGNORED` indexes — why they weren't needed), hygiene follow-ups, and the verification log. Linked from `docs/README.md`.

### Numbering and the migration registry

`release/2026.08` already carries `common/V1.0.17__enable_digital_signatures_by_default.sql`, published in `2026.08.0-alpha9` and therefore checksum-frozen, so this change takes **`common/V1.0.18` and `bc/V1.0.19`**; the next free number for any location is `V1.0.20`. `database/mysql/migration/README.md` (layout list + global high-water mark — it still said V1.0.16/V1.0.17) and `common/README.md` (still said V1.0.13) are advanced to match. When this line is forward-merged into `develop`, keep these numbers: `develop` has no V1.0.17 yet, and only an unreleased migration on the newer line may be renumbered.

### Reviewer notes

- Both migrations follow the V1.0.3 idiom exactly: idempotent `CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF EXISTS`, composites created **before** the shadow drops, every statement an online InnoDB index operation.
- Schema and docs only — no Java changed.

## Related Issues

Related to #3150 (the V1.0.3 performance-index migration this builds on). Supersedes #3591.

## Target Branch

`release/2026.08` — a maintainer-requested inclusion in the 2026.08 train (index-only performance change, schema and docs). The original PR (#3591) targeted `develop`; retargeting is a new branch because the repo policy forbids force-pushing a rewritten branch.

## How Was This Tested?

Locally on this branch, mirroring `db-schema-verify.yml` (same image, server config and Flyway version):

- `mariadb:11.8.8` with the CARLOS `my.cnf` (`innodb_page_size` asserted = 32768).
- Flyway CLI 11.14.0 (SHA-256 pinned as in CI) `migrate` + `validate` for both provinces: Ontario 19 migrations applied → v1.0.18, validated; BC 17 migrations → v1.0.19, validated.
- `information_schema.statistics` assertions in both databases: all new indexes present with the intended column order; the four dropped shadows absent; every PRIMARY KEY and other pre-existing index on the touched tables intact.
- Idempotency: V1.0.18 re-applied to both databases and V1.0.19 to BC — exit 0, only `Note 1061 / 1091` no-op notices, index counts unchanged.
- `EXPLAIN` spot-checks on six representative DAO shapes each chose the new index.

The `db-schema-verify` workflow (triggered on `database/mysql/**`) is the authoritative gate. On #3591 (same SQL, numbered V1.0.17/V1.0.18 against `develop`) both `flyway-baseline (on)` and `flyway-baseline (bc)` passed.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`) — **not yet**: the commit was authored by the assistant and carries no `Signed-off-by`; the author should sign it or use the DCO workflow's confirmation comment.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests (schema-only; verified by the `db-schema-verify` workflow)
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md) — maintainer-directed inclusion in the 2026.08 train
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1vTrFqppADXHoFKi2GwJi

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1vTrFqppADXHoFKi2GwJi)_

## Summary by Sourcery

Improve database query performance by adding targeted common and British Columbia indexes and removing redundant coverage.

New Features:
- Add DAO-justified indexes for common-schema query patterns and British Columbia billing lookups.

Enhancements:
- Remove redundant indexes that are superseded by composite indexes or duplicate primary-key coverage.

Documentation:
- Document the database index review, migration rationale, rejected candidates, and updated migration numbering.

Tests:
- Verify both migrations with Flyway migration and validation, index-presence and idempotency checks, and representative query plans.

Chores:
- Advance the database migration registries to reflect the new global version high-water mark.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two index migrations, `common/V1.0.18` and `bc/V1.0.19`, that close the gaps found in a DAO-justified review of the `oscar` schema, plus a review doc with the rationale. Schema and docs only — no Java changed.

The migrations create nine indexes in the common schema and two in BC's `billingmaster`, covering shapes like provider + date ranges, demographic lookups, and chart-number searches that previously scanned tables with only a PK or no index at all. Four redundant single-column or PK-duplicate indexes are dropped because the new composites supersede them.

**Migration**
- `common/V1.0.17` is checksum-frozen in `2026.08.0-alpha9`, so the new files take `V1.0.18` / `V1.0.19`; the next free number for any location is `V1.0.20`, which all migration READMEs (`common/`, `on/`, `bc/`) now reflect.
- Keep these numbers when forward-merging into `develop`, which has no release-line `V1.0.17` yet.
- Both migrations are idempotent MariaDB DDL and run as online InnoDB index operations.

<sup>Written for commit b6c74bdb8aace18eaa930e9ecce190855ee51133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

