### PR TITLE
fix(administration): restore framed-section resize/scroll so the schedule wizard advances visibly

### DIFF
--- a/docs/administration-shell-framing.md
+++ b/docs/administration-shell-framing.md
@@ -60,3 +60,19 @@ document is not clipped, and that the sibling Schedule Management pages that cal
 `resizeIframe()` load without a browser exception. It scrolls the shell to the bottom
 before pressing each "Next" — the defect is invisible from a shell that was already at
 the top. It writes schedule rows, so run it against a disposable local/dev database.
+
+Point `BASE_URL` at a packaged install to run it through the real front door, which is
+what an operator actually uses:
+
+```
+BASE_URL=https://<host>/carlos TEST_PASSWORD=<password> \
+  node scripts/schedule-setting-playwright-checks.js
+```
+
+The wizard's `avail_hour` parameter carries markup-shaped values
+(`<MON>Standard</MON>…`). That reads like an XSS payload, but it does not score against
+CRS 3.3.8 at paranoia level 1 — libinjection's tag blacklist ignores three-letter tags
+other than XML and SVG, and the generic HTML-tag-handler rules are paranoia level 2. A
+full run against a packaged install with `SecRuleEngine On` logged zero denials, so the
+schedule routes need no WAF exclusion of their own. Re-check that if the paranoia level
+is ever raised.

--- a/docs/administration-shell-framing.md
+++ b/docs/administration-shell-framing.md
@@ -62,12 +62,21 @@ before pressing each "Next" — the defect is invisible from a shell that was al
 the top. It writes schedule rows, so run it against a disposable local/dev database.
 
 Point `BASE_URL` at a packaged install to run it through the real front door, which is
-what an operator actually uses:
+what an operator actually uses. The check logs in with real credentials, so it only
+skips TLS verification for a loopback target — reach a packaged install by forwarding a
+local port to its 443 rather than by naming the container or host directly:
 
 ```
-BASE_URL=https://<host>/carlos TEST_PASSWORD=<password> \
+socat TCP-LISTEN:9443,bind=127.0.0.1,fork,reuseaddr TCP:<container-ip>:443 &
+
+BASE_URL=https://127.0.0.1:9443/carlos TEST_PASSWORD=<password> \
   node scripts/schedule-setting-playwright-checks.js
 ```
+
+Naming a non-loopback host instead fails with `net::ERR_CERT_AUTHORITY_INVALID`
+against the self-signed certificate a fresh install generates. That is deliberate:
+`ALLOW_NON_LOCAL_BASE_URL` widens which hosts the check will talk to, never whether it
+verifies their certificate.
 
 The wizard's `avail_hour` parameter carries markup-shaped values
 (`<MON>Standard</MON>…`). That reads like an XSS payload, but it does not score against

--- a/docs/administration-shell-framing.md
+++ b/docs/administration-shell-framing.md
@@ -1,0 +1,62 @@
+# Administration shell: how framed section pages are hosted
+
+`WEB-INF/jsp/administration/index.jsp` is the Administration shell. Most section
+pages do not replace it — they are loaded into an `<iframe id="myFrame">` that the
+`.xlink` click handler in `leftNav.jspf` creates inside `#dynamic-content`. A few
+entries instead load through jQuery `.load()` into the same container (`a.contentLink`,
+`registerFormSubmit`); those are "AJAX mode" and have no frame.
+
+## The contract
+
+The shell owns two things on behalf of every framed page:
+
+1. **Height.** `.dynamic-iframe-content` sizes the frame with `padding-top: 80%` — an
+   aspect-ratio box with no relation to the content. Anything taller is clipped and
+   gets a nested scrollbar. `growFrameTo()` replaces that box with the real content
+   height. It only ever grows, so a page that reports a nonsense height cannot
+   collapse the frame.
+2. **Scroll position.** After the frame loads a new document the shell must return to
+   the top. Wizard buttons ("Next", "Save") sit at the bottom of the framed page, so
+   the reader is scrolled *down* when they press one. If the shell stays at that
+   offset while the frame swaps in the next step, the reader is looking at the middle
+   of a page they have never seen and reasonably concludes the button did nothing.
+
+`scrollFramedContentIntoView(frame)` does both, and the `.xlink` handler binds it to
+the frame's `load` event so it runs for the initial document **and** every in-frame
+navigation after it — a link, a form post, a wizard step. That coverage matters:
+only a handful of legacy pages ask for it themselves.
+
+## `parent.parent.resizeIframe(...)`
+
+Some framed pages call `parent.parent.resizeIframe($('html').height())` from their own
+jQuery `ready` callback to request the same thing. `resizeIframe()` is the shell-side
+hook for that. Two rules:
+
+- **Do not remove `resizeIframe()` from the shell.** It was commented out during the
+  Bootstrap 5 rework. That produced two alpha10 reports at once: Administration >
+  Schedule Management > Schedule Setting "saves the schedule but clicking Next does
+  nothing" (the shell never scrolled back, so the next wizard step loaded off-screen),
+  and a console `Uncaught TypeError: parent.parent.resizeIframe is not a function`
+  surfacing at `jquery-3.7.1.min.js:2` — jQuery re-throwing a failed ready callback
+  through `jQuery.readyException`.
+- **Guard the call site.** A framed page can also be opened standalone or by a
+  different shell, where no such function exists:
+
+  ```js
+  if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+      parent.parent.resizeIframe($('html').height());
+  }
+  ```
+
+  An unguarded call throws out of the ready callback and abandons whatever else that
+  callback was going to do.
+
+## Regression check
+
+`scripts/schedule-setting-playwright-checks.js` (`npm run test:schedule-setting-playwright`)
+drives the three-step Schedule Setting wizard through the shell and asserts that each
+step advances, that the newly loaded step's top is in the viewport, that the framed
+document is not clipped, and that the sibling Schedule Management pages that call
+`resizeIframe()` load without a browser exception. It scrolls the shell to the bottom
+before pressing each "Next" — the defect is invisible from a shell that was already at
+the top. It writes schedule rows, so run it against a disposable local/dev database.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:error-sanitization-playwright": "node scripts/error-sanitization-playwright-checks.js",
     "test:eform-admin-schedule-nav-playwright": "node scripts/eform-admin-schedule-navigation-playwright-checks.js",
     "test:schedule-links-playwright": "node scripts/schedule-links-playwright-checks.js",
+    "test:schedule-setting-playwright": "node scripts/schedule-setting-playwright-checks.js",
     "test:tickler-crud-playwright": "node scripts/tickler-crud-playwright-checks.js",
     "test:fax-configure-playwright": "node scripts/fax-configure-playwright-checks.js",
     "test:tickler-note-dialog-playwright": "node scripts/tickler-note-dialog-playwright-checks.js",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:eform-admin-schedule-nav-playwright": "node scripts/eform-admin-schedule-navigation-playwright-checks.js",
     "test:schedule-links-playwright": "node scripts/schedule-links-playwright-checks.js",
     "test:schedule-setting-playwright": "node scripts/schedule-setting-playwright-checks.js",
+    "test:scripts": "node --test \"scripts/*.test.js\"",
     "test:tickler-crud-playwright": "node scripts/tickler-crud-playwright-checks.js",
     "test:fax-configure-playwright": "node scripts/fax-configure-playwright-checks.js",
     "test:tickler-note-dialog-playwright": "node scripts/tickler-note-dialog-playwright-checks.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:eform-admin-schedule-nav-playwright": "node scripts/eform-admin-schedule-navigation-playwright-checks.js",
     "test:schedule-links-playwright": "node scripts/schedule-links-playwright-checks.js",
     "test:schedule-setting-playwright": "node scripts/schedule-setting-playwright-checks.js",
-    "test:scripts": "node --test \"scripts/*.test.js\"",
+    "test:scripts": "node --test scripts/*.test.js",
     "test:tickler-crud-playwright": "node scripts/tickler-crud-playwright-checks.js",
     "test:fax-configure-playwright": "node scripts/fax-configure-playwright-checks.js",
     "test:tickler-note-dialog-playwright": "node scripts/tickler-note-dialog-playwright-checks.js",

--- a/scripts/csrf-token-fetch.test.js
+++ b/scripts/csrf-token-fetch.test.js
@@ -59,6 +59,12 @@ function loadHelper({ fetchImpl, inputCount = 1 }) {
     fireUnload: () => unloadListeners.pagehide.forEach((handler) => handler()),
     /** Simulates the document being restored from the back/forward cache. */
     fireRestore: () => unloadListeners.pageshow.forEach((handler) => handler()),
+    /** How many listeners the helper registered for each lifecycle event. */
+    listenerCounts: () => ({
+      pagehide: unloadListeners.pagehide.length,
+      beforeunload: unloadListeners.beforeunload.length,
+      pageshow: unloadListeners.pageshow.length,
+    }),
   };
 }
 
@@ -149,4 +155,15 @@ test('warns again on a real failure after a back/forward-cache restore', async (
   await assert.rejects(helper.fetchCsrfToken('/carlos'), /Failed to fetch/);
   await drainTimers();
   assert.equal(helper.warnings.length, 1, 'reported again once the page is back');
+});
+
+test('does not register a beforeunload listener', () => {
+  // beforeunload makes a page ineligible for the back/forward cache in some
+  // browsers, and this script loads on every JSP that bootstraps a token.
+  // pagehide covers every teardown case the flag is for.
+  const helper = loadHelper({ fetchImpl: async () => ({ ok: true, text: async () => TOKEN_SCRIPT }) });
+
+  assert.equal(helper.listenerCounts().beforeunload, 0);
+  assert.ok(helper.listenerCounts().pagehide > 0, 'pagehide is still observed');
+  assert.ok(helper.listenerCounts().pageshow > 0, 'pageshow is still observed');
 });

--- a/scripts/csrf-token-fetch.test.js
+++ b/scripts/csrf-token-fetch.test.js
@@ -28,7 +28,7 @@ const TOKEN_SCRIPT = 'var masterTokenValue = "TOKEN-VALUE-1234";';
 /** Builds a fresh browser-ish context around the helper for one test. */
 function loadHelper({ fetchImpl, inputCount = 1 }) {
   const warnings = [];
-  const unloadListeners = { pagehide: [], beforeunload: [] };
+  const unloadListeners = { pagehide: [], beforeunload: [], pageshow: [] };
   const inputs = Array.from({ length: inputCount }, () => ({ value: '' }));
 
   const context = {
@@ -57,6 +57,8 @@ function loadHelper({ fetchImpl, inputCount = 1 }) {
     fetchCsrfToken: (ctxPath) => vm.runInContext('fetchCsrfToken', context)(ctxPath),
     /** Simulates the document starting to go away. */
     fireUnload: () => unloadListeners.pagehide.forEach((handler) => handler()),
+    /** Simulates the document being restored from the back/forward cache. */
+    fireRestore: () => unloadListeners.pageshow.forEach((handler) => handler()),
   };
 }
 
@@ -128,4 +130,23 @@ test('rejects without warning when the unload event arrives after the rejection'
   await drainTimers();
 
   assert.deepEqual(helper.warnings, []);
+});
+
+test('warns again on a real failure after a back/forward-cache restore', async () => {
+  // Entering the bfcache fires pagehide without destroying the document, and
+  // coming back does not re-run this script. Without the pageshow reset the
+  // flag would stay set and silence every genuine failure on the restored page.
+  const helper = loadHelper({
+    fetchImpl: async () => { throw new TypeError('Failed to fetch'); },
+  });
+
+  helper.fireUnload();
+  await assert.rejects(helper.fetchCsrfToken('/carlos'), /Failed to fetch/);
+  await drainTimers();
+  assert.deepEqual(helper.warnings, [], 'suppressed while the page is away');
+
+  helper.fireRestore();
+  await assert.rejects(helper.fetchCsrfToken('/carlos'), /Failed to fetch/);
+  await drainTimers();
+  assert.equal(helper.warnings.length, 1, 'reported again once the page is back');
 });

--- a/scripts/csrf-token-fetch.test.js
+++ b/scripts/csrf-token-fetch.test.js
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for src/main/webapp/share/javascript/csrfTokenFetch.js.
+ *
+ * The helper runs in a browser, so it is loaded into a vm context with just
+ * enough of window/document/fetch/console to exercise it. Run with:
+ *   node --test scripts/csrf-token-fetch.test.js
+ *
+ * What these pin: a navigation cancels an in-flight fetch and the rejection
+ * arrives as a bare "TypeError: Failed to fetch" — the same message a real
+ * network failure produces. The helper must stay quiet for the first and warn
+ * for the second, and must reject either way, because callers (efmformmanager's
+ * csrfToken(), the csrf-token.jspf bootstrap) branch on the rejection.
+ */
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'main', 'webapp', 'share', 'javascript', 'csrfTokenFetch.js'),
+  'utf8',
+);
+
+const TOKEN_SCRIPT = 'var masterTokenValue = "TOKEN-VALUE-1234";';
+
+/** Builds a fresh browser-ish context around the helper for one test. */
+function loadHelper({ fetchImpl, inputCount = 1 }) {
+  const warnings = [];
+  const unloadListeners = { pagehide: [], beforeunload: [] };
+  const inputs = Array.from({ length: inputCount }, () => ({ value: '' }));
+
+  const context = {
+    fetch: fetchImpl,
+    setTimeout,
+    clearTimeout,
+    console: { warn: (...args) => warnings.push(args.map(String).join(' ')) },
+    document: {
+      querySelectorAll: () => inputs,
+    },
+  };
+  context.window = {
+    addEventListener: (type, handler) => {
+      if (unloadListeners[type]) {
+        unloadListeners[type].push(handler);
+      }
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(SOURCE, context);
+
+  return {
+    context,
+    warnings,
+    inputs,
+    fetchCsrfToken: (ctxPath) => vm.runInContext('fetchCsrfToken', context)(ctxPath),
+    /** Simulates the document starting to go away. */
+    fireUnload: () => unloadListeners.pagehide.forEach((handler) => handler()),
+  };
+}
+
+/** Lets any setTimeout(..., 0) the helper queued actually run. */
+function drainTimers() {
+  return new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+test('populates every CSRF-TOKEN input and stays silent on success', async () => {
+  const helper = loadHelper({
+    fetchImpl: async () => ({ ok: true, text: async () => TOKEN_SCRIPT }),
+    inputCount: 2,
+  });
+
+  await helper.fetchCsrfToken('/carlos');
+  await drainTimers();
+
+  assert.deepEqual(helper.inputs.map((input) => input.value), ['TOKEN-VALUE-1234', 'TOKEN-VALUE-1234']);
+  assert.deepEqual(helper.warnings, []);
+});
+
+test('warns and rejects when the server rejects the token request', async () => {
+  const helper = loadHelper({ fetchImpl: async () => ({ ok: false, status: 500 }) });
+
+  await assert.rejects(helper.fetchCsrfToken('/carlos'), /status 500/);
+  await drainTimers();
+
+  assert.equal(helper.warnings.length, 1);
+  assert.match(helper.warnings[0], /CSRF token fetch failed/);
+});
+
+test('warns and rejects on a genuine network failure', async () => {
+  // Same message a cancelled request produces, so the helper cannot tell these
+  // apart by the error alone — only by whether the page is going away.
+  const helper = loadHelper({
+    fetchImpl: async () => { throw new TypeError('Failed to fetch'); },
+  });
+
+  await assert.rejects(helper.fetchCsrfToken('/carlos'), /Failed to fetch/);
+  await drainTimers();
+
+  assert.equal(helper.warnings.length, 1);
+});
+
+test('rejects without warning when the page unloads before the request fails', async () => {
+  let helper;
+  helper = loadHelper({
+    fetchImpl: async () => {
+      helper.fireUnload();
+      throw new TypeError('Failed to fetch');
+    },
+  });
+
+  await assert.rejects(helper.fetchCsrfToken('/carlos'), /Failed to fetch/);
+  await drainTimers();
+
+  assert.deepEqual(helper.warnings, []);
+});
+
+test('rejects without warning when the unload event arrives after the rejection', async () => {
+  // The rejection can be delivered before pagehide runs, which is why the
+  // warning is deferred and the flag re-checked rather than read once.
+  const helper = loadHelper({
+    fetchImpl: async () => { throw new TypeError('Failed to fetch'); },
+  });
+
+  await assert.rejects(helper.fetchCsrfToken('/carlos'), /Failed to fetch/);
+  helper.fireUnload();
+  await drainTimers();
+
+  assert.deepEqual(helper.warnings, []);
+});

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -101,7 +101,10 @@ function validateBaseUrl(rawBaseUrl) {
   }
 
   const host = normalizeHost(parsed.hostname);
-  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'db', 'carlos']);
+  // Reachability is the loosest tier: everything the two sets above allow, plus
+  // the bind-any address and the Docker host alias. Derived from LOCAL_HTTP_HOSTS
+  // rather than restated, so a host added there cannot end up refused here.
+  const localHosts = new Set([...LOCAL_HTTP_HOSTS, '0.0.0.0', 'host.docker.internal']);
   const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
   if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -112,7 +112,10 @@ function recordableUrl(rawUrl) {
     const parsed = new URL(rawUrl);
     return `${parsed.origin}${parsed.pathname}`;
   } catch (e) {
-    return rawUrl;
+    // Unparseable — a truncated or malformed URL quoted inside diagnostic text.
+    // Falling back to the raw value would hand back the very query string this
+    // function exists to drop, so cut it at the first query or fragment marker.
+    return rawUrl.replace(/[?#].*$/, '');
   }
 }
 

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -40,13 +40,24 @@
 const { chromium } = require('playwright');
 
 /*
- * Hosts that are unambiguously this machine. TLS verification may only be
- * skipped for these: the check logs in with real credentials, so any other
- * target has to prove its certificate. A packaged install is reached the same
- * way the other packaged-install checks reach one — forward a loopback port to
- * the container's 443 and point BASE_URL at the forward.
+ * Two tiers, because the two decisions they gate carry different risk.
+ *
+ * Loopback: traffic cannot leave this machine, so nothing but this machine can
+ * answer it. TLS verification may only be skipped here — the check logs in with
+ * real credentials, and a self-signed certificate from anywhere else is exactly
+ * what certificate verification exists to reject. A packaged install is reached
+ * the way the other packaged-install checks reach one: forward a loopback port
+ * to the container's 443 and point BASE_URL at the forward.
  */
-const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0:0:0:0:0:0:0:1']);
+
+/*
+ * Plus the devcontainer's compose service names, which resolve to sibling
+ * containers on the Docker bridge network. Not loopback — so they never get a
+ * TLS bypass — but still inside the developer's own machine, and nothing serves
+ * TLS on them, so cleartext is allowed for these and nothing else.
+ */
+const LOCAL_HTTP_HOSTS = new Set([...LOOPBACK_HOSTS, 'db', 'carlos']);
 
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
 const chromePath = process.env.CHROME_PATH || '';
@@ -70,8 +81,12 @@ function normalizeHost(rawHost) {
   return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
 }
 
-function isExactLocalHost(rawHost) {
-  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
+function isLoopbackHost(rawHost) {
+  return LOOPBACK_HOSTS.has(normalizeHost(rawHost));
+}
+
+function isLocalHttpHost(rawHost) {
+  return LOCAL_HTTP_HOSTS.has(normalizeHost(rawHost));
 }
 
 function validateBaseUrl(rawBaseUrl) {
@@ -91,12 +106,12 @@ function validateBaseUrl(rawBaseUrl) {
   if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
   }
-  // This check logs in with real credentials, so anything that is not plainly
-  // loopback must at least carry them over TLS — and, per the context below,
-  // prove its certificate while doing it. Same rule as
+  // This check logs in with real credentials, so anything outside this machine
+  // must at least carry them over TLS — and, per the context below, prove its
+  // certificate while doing it. Same rule as
   // scripts/flu-billing-report-playwright-checks.js.
-  if (!isExactLocalHost(host) && parsed.protocol !== 'https:') {
-    throw new Error(`Non-loopback BASE_URL host ${host} must use https`);
+  if (!isLocalHttpHost(host) && parsed.protocol !== 'https:') {
+    throw new Error(`Non-local BASE_URL host ${host} must use https`);
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
@@ -574,7 +589,7 @@ async function checkResizeIframeCallers(page) {
   const browser = await chromium.launch(launchOptions);
   try {
     const context = await browser.newContext({
-      ignoreHTTPSErrors: isExactLocalHost(baseUrl.hostname),
+      ignoreHTTPSErrors: isLoopbackHost(baseUrl.hostname),
       viewport: { width: 1440, height: 900 },
     });
     const page = await login(context);

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -406,6 +406,43 @@ async function runWizard(context, page) {
   if (!/finished/i.test(finalText)) {
     findings.push({ label: 'schedule-final', type: 'unexpected-final-step', body: finalText.slice(0, 300) });
   }
+
+  await assertFrameHeightDoesNotRatchet(page, finalFrame, 'schedule-final');
+}
+
+/**
+ * Reloading the SAME framed document must not change the frame's height.
+ *
+ * A document shorter than its frame reports a scrollHeight equal to the frame's
+ * own height, so a sizing rule that adds its breathing-room margin before
+ * comparing grows the frame on every single in-frame navigation and accumulates
+ * blank space without limit across a multi-step flow. Reloading one document is
+ * the tightest probe for that: nothing about the content changed, so nothing
+ * about the frame may change either.
+ */
+async function assertFrameHeightDoesNotRatchet(page, frame, label) {
+  const before = await readShellGeometry(page);
+  for (let reload = 0; reload < 3; reload++) {
+    await Promise.all([
+      frame.waitForLoadState('load', { timeout: 30000 }).catch(() => {}),
+      frame.evaluate(() => { window.location.reload(); }).catch(() => {}),
+    ]);
+    await page.waitForTimeout(1500);
+  }
+  const after = await waitForShellScrollTop(page);
+  if (after.frameHeight !== null && before.frameHeight !== null
+      && after.frameHeight > before.frameHeight) {
+    findings.push({
+      label,
+      type: 'frame-height-ratchets',
+      detail: `frame grew from ${before.frameHeight}px to ${after.frameHeight}px over 3 reloads of the same document`,
+    });
+  }
+  visited.push({
+    label: `${label}-reload-stability`,
+    frameHeightBefore: before.frameHeight,
+    frameHeightAfter: after.frameHeight,
+  });
 }
 
 /**

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -55,20 +55,58 @@ const WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri'];
 const findings = [];
 const visited = [];
 
+/** URL.hostname keeps the brackets on an IPv6 literal; the allowlists below do not. */
+function normalizeHost(rawHost) {
+  const host = (rawHost || '').toLowerCase();
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+}
+
+/*
+ * Hosts that are unambiguously this machine. TLS verification may only be
+ * skipped for these: the check logs in with real credentials, so any other
+ * target has to prove its certificate. A packaged install is reached the same
+ * way the other packaged-install checks reach one — forward a loopback port to
+ * the container's 443 and point BASE_URL at the forward.
+ */
+const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
+
+function isExactLocalHost(rawHost) {
+  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
+}
+
 function validateBaseUrl(rawBaseUrl) {
   const parsed = new URL(rawBaseUrl);
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
   }
+  // Credentials in the URL would ride every navigation and surface in the
+  // diagnostics this check prints; it logs in through the form instead.
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not embed a username or password');
+  }
 
-  const host = parsed.hostname.toLowerCase();
-  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const host = normalizeHost(parsed.hostname);
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'db', 'carlos']);
   const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
   if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
+}
+
+/**
+ * Query strings on this application's routes carry provider numbers and other
+ * identifiers that join back to records; the path and status are what diagnose a
+ * failure. Record the path only.
+ */
+function recordableUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch (e) {
+    return rawUrl;
+  }
 }
 
 function appUrl(appPath) {
@@ -112,7 +150,7 @@ function wirePage(page, label) {
   page.on('response', (response) => {
     const status = response.status();
     if (status >= 400 && !isExpectedMissingAsset(status, response.url())) {
-      findings.push({ label, type: 'http', status, url: response.url() });
+      findings.push({ label, type: 'http', status, url: recordableUrl(response.url()) });
     }
   });
   page.on('console', (message) => {
@@ -134,7 +172,7 @@ function wirePage(page, label) {
 async function assertNoErrorPage(frame, label) {
   const bodyText = await frame.locator('body').innerText().catch(() => '');
   if (/CARLOS has encountered an unexpected error|CARLOS Error|HTTP Status 5\d\d|Exception Report/i.test(bodyText)) {
-    findings.push({ label, type: 'error-page', url: frame.url(), body: bodyText.replace(/\s+/g, ' ').slice(0, 500) });
+    findings.push({ label, type: 'error-page', url: recordableUrl(frame.url()), body: bodyText.replace(/\s+/g, ' ').slice(0, 500) });
   }
 }
 
@@ -149,7 +187,7 @@ async function login(context) {
     page.waitForURL(/providercontrol/, { timeout: 30000 }),
     page.locator('input[type="submit"], button[type="submit"]').first().click(),
   ]);
-  visited.push({ label: 'login', url: page.url() });
+  visited.push({ label: 'login', url: recordableUrl(page.url()) });
   return page;
 }
 
@@ -161,7 +199,7 @@ async function openAdminSection(page, relSuffix, urlPattern, label) {
   await link.click({ timeout: 20000 });
   const frame = await waitForFrame(page, urlPattern, label);
   if (frame) {
-    visited.push({ label, url: frame.url() });
+    visited.push({ label, url: recordableUrl(frame.url()) });
     await assertNoErrorPage(frame, label);
   }
   return frame;
@@ -352,7 +390,7 @@ async function runWizard(context, page) {
   if (!weekFrame) {
     return;
   }
-  visited.push({ label: 'schedule-week-setting', url: weekFrame.url(), provider: provider.value });
+  visited.push({ label: 'schedule-week-setting', url: recordableUrl(weekFrame.url()), provider: provider.value });
   await assertNoErrorPage(weekFrame, 'schedule-week-setting');
   assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-week-setting');
 
@@ -374,7 +412,7 @@ async function runWizard(context, page) {
     return;
   }
   await calendarFrame.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
-  visited.push({ label: 'schedule-calendar', url: calendarFrame.url() });
+  visited.push({ label: 'schedule-calendar', url: recordableUrl(calendarFrame.url()) });
   await assertNoErrorPage(calendarFrame, 'schedule-calendar');
   assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-calendar');
 
@@ -398,7 +436,7 @@ async function runWizard(context, page) {
     return;
   }
   await finalFrame.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
-  visited.push({ label: 'schedule-final', url: finalFrame.url() });
+  visited.push({ label: 'schedule-final', url: recordableUrl(finalFrame.url()) });
   await assertNoErrorPage(finalFrame, 'schedule-final');
   assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-final');
 
@@ -423,8 +461,16 @@ async function runWizard(context, page) {
 async function assertFrameHeightDoesNotRatchet(page, frame, label) {
   const before = await readShellGeometry(page);
   for (let reload = 0; reload < 3; reload++) {
+    // Wait for THIS frame's navigation before its load state: the frame is
+    // already loaded when the wait is registered, so waitForLoadState('load')
+    // on its own resolves immediately against the pre-reload document and the
+    // probe would measure before anything happened.
+    const reloaded = page.waitForEvent('framenavigated', {
+      predicate: (navigated) => navigated === frame,
+      timeout: 30000,
+    }).then(() => frame.waitForLoadState('load', { timeout: 30000 })).catch(() => {});
     await Promise.all([
-      frame.waitForLoadState('load', { timeout: 30000 }).catch(() => {}),
+      reloaded,
       frame.evaluate(() => { window.location.reload(); }).catch(() => {}),
     ]);
     await page.waitForTimeout(1500);
@@ -479,7 +525,10 @@ async function checkResizeIframeCallers(page) {
 
   const browser = await chromium.launch(launchOptions);
   try {
-    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 900 } });
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: isExactLocalHost(baseUrl.hostname),
+      viewport: { width: 1440, height: 900 },
+    });
     const page = await login(context);
     context.on('page', (popup) => wirePage(popup, 'popup'));
 

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/*
+ * Browser regression checks for Administration > Schedule Management > Schedule Setting.
+ *
+ * Covers the alpha10 report "unable to set week schedule": the week-setting
+ * ("illustrated") window's Next button posted and saved the schedule, but the
+ * admin shell stayed parked at the scroll offset the reader had used to reach
+ * the button, so the next wizard step loaded off-screen and clicking Next
+ * looked like it did nothing. The same root cause — resizeIframe() commented
+ * out of the admin shell — also threw
+ * "parent.parent.resizeIframe is not a function" out of the sibling Schedule
+ * Management pages that call it.
+ *
+ * The script drives the whole three-step wizard end to end and asserts:
+ *   1. Schedule Setting opens in the shell's #myFrame.
+ *   2. Selecting a provider loads the week-setting window.
+ *   3. Next advances to the calendar step, the shell is scrolled back to the
+ *      top, and the framed page is not clipped by the shell's aspect box.
+ *   4. The chosen template is actually applied to the generated schedule dates.
+ *   5. Next on the calendar step reaches the "setting finished" step.
+ *   6. The Schedule Management pages that call parent.parent.resizeIframe()
+ *      load without a browser exception.
+ *
+ * It writes schedule rows for the selected provider, so run it against a
+ * disposable local/dev database.
+ *
+ * Defaults are for the local devcontainer:
+ *   node scripts/schedule-setting-playwright-checks.js
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc
+ *   TEST_PASSWORD=carlos2026
+ *   TEST_PIN=2026
+ *   TEST_SCHEDULE_PROVIDER=999998  provider_no to configure; blank picks the logged-in provider
+ *   ALLOW_NON_LOCAL_BASE_URL=true  only when intentionally targeting a non-local test app
+ */
+
+const { chromium } = require('playwright');
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+const requestedProvider = process.env.TEST_SCHEDULE_PROVIDER || '';
+
+// The wizard writes real rschedule/scheduledate rows. Use a range far enough out
+// that it cannot collide with demo appointments a human is looking at.
+const SCHEDULE_START = { year: '2031', month: '3', day: '3' };
+const SCHEDULE_END = { year: '2031', month: '3', day: '28' };
+const WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri'];
+
+const findings = [];
+const visited = [];
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
+  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+function appUrl(appPath) {
+  if (!appPath.startsWith('/') || appPath.startsWith('//')) {
+    throw new Error(`Application path must be root-relative, got ${appPath}`);
+  }
+  const url = new URL(baseUrl.href);
+  url.pathname = `${baseUrl.pathname}${appPath}`.replace(/\/{2,}/g, '/');
+  url.search = '';
+  return url.toString();
+}
+
+function safeGoto(page, appPath, options) {
+  return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
+}
+
+function isExpectedMissingAsset(status, responseUrl) {
+  return status === 404 && (/\/imageRenderingServlet\?/.test(responseUrl) || /\/favicon\.ico$/.test(responseUrl));
+}
+
+function isExpectedConsoleNoise(message) {
+  const text = message.text();
+  return /Content Security Policy.*report-only/i.test(text)
+    || /\[Report Only\]/.test(text)
+    || /Master token \[CSRF-TOKEN\]/.test(text)
+    || /Hidden (?:input element|token fields)/.test(text);
+}
+
+function isSevereConsoleMessage(message) {
+  if (isExpectedConsoleNoise(message)) {
+    return false;
+  }
+  const text = message.text();
+  if (message.type() === 'error') {
+    return !/imageRenderingServlet\?|favicon\.ico/i.test(text);
+  }
+  return /(ReferenceError|TypeError|SyntaxError|is not a function|Cannot read|Cannot set)/i.test(text);
+}
+
+function wirePage(page, label) {
+  page.on('response', (response) => {
+    const status = response.status();
+    if (status >= 400 && !isExpectedMissingAsset(status, response.url())) {
+      findings.push({ label, type: 'http', status, url: response.url() });
+    }
+  });
+  page.on('console', (message) => {
+    if (isSevereConsoleMessage(message)) {
+      findings.push({ label, type: `console:${message.type()}`, text: message.text(), location: message.location() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    findings.push({ label, type: 'pageerror', text: error.message });
+  });
+  page.on('dialog', async (dialog) => {
+    // Every dialog here is a validation alert from the wizard — that is a failure,
+    // not noise: the step under test did not submit.
+    findings.push({ label, type: 'dialog', text: dialog.message() });
+    await dialog.accept();
+  });
+}
+
+async function assertNoErrorPage(frame, label) {
+  const bodyText = await frame.locator('body').innerText().catch(() => '');
+  if (/CARLOS has encountered an unexpected error|CARLOS Error|HTTP Status 5\d\d|Exception Report/i.test(bodyText)) {
+    findings.push({ label, type: 'error-page', url: frame.url(), body: bodyText.replace(/\s+/g, ' ').slice(0, 500) });
+  }
+}
+
+async function login(context) {
+  const page = await context.newPage();
+  wirePage(page, 'admin-shell');
+  await safeGoto(page, '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await Promise.all([
+    page.waitForURL(/providercontrol/, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  visited.push({ label: 'login', url: page.url() });
+  return page;
+}
+
+/** Opens an Administration section through the shell's .xlink handler and returns its frame. */
+async function openAdminSection(page, relSuffix, urlPattern, label) {
+  await safeGoto(page, '/administration', { waitUntil: 'domcontentloaded', timeout: 30000 });
+  const link = page.locator(`a.xlink[rel$="${relSuffix}"]`).last();
+  await expandContainingAccordion(page, link);
+  await link.click({ timeout: 20000 });
+  const frame = await waitForFrame(page, urlPattern, label);
+  if (frame) {
+    visited.push({ label, url: frame.url() });
+    await assertNoErrorPage(frame, label);
+  }
+  return frame;
+}
+
+/**
+ * Several Schedule Management entries live only inside the left nav's collapsed
+ * accordion (there is no quick-link card for them), so the link exists in the DOM
+ * but is not clickable until its section is expanded.
+ */
+async function expandContainingAccordion(page, link) {
+  if (await link.isVisible().catch(() => false)) {
+    return;
+  }
+  const collapseId = await link.evaluate((el) => {
+    const collapse = el.closest('.accordion-collapse');
+    return collapse ? collapse.id : null;
+  }).catch(() => null);
+  if (!collapseId) {
+    return;
+  }
+  await page.locator(`button[data-bs-target="#${collapseId}"]`).click({ timeout: 10000 }).catch(() => {});
+  await link.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+}
+
+async function waitForFrame(page, urlPattern, label, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const frame = page.frames().find((f) => urlPattern.test(f.url()));
+    if (frame) {
+      await frame.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {});
+      return frame;
+    }
+    await page.waitForTimeout(250);
+  }
+  findings.push({ label, type: 'missing-frame', pattern: String(urlPattern) });
+  return null;
+}
+
+/** Reads the shell's scroll offset and how far the framed document overflows its box. */
+function readShellGeometry(page) {
+  return page.evaluate(() => {
+    const frame = document.getElementById('myFrame');
+    const rect = frame ? frame.getBoundingClientRect() : null;
+    let contentHeight = null;
+    try {
+      const doc = frame && frame.contentDocument;
+      contentHeight = doc && doc.documentElement ? doc.documentElement.scrollHeight : null;
+    } catch (e) {
+      contentHeight = null;
+    }
+    const scroller = document.scrollingElement || document.documentElement;
+    return {
+      scrollY: Math.round(window.scrollY),
+      shellHeight: Math.round(scroller.scrollHeight),
+      viewportHeight: Math.round(scroller.clientHeight),
+      frameTopInViewport: rect ? Math.round(rect.top) : null,
+      frameHeight: rect ? Math.round(rect.height) : null,
+      contentHeight: contentHeight === null ? null : Math.round(contentHeight),
+    };
+  });
+}
+
+/**
+ * Put the shell where a reader is when they press a wizard button: scrolled down so
+ * the bottom of the framed step — where every Next button sits — is on screen. The
+ * defect only shows from this state, so the check has to reproduce it rather than
+ * rely on Playwright's actionability scroll, which does nothing when the control
+ * already happens to be above the fold.
+ */
+async function scrollShellToFramedStepBottom(page) {
+  await page.evaluate(() => {
+    const scroller = document.scrollingElement || document.documentElement;
+    // The shell animates itself back to the top with jQuery on every framed load;
+    // an animation still in flight would immediately undo this positioning.
+    if (window.jQuery) {
+      window.jQuery('html, body').stop(true, false);
+    }
+    // Defeat any smooth-scroll behaviour so the offset lands synchronously.
+    const previous = scroller.style.scrollBehavior;
+    scroller.style.scrollBehavior = 'auto';
+    window.scrollTo(0, scroller.scrollHeight);
+    scroller.style.scrollBehavior = previous;
+  });
+  // The offset is applied on a later frame in some engines; poll until it settles.
+  let geometry = await readShellGeometry(page);
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await page.waitForTimeout(150);
+    const next = await readShellGeometry(page);
+    if (next.scrollY === geometry.scrollY) {
+      return next;
+    }
+    geometry = next;
+  }
+  return geometry;
+}
+
+/** The shell scrolls back to the top with a jQuery "slow" animation; give it time to settle. */
+async function waitForShellScrollTop(page, timeoutMs = 6000) {
+  const deadline = Date.now() + timeoutMs;
+  let geometry = await readShellGeometry(page);
+  while (Date.now() < deadline && geometry.scrollY > 2) {
+    await page.waitForTimeout(200);
+    geometry = await readShellGeometry(page);
+  }
+  return geometry;
+}
+
+/**
+ * The defect this pins: after an in-frame navigation the reader must be looking at
+ * the TOP of the newly loaded step, and the step must not be clipped by the shell's
+ * fixed aspect-ratio box.
+ */
+function assertFramedStepIsVisible(geometry, label) {
+  if (geometry.scrollY > 2) {
+    findings.push({
+      label,
+      type: 'shell-not-scrolled-to-top',
+      detail: `shell still scrolled ${geometry.scrollY}px down, so the new step loaded off-screen`,
+    });
+  }
+  if (geometry.frameTopInViewport !== null && geometry.frameTopInViewport < -2) {
+    findings.push({
+      label,
+      type: 'framed-step-above-viewport',
+      detail: `frame top is ${geometry.frameTopInViewport}px above the viewport`,
+    });
+  }
+  if (geometry.contentHeight !== null && geometry.frameHeight !== null
+      && geometry.contentHeight - geometry.frameHeight > 2) {
+    findings.push({
+      label,
+      type: 'framed-step-clipped',
+      detail: `framed document is ${geometry.contentHeight}px tall inside a ${geometry.frameHeight}px frame`,
+    });
+  }
+}
+
+async function pickProvider(frame) {
+  const options = await frame.locator('select[name="provider_no"] option')
+    .evaluateAll((els) => els.map((el) => ({ value: el.value, label: (el.textContent || '').trim() })));
+  const selectable = options.filter((option) => option.value);
+  if (!selectable.length) {
+    findings.push({ label: 'schedule-setting', type: 'no-selectable-provider' });
+    return null;
+  }
+  if (requestedProvider) {
+    const match = selectable.find((option) => option.value === requestedProvider);
+    if (!match) {
+      findings.push({ label: 'schedule-setting', type: 'requested-provider-missing', provider: requestedProvider });
+      return null;
+    }
+    return match;
+  }
+  const own = selectable.find((option) => option.label.toLowerCase().startsWith(testUser.toLowerCase()));
+  return own || selectable[0];
+}
+
+async function fillWeekSchedule(frame, templateName) {
+  await frame.locator('input[name="syear"]').fill(SCHEDULE_START.year);
+  await frame.locator('input[name="smonth"]').fill(SCHEDULE_START.month);
+  await frame.locator('input[name="sday"]').fill(SCHEDULE_START.day);
+  await frame.locator('input[name="eyear"]').fill(SCHEDULE_END.year);
+  await frame.locator('input[name="emonth"]').fill(SCHEDULE_END.month);
+  await frame.locator('input[name="eday"]').fill(SCHEDULE_END.day);
+
+  await frame.locator('select[name="mytemplate"]').selectOption(templateName);
+  for (const day of WEEKDAYS) {
+    await frame.locator(`input[name="check${day}"]`).check();
+    // The "<<" button copies the selected template into that day's slot.
+    await frame.locator(`input[name="${day}to1"]`).click();
+  }
+}
+
+async function runWizard(context, page) {
+  const settingFrame = await openAdminSection(page, '/schedule/TemplateSetting', /\/schedule\/TemplateSetting/, 'schedule-setting');
+  if (!settingFrame) {
+    return;
+  }
+
+  const provider = await pickProvider(settingFrame);
+  if (!provider) {
+    return;
+  }
+  await settingFrame.locator('select[name="provider_no"]').selectOption(provider.value);
+
+  const weekFrame = await waitForFrame(page, /\/schedule\/TemplateApplying/, 'schedule-week-setting');
+  if (!weekFrame) {
+    return;
+  }
+  visited.push({ label: 'schedule-week-setting', url: weekFrame.url(), provider: provider.value });
+  await assertNoErrorPage(weekFrame, 'schedule-week-setting');
+  assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-week-setting');
+
+  const templates = await weekFrame.locator('select[name="mytemplate"] option').evaluateAll((els) => els.map((el) => el.value));
+  if (!templates.length) {
+    findings.push({ label: 'schedule-week-setting', type: 'no-day-template-available' });
+    return;
+  }
+  const templateName = templates[0];
+  await fillWeekSchedule(weekFrame, templateName);
+
+  const weekScroll = await scrollShellToFramedStepBottom(page);
+  visited.push({ label: 'schedule-week-setting-next', geometry: weekScroll });
+  await weekFrame.locator('input[type="submit"]').click();
+
+  const calendarFrame = await waitForFrame(page, /\/schedule\/CreateDate/, 'schedule-calendar');
+  if (!calendarFrame) {
+    findings.push({ label: 'schedule-week-setting', type: 'next-did-not-advance' });
+    return;
+  }
+  await calendarFrame.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+  visited.push({ label: 'schedule-calendar', url: calendarFrame.url() });
+  await assertNoErrorPage(calendarFrame, 'schedule-calendar');
+  assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-calendar');
+
+  // The wizard is only useful if the week template actually reached the generated
+  // schedule dates — "the schedule is saved" was the one part of the report that worked.
+  const calendarText = (await calendarFrame.locator('body').innerText().catch(() => '')).replace(/\s+/g, ' ');
+  if (!calendarText.includes(templateName)) {
+    findings.push({ label: 'schedule-calendar', type: 'template-not-applied', template: templateName });
+  }
+  const effectiveRange = `${SCHEDULE_START.year}-${SCHEDULE_START.month.padStart(2, '0')}-${SCHEDULE_START.day.padStart(2, '0')}`;
+  if (!calendarText.includes(effectiveRange)) {
+    findings.push({ label: 'schedule-calendar', type: 'effective-range-missing', expected: effectiveRange });
+  }
+
+  const calendarScroll = await scrollShellToFramedStepBottom(page);
+  visited.push({ label: 'schedule-calendar-next', geometry: calendarScroll });
+  await calendarFrame.locator('input[type="submit"]').click();
+  const finalFrame = await waitForFrame(page, /\/schedule\/DateFinal/, 'schedule-final');
+  if (!finalFrame) {
+    findings.push({ label: 'schedule-calendar', type: 'next-did-not-advance' });
+    return;
+  }
+  await finalFrame.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+  visited.push({ label: 'schedule-final', url: finalFrame.url() });
+  await assertNoErrorPage(finalFrame, 'schedule-final');
+  assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-final');
+
+  const finalText = (await finalFrame.locator('body').innerText().catch(() => '')).replace(/\s+/g, ' ');
+  if (!/finished/i.test(finalText)) {
+    findings.push({ label: 'schedule-final', type: 'unexpected-final-step', body: finalText.slice(0, 300) });
+  }
+}
+
+/**
+ * The sibling Schedule Management pages that call parent.parent.resizeIframe().
+ * They are reached from the same menu and were the source of the reported
+ * "parent.parent.resizeIframe is not a function" console error.
+ */
+const RESIZE_CALLER_SECTIONS = [
+  { label: 'schedule-my-group', rel: '/admin/ViewAdminDisplayMyGroup', pattern: /\/admin\/ViewAdminDisplayMyGroup/ },
+  { label: 'schedule-prevention-notification', rel: '/prevention/ViewPreventionManager', pattern: /\/prevention\/ViewPreventionManager/ },
+];
+
+async function checkResizeIframeCallers(page) {
+  for (const section of RESIZE_CALLER_SECTIONS) {
+    const frame = await openAdminSection(page, section.rel, section.pattern, section.label);
+    if (!frame) {
+      continue;
+    }
+    await frame.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+    // Let the framed page's own jQuery ready callback run and throw, if it is going to.
+    await page.waitForTimeout(1500);
+    assertFramedStepIsVisible(await waitForShellScrollTop(page), section.label);
+  }
+}
+
+(async () => {
+  const launchOptions = {
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  };
+  if (chromePath) {
+    launchOptions.executablePath = chromePath;
+  }
+
+  const browser = await chromium.launch(launchOptions);
+  try {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 900 } });
+    const page = await login(context);
+    context.on('page', (popup) => wirePage(popup, 'popup'));
+
+    await runWizard(context, page);
+    await checkResizeIframeCallers(page);
+
+    console.log(JSON.stringify({ visited, findings }, null, 2));
+
+    if (findings.length) {
+      throw new Error(`schedule setting browser check found ${findings.length} issue(s)`);
+    }
+    console.log('PASS schedule setting wizard advances through every step with the new step in view');
+  } finally {
+    await browser.close();
+  }
+})().catch((error) => {
+  console.error('FAIL schedule setting Playwright check');
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -116,6 +116,21 @@ function recordableUrl(rawUrl) {
   }
 }
 
+/**
+ * Strip query strings out of free-form diagnostic text. Console message
+ * locations, page error messages, and the Playwright stack we print on failure
+ * all quote URLs verbatim, and this application's routes carry provider numbers
+ * in the query string. The path is what identifies the failing route.
+ */
+function redactUrls(text) {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  return text
+    .replace(/\bhttps?:\/\/[^\s"'<>()]+/gi, (match) => recordableUrl(match))
+    .replace(/(^|[\s"'(<=])(\/[^\s"'<>()?]*)\?[^\s"'<>()]*/g, '$1$2');
+}
+
 function appUrl(appPath) {
   if (!appPath.startsWith('/') || appPath.startsWith('//')) {
     throw new Error(`Application path must be root-relative, got ${appPath}`);
@@ -162,16 +177,22 @@ function wirePage(page, label) {
   });
   page.on('console', (message) => {
     if (isSevereConsoleMessage(message)) {
-      findings.push({ label, type: `console:${message.type()}`, text: message.text(), location: message.location() });
+      const location = message.location();
+      findings.push({
+        label,
+        type: `console:${message.type()}`,
+        text: redactUrls(message.text()),
+        location: { ...location, url: recordableUrl(location.url) },
+      });
     }
   });
   page.on('pageerror', (error) => {
-    findings.push({ label, type: 'pageerror', text: error.message });
+    findings.push({ label, type: 'pageerror', text: redactUrls(error.message) });
   });
   page.on('dialog', async (dialog) => {
     // Every dialog here is a validation alert from the wizard — that is a failure,
     // not noise: the step under test did not submit.
-    findings.push({ label, type: 'dialog', text: dialog.message() });
+    findings.push({ label, type: 'dialog', text: redactUrls(dialog.message()) });
     await dialog.accept();
   });
 }
@@ -179,7 +200,12 @@ function wirePage(page, label) {
 async function assertNoErrorPage(frame, label) {
   const bodyText = await frame.locator('body').innerText().catch(() => '');
   if (/CARLOS has encountered an unexpected error|CARLOS Error|HTTP Status 5\d\d|Exception Report/i.test(bodyText)) {
-    findings.push({ label, type: 'error-page', url: recordableUrl(frame.url()), body: bodyText.replace(/\s+/g, ' ').slice(0, 500) });
+    findings.push({
+      label,
+      type: 'error-page',
+      url: recordableUrl(frame.url()),
+      body: redactUrls(bodyText.replace(/\s+/g, ' ')).slice(0, 500),
+    });
   }
 }
 
@@ -565,6 +591,6 @@ async function checkResizeIframeCallers(page) {
   }
 })().catch((error) => {
   console.error('FAIL schedule setting Playwright check');
-  console.error(error.stack || error.message);
+  console.error(redactUrls(error.stack || error.message));
   process.exit(1);
 });

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -39,6 +39,15 @@
 
 const { chromium } = require('playwright');
 
+/*
+ * Hosts that are unambiguously this machine. TLS verification may only be
+ * skipped for these: the check logs in with real credentials, so any other
+ * target has to prove its certificate. A packaged install is reached the same
+ * way the other packaged-install checks reach one — forward a loopback port to
+ * the container's 443 and point BASE_URL at the forward.
+ */
+const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
+
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
 const chromePath = process.env.CHROME_PATH || '';
 const testUser = process.env.TEST_USER || 'carlosdoc';
@@ -61,15 +70,6 @@ function normalizeHost(rawHost) {
   return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
 }
 
-/*
- * Hosts that are unambiguously this machine. TLS verification may only be
- * skipped for these: the check logs in with real credentials, so any other
- * target has to prove its certificate. A packaged install is reached the same
- * way the other packaged-install checks reach one — forward a loopback port to
- * the container's 443 and point BASE_URL at the forward.
- */
-const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
-
 function isExactLocalHost(rawHost) {
   return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
 }
@@ -90,6 +90,13 @@ function validateBaseUrl(rawBaseUrl) {
   const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
   if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  // This check logs in with real credentials, so anything that is not plainly
+  // loopback must at least carry them over TLS — and, per the context below,
+  // prove its certificate while doing it. Same rule as
+  // scripts/flu-billing-report-playwright-checks.js.
+  if (!isExactLocalHost(host) && parsed.protocol !== 'https:') {
+    throw new Error(`Non-loopback BASE_URL host ${host} must use https`);
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
@@ -349,7 +356,12 @@ async function pickProvider(frame) {
   if (requestedProvider) {
     const match = selectable.find((option) => option.value === requestedProvider);
     if (!match) {
-      findings.push({ label: 'schedule-setting', type: 'requested-provider-missing', provider: requestedProvider });
+      findings.push({
+        label: 'schedule-setting',
+        type: 'requested-provider-missing',
+        detail: 'TEST_SCHEDULE_PROVIDER names a provider the Schedule Setting dropdown does not offer',
+        selectableProviders: selectable.length,
+      });
       return null;
     }
     return match;
@@ -390,7 +402,14 @@ async function runWizard(context, page) {
   if (!weekFrame) {
     return;
   }
-  visited.push({ label: 'schedule-week-setting', url: recordableUrl(weekFrame.url()), provider: provider.value });
+  // Deliberately no provider number: it is an identifier that joins back to
+  // records, and what a failed run actually needs to know is HOW the provider was
+  // chosen — a caller reproducing the run sets TEST_SCHEDULE_PROVIDER themselves.
+  visited.push({
+    label: 'schedule-week-setting',
+    url: recordableUrl(weekFrame.url()),
+    providerSource: requestedProvider ? 'TEST_SCHEDULE_PROVIDER' : 'auto-selected',
+  });
   await assertNoErrorPage(weekFrame, 'schedule-week-setting');
   assertFramedStepIsVisible(await waitForShellScrollTop(page), 'schedule-week-setting');
 

--- a/src/main/webapp/WEB-INF/jsp/admin/adminsavemygroup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/adminsavemygroup.jsp
@@ -114,7 +114,13 @@
 
     <script>
         $(document).ready(function () {
-            parent.parent.resizeIframe($('html').height());
+            // resizeIframe lives on the admin shell that frames this page. A page opened
+            // standalone, or framed by a different shell, has no such function, and an
+            // unguarded call throws out of the jQuery ready callback as
+            // "parent.parent.resizeIframe is not a function" (reported on alpha10).
+            if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+                parent.parent.resizeIframe($('html').height());
+            }
         });
     </script>
 

--- a/src/main/webapp/WEB-INF/jsp/admin/resourcebaseurl.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/resourcebaseurl.jsp
@@ -281,7 +281,13 @@
 
 
     $(document).ready(function () {
-        parent.parent.resizeIframe($('html').height());
+        // resizeIframe lives on the admin shell that frames this page. A page opened
+        // standalone, or framed by a different shell, has no such function, and an
+        // unguarded call throws out of the jQuery ready callback as
+        // "parent.parent.resizeIframe is not a function" (reported on alpha10).
+        if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+            parent.parent.resizeIframe($('html').height());
+        }
     });
 </script>
 </body>

--- a/src/main/webapp/WEB-INF/jsp/administration/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/administration/index.jsp
@@ -386,6 +386,9 @@
             if (!href || href === "#" || /^\s*javascript:/i.test(href)) {
                 return;
             }
+            // AJAX-loaded content flows in the shell's own scroll; drop any
+            // height the previous framed section left on the container.
+            resetFrameSizing();
             $("#dynamic-content").removeClass("dynamic-iframe-content");
             $("#dynamic-content").load(href,
                 function (response, status, xhr) {
@@ -511,11 +514,88 @@
         }
     }
 
-    /* function resizeIframe(newHgt)
-    {
-        $('#myFrame').height((parseInt(newHgt)+75)+'px');
+    // The admin shell hosts most section pages inside #myFrame (see the .xlink
+    // handler in leftNav.jspf). Two things have to happen when the framed page
+    // changes: the frame has to be tall enough for the new document, and the
+    // SHELL has to scroll back to the top so the reader is looking at the top of
+    // it. This function is the hook a framed page calls to ask for both, passing
+    // its own content height; scrollFramedContentIntoView() below is the same
+    // behaviour driven from the shell for the many legacy pages that never call
+    // in.
+    //
+    // It was commented out during the Bootstrap 5 rework, which left the shell
+    // parked at whatever scroll offset the reader had used to reach a button
+    // near the bottom of the frame. A multi-step wizard then looks broken: the
+    // schedule week-setting "Next" posts, saves, and loads the next step, but the
+    // reader is still looking at the middle of it and reports that "nothing
+    // happens". The pages that DID call in got a hard
+    // "parent.parent.resizeIframe is not a function" instead. Keep it defined.
+    function resizeIframe(newHgt) {
+        var frame = document.getElementById('myFrame');
+        if (!frame) {
+            // AJAX-loaded (non-framed) content also reaches this via a nested
+            // page; there is nothing to size, but the scroll is still wanted.
+            scrollShellToTop();
+            return;
+        }
+        growFrameTo(parseInt(newHgt, 10) + 75);
+        scrollShellToTop();
+    }
+
+    // Grow the frame (and the aspect-ratio box it lives in) to `height` px.
+    // Only ever grows: a page shorter than the CSS box keeps the box, so this
+    // cannot collapse the frame on a page that reports a bogus height.
+    function growFrameTo(height) {
+        var frame = document.getElementById('myFrame');
+        var container = document.getElementById('dynamic-content');
+        if (!frame || !isFinite(height) || height <= 0) {
+            return;
+        }
+        if (height <= frame.getBoundingClientRect().height) {
+            return;
+        }
+        if (container) {
+            // The .dynamic-iframe-content box is sized by `padding-top: 80%`, an
+            // aspect-ratio hack with no relation to the content. Swap it for a
+            // real height once the real height is known.
+            container.style.paddingTop = '0';
+            container.style.height = height + 'px';
+        }
+        frame.style.height = height + 'px';
+    }
+
+    // Undo anything growFrameTo() applied, so the next section starts from the
+    // CSS box again instead of inheriting the previous page's height.
+    function resetFrameSizing() {
+        var container = document.getElementById('dynamic-content');
+        if (container) {
+            container.style.paddingTop = '';
+            container.style.height = '';
+        }
+    }
+
+    function scrollShellToTop() {
         $("html, body").animate({ scrollTop: 0 }, "slow");
-    } */
+    }
+
+    // Called by the .xlink handler on every document the frame loads. Reads the
+    // framed document's own height (same-origin — every section route is served
+    // by this application) so a page taller than the aspect box is not clipped
+    // behind a nested scrollbar, then puts the shell back at the top so the
+    // reader sees the new page from its beginning. A page that also calls
+    // resizeIframe() itself just asks for the same thing twice, which is
+    // harmless: growFrameTo() only ever grows.
+    function scrollFramedContentIntoView(frame) {
+        try {
+            var doc = frame && frame.contentDocument;
+            if (doc && doc.documentElement) {
+                growFrameTo(doc.documentElement.scrollHeight + 75);
+            }
+        } catch (e) {
+            // A cross-origin document cannot be measured; the CSS box still applies.
+        }
+        scrollShellToTop();
+    }
 
     $(document).ready(function () {
 

--- a/src/main/webapp/WEB-INF/jsp/administration/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/administration/index.jsp
@@ -650,7 +650,18 @@
                 // Document went away or turned cross-origin mid-observation.
             }
         });
+        // Observe BOTH roots. ResizeObserver reports an element's own box, not
+        // the document's scrollHeight, so which of the two actually changes
+        // depends on the framed page's CSS. Measured in Chromium: with the
+        // default auto heights either one fires; with `html { height: 100% }`
+        // and an auto body only <body> fires; with `body { height: 100% }`
+        // neither does — such a page still has to call resizeIframe() itself.
+        // Observing both costs one extra registration and covers a case a
+        // single root misses.
         observer.observe(doc.documentElement);
+        if (doc.body) {
+            observer.observe(doc.body);
+        }
         frame.carlosContentObserver = observer;
     }
 

--- a/src/main/webapp/WEB-INF/jsp/administration/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/administration/index.jsp
@@ -538,22 +538,37 @@
             scrollShellToTop();
             return;
         }
-        growFrameTo(parseInt(newHgt, 10) + 75);
+        growFrameTo(parseInt(newHgt, 10));
         scrollShellToTop();
     }
 
-    // Grow the frame (and the aspect-ratio box it lives in) to `height` px.
-    // Only ever grows: a page shorter than the CSS box keeps the box, so this
-    // cannot collapse the frame on a page that reports a bogus height.
-    function growFrameTo(height) {
+    // Breathing room added on top of a framed document's own height, so the
+    // grown frame does not sit flush against its content and re-introduce a
+    // nested scrollbar from sub-pixel rounding.
+    var FRAME_HEIGHT_MARGIN = 75;
+
+    // Grow the frame (and the aspect-ratio box it lives in) to fit a framed
+    // document `contentHeight` px tall. Only ever grows, and only when the
+    // content genuinely does not fit.
+    //
+    // The margin is added ONLY when growth is needed, which is what keeps this
+    // from ratcheting. A document shorter than its frame reports a scrollHeight
+    // equal to the frame's own height — the viewport is its lower bound — so
+    // adding the margin first and comparing afterwards would grow the frame by
+    // FRAME_HEIGHT_MARGIN on EVERY in-frame navigation, accumulating blank
+    // space without limit across a multi-step flow. Comparing the bare content
+    // height first makes the fitting case a no-op, and one growth step is
+    // enough: the next measurement equals the new frame height and stops.
+    function growFrameTo(contentHeight) {
         var frame = document.getElementById('myFrame');
         var container = document.getElementById('dynamic-content');
-        if (!frame || !isFinite(height) || height <= 0) {
+        if (!frame || !isFinite(contentHeight) || contentHeight <= 0) {
             return;
         }
-        if (height <= frame.getBoundingClientRect().height) {
+        if (contentHeight <= frame.getBoundingClientRect().height) {
             return;
         }
+        var height = contentHeight + FRAME_HEIGHT_MARGIN;
         if (container) {
             // The .dynamic-iframe-content box is sized by `padding-top: 80%`, an
             // aspect-ratio hack with no relation to the content. Swap it for a
@@ -574,8 +589,13 @@
         }
     }
 
+    // .stop(true) first: the .xlink handler scrolls on click and this runs again
+    // when the frame finishes loading, so without it the two animations queue and
+    // the shell keeps animating after it has already arrived. Clearing the queue
+    // also means a reader who scrolls during the animation is not fought by a
+    // stale one that is still ticking.
     function scrollShellToTop() {
-        $("html, body").animate({ scrollTop: 0 }, "slow");
+        $("html, body").stop(true).animate({ scrollTop: 0 }, "slow");
     }
 
     // Called by the .xlink handler on every document the frame loads. Reads the
@@ -584,12 +604,12 @@
     // behind a nested scrollbar, then puts the shell back at the top so the
     // reader sees the new page from its beginning. A page that also calls
     // resizeIframe() itself just asks for the same thing twice, which is
-    // harmless: growFrameTo() only ever grows.
+    // harmless: growFrameTo() is a no-op once the content fits.
     function scrollFramedContentIntoView(frame) {
         try {
             var doc = frame && frame.contentDocument;
             if (doc && doc.documentElement) {
-                growFrameTo(doc.documentElement.scrollHeight + 75);
+                growFrameTo(doc.documentElement.scrollHeight);
             }
         } catch (e) {
             // A cross-origin document cannot be measured; the CSS box still applies.

--- a/src/main/webapp/WEB-INF/jsp/administration/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/administration/index.jsp
@@ -610,11 +610,48 @@
             var doc = frame && frame.contentDocument;
             if (doc && doc.documentElement) {
                 growFrameTo(doc.documentElement.scrollHeight);
+                observeFramedContentHeight(frame, doc);
             }
         } catch (e) {
             // A cross-origin document cannot be measured; the CSS box still applies.
         }
         scrollShellToTop();
+    }
+
+    // Keep following the framed document's height after load.
+    //
+    // Measuring once at load is not enough for the pages this shell-side path
+    // exists to cover: a section that renders a table from its own AJAX call,
+    // expands an accordion, or loads images without declared dimensions is
+    // taller a moment later, and would sit clipped behind the aspect box with a
+    // nested scrollbar — the defect this is meant to remove. The legacy pages
+    // escape that by calling resizeIframe() again themselves; a page that never
+    // calls in has no second chance without this.
+    //
+    // It only grows the frame — it deliberately does NOT scroll. A reader who
+    // opens a collapsed panel half way down a section has not asked to be sent
+    // back to the top.
+    function observeFramedContentHeight(frame, doc) {
+        if (typeof ResizeObserver === 'undefined') {
+            return;
+        }
+        // One observer per frame: each load replaces the document, and a stale
+        // observer would keep measuring the previous one.
+        if (frame.carlosContentObserver) {
+            frame.carlosContentObserver.disconnect();
+        }
+        var observer = new ResizeObserver(function () {
+            try {
+                var current = frame.contentDocument;
+                if (current && current.documentElement) {
+                    growFrameTo(current.documentElement.scrollHeight);
+                }
+            } catch (e) {
+                // Document went away or turned cross-origin mid-observation.
+            }
+        });
+        observer.observe(doc.documentElement);
+        frame.carlosContentObserver = observer;
     }
 
     $(document).ready(function () {

--- a/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
+++ b/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
@@ -907,6 +907,10 @@ $(document).ready(function(){
 		var source = $(this).attr('rel');
 		var submitForm = $(this).data('submit-form');
 		var iframeTitle = $(this).data('frame-title') || $.trim($(this).text()) || "Administration page";
+		if (typeof resetFrameSizing === 'function') {
+			// Start from the CSS aspect box; the previous section may have grown it.
+			resetFrameSizing();
+		}
 		$("#dynamic-content").addClass("dynamic-iframe-content");
 		$("#dynamic-content").empty().append($("<iframe>", {
 			id: "myFrame",
@@ -916,6 +920,21 @@ $(document).ready(function(){
 			role: "region",
 			"aria-live": "polite"
 		}).css("border", "0"));
+		// Every document the frame loads — the first one AND every in-frame
+		// navigation after it (a link, a form post, a wizard's "Next") — has to
+		// bring the shell back to the top of the new page. Without this, a reader
+		// who scrolled the SHELL down to reach a control near the bottom of the
+		// frame stays parked at that offset while the frame swaps in a new
+		// document, and sees the middle of it: the schedule week-setting "Next"
+		// saved the schedule and loaded the calendar step, and the reader
+		// reported that clicking it did nothing (alpha10). Only a handful of
+		// legacy pages call parent.parent.resizeIframe() themselves, so this has
+		// to be driven from the shell to cover the rest.
+		$("#myFrame").on("load", function () {
+			if (typeof scrollFramedContentIntoView === 'function') {
+				scrollFramedContentIntoView(this);
+			}
+		});
 		if (submitForm) {
 			var form = document.getElementById(submitForm);
 			if (form) {

--- a/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
+++ b/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
@@ -943,7 +943,17 @@ $(document).ready(function(){
 		} else {
 			$("#myFrame").attr("src", source);
 		}
-		$("html, body").animate({ scrollTop: 0 }, "slow");
+		// Immediate feedback: a section whose page takes a moment to arrive would
+		// otherwise leave the reader at their old offset until it does. The load
+		// handler above then owns the final position once the real content height
+		// is known. Go through the shell's helper so this scroll clears the
+		// animation queue too — two clicks in quick succession would otherwise
+		// queue and extend each other.
+		if (typeof scrollShellToTop === 'function') {
+			scrollShellToTop();
+		} else {
+			$("html, body").stop(true).animate({ scrollTop: 0 }, "slow");
+		}
 	});
 
 

--- a/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereport.jsp
@@ -304,7 +304,13 @@
     <script src="<%=request.getContextPath() %>/library/jquery/jquery-compat.js"></script>
     <script>
         $(document).ready(function () {
-            parent.parent.resizeIframe($('html').height());
+            // resizeIframe lives on the admin shell that frames this page. A page opened
+            // standalone, or framed by a different shell, has no such function, and an
+            // unguarded call throws out of the jQuery ready callback as
+            // "parent.parent.resizeIframe is not a function" (reported on alpha10).
+            if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+                parent.parent.resizeIframe($('html').height());
+            }
 
         });
     </script>

--- a/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereportdetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereportdetail.jsp
@@ -408,7 +408,13 @@
     <script src="<%=request.getContextPath() %>/library/jquery/jquery-compat.js"></script>
     <script>
         $(document).ready(function () {
-            parent.parent.resizeIframe($('html').height());
+            // resizeIframe lives on the admin shell that frames this page. A page opened
+            // standalone, or framed by a different shell, has no such function, and an
+            // unguarded call throws out of the jQuery ready callback as
+            // "parent.parent.resizeIframe is not a function" (reported on alpha10).
+            if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+                parent.parent.resizeIframe($('html').height());
+            }
         });
     </script>
     </body>

--- a/src/main/webapp/WEB-INF/jsp/prevention/PreventionListManager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/PreventionListManager.jsp
@@ -288,7 +288,13 @@
             indicatorAllDisplay($('#property-bin').val());
         }
 
-        parent.parent.resizeIframe($('html').height());
+        // resizeIframe lives on the admin shell that frames this page. A page opened
+        // standalone, or framed by a different shell, has no such function, and an
+        // unguarded call throws out of the jQuery ready callback as
+        // "parent.parent.resizeIframe is not a function" (reported on alpha10).
+        if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+            parent.parent.resizeIframe($('html').height());
+        }
     });
 </script>
 </body>

--- a/src/main/webapp/WEB-INF/jsp/prevention/PreventionManager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/PreventionManager.jsp
@@ -373,7 +373,13 @@
     <script src="<%=request.getContextPath() %>/library/jquery/jquery-compat.js"></script>
     <script>
         $(document).ready(function () {
-            parent.parent.resizeIframe($('html').height());
+            // resizeIframe lives on the admin shell that frames this page. A page opened
+            // standalone, or framed by a different shell, has no such function, and an
+            // unguarded call throws out of the jQuery ready callback as
+            // "parent.parent.resizeIframe is not a function" (reported on alpha10).
+            if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+                parent.parent.resizeIframe($('html').height());
+            }
 
         });
     </script>

--- a/src/main/webapp/share/javascript/csrfTokenFetch.js
+++ b/src/main/webapp/share/javascript/csrfTokenFetch.js
@@ -9,11 +9,32 @@
  * either await resolution or handle rejection so they do not submit
  * with an empty token.
  *
+ * A navigation that starts while the fetch is still in flight cancels it, and
+ * the resulting rejection is reported as a plain "TypeError: Failed to fetch"
+ * — indistinguishable from a real network failure. That case is not worth
+ * warning about: the document that would have used the token is already being
+ * destroyed. The promise still rejects (callers depend on that), but the
+ * console stays quiet, so a genuine warning means a genuine failure.
+ *
  * @param {string} contextPath - the application context path (e.g. "/carlos")
  * @returns {Promise<void>} resolves after tokens have been populated;
  *                          rejects if the token cannot be fetched or parsed
  * @since 2026-04-07
  */
+
+/**
+ * Set once this document starts going away, so the rejection handler below can
+ * tell "the page was torn down mid-request" from "the request really failed".
+ * Both pagehide and beforeunload are observed because which one runs first —
+ * and whether either runs before the in-flight request is cancelled — varies
+ * with how the navigation was initiated.
+ */
+var carlosCsrfPageUnloading = false;
+if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('pagehide', function () { carlosCsrfPageUnloading = true; }, true);
+    window.addEventListener('beforeunload', function () { carlosCsrfPageUnloading = true; }, true);
+}
+
 function fetchCsrfToken(contextPath) {
     return fetch(contextPath + '/csrfguard', { credentials: 'same-origin' })
         .then(function(r) {
@@ -36,7 +57,20 @@ function fetchCsrfToken(contextPath) {
             }
         })
         .catch(function(err) {
-            console.warn('CSRF token fetch failed:', err);
+            if (!carlosCsrfPageUnloading) {
+                // Deferred by one task on purpose. A navigation cancels this
+                // request and destroys the document a moment later, and the
+                // rejection can be delivered before either unload event runs —
+                // so the flag above is not on its own enough. A task queued on
+                // a document that is being destroyed is discarded with it, so
+                // the warning survives only if the page is still alive to act
+                // on it. The rejection itself is not deferred.
+                setTimeout(function () {
+                    if (!carlosCsrfPageUnloading) {
+                        console.warn('CSRF token fetch failed:', err);
+                    }
+                }, 0);
+            }
             throw err;
         });
 }

--- a/src/main/webapp/share/javascript/csrfTokenFetch.js
+++ b/src/main/webapp/share/javascript/csrfTokenFetch.js
@@ -25,9 +25,14 @@
 /**
  * Set once this document starts going away, so the rejection handler below can
  * tell "the page was torn down mid-request" from "the request really failed".
- * Both pagehide and beforeunload are observed because which one runs first —
- * and whether either runs before the in-flight request is cancelled — varies
- * with how the navigation was initiated.
+ *
+ * pagehide only, deliberately NOT beforeunload. A beforeunload listener makes
+ * the page ineligible for the back/forward cache in some browsers, and this
+ * script is included on every JSP that bootstraps a token — a real cost paid on
+ * every page for no benefit here, since pagehide fires in every teardown case
+ * this cares about. Ordering is not what the flag is for anyway: the rejection
+ * is frequently delivered before ANY unload event runs, which is why the
+ * warning below is also deferred a task.
  *
  * Cleared again on pageshow. A document entering the back/forward cache fires
  * pagehide WITHOUT being destroyed, and coming back does not re-run this
@@ -38,7 +43,6 @@
 var carlosCsrfPageUnloading = false;
 if (typeof window !== 'undefined' && window.addEventListener) {
     window.addEventListener('pagehide', function () { carlosCsrfPageUnloading = true; }, true);
-    window.addEventListener('beforeunload', function () { carlosCsrfPageUnloading = true; }, true);
     window.addEventListener('pageshow', function () { carlosCsrfPageUnloading = false; }, true);
 }
 

--- a/src/main/webapp/share/javascript/csrfTokenFetch.js
+++ b/src/main/webapp/share/javascript/csrfTokenFetch.js
@@ -28,11 +28,18 @@
  * Both pagehide and beforeunload are observed because which one runs first —
  * and whether either runs before the in-flight request is cancelled — varies
  * with how the navigation was initiated.
+ *
+ * Cleared again on pageshow. A document entering the back/forward cache fires
+ * pagehide WITHOUT being destroyed, and coming back does not re-run this
+ * script — so without the reset the flag would stay set for the rest of that
+ * document's life and silence every later genuine failure on it, including the
+ * eForm manager's retry.
  */
 var carlosCsrfPageUnloading = false;
 if (typeof window !== 'undefined' && window.addEventListener) {
     window.addEventListener('pagehide', function () { carlosCsrfPageUnloading = true; }, true);
     window.addEventListener('beforeunload', function () { carlosCsrfPageUnloading = true; }, true);
+    window.addEventListener('pageshow', function () { carlosCsrfPageUnloading = false; }, true);
 }
 
 function fetchCsrfToken(contextPath) {


### PR DESCRIPTION
## Description

An alpha tester on 2026.08.0-alpha10 reported: *"Admin > Schedule Management > Schedule Setting — set the schedule and click next on the illustrated window and nothing happens (although the schedule is saved)"*, with `jquery-3.7.1.min.js:2 Uncaught TypeError: parent.parent.resizeIframe is not a function` in the console.

Both symptoms are the same root cause. `resizeIframe()` had been **commented out** of `administration/index.jsp` during the Bootstrap 5 rework. It did two things for every page framed in the admin shell's `#myFrame`: size the frame to its content, and scroll the shell back to the top.

Without the scroll-back, a reader who scrolled the *shell* down to reach a wizard button at the bottom of the frame stays parked at that offset while the frame swaps in the next step. Measured on a live install: the shell sits at **scrollY 252** after "Next", so the schedule saves, the calendar step loads, and the reader is looking at the middle of a page they have never seen. It reads as nothing happening. The handful of legacy pages that *did* call `resizeIframe()` themselves got the hard TypeError instead — that is the console error in the report, jQuery re-throwing a failed `ready` callback through `jQuery.readyException`.

This is not limited to Schedule Setting. Every framed Administration section has behaved this way since the rework; the schedule wizard is just where it is most visible, because the flow has three steps.

The PR also fixes an unrelated defect found while validating: `fetchCsrfToken()` warned `CSRF token fetch failed: TypeError: Failed to fetch` whenever a navigation cancelled the request mid-flight. Nothing was wrong — the document that would have used the token was already being destroyed — but a reader who clicks away during page load got a scary console error, and `eform-admin-schedule-navigation-playwright-checks.js` (which fails on any console warning) was flaky against the packaged front door, where HTTP/2 widens the window in which a request is still open when the next navigation commits.

### What changed

**Admin shell** (`administration/index.jsp`, `leftNav.jspf`)
- Restore `resizeIframe()`, split into `growFrameTo()` — which replaces the `padding-top: 80%` aspect box with the real content height, grow-only so a bogus height cannot collapse the frame — plus `resetFrameSizing()` and `scrollShellToTop()`.
- Bind `scrollFramedContentIntoView()` to the frame's `load` event, so the size-and-scroll runs for the first document **and** every in-frame navigation (a link, a form post, a wizard's Next). Only a handful of legacy pages call in themselves, so this has to be driven from the shell to cover the rest — the schedule wizard among them.
- Reset the container sizing when a section switches to AJAX mode or a new section opens, so one page's height is not inherited by the next.
- Guard the six remaining unguarded `parent.parent.resizeIframe()` call sites the way `adminnewgroup.jsp` and `admindisplaymygroup.jsp` already were, so a page opened standalone or under another shell cannot throw out of `ready`.

**CSRF helper** (`share/javascript/csrfTokenFetch.js`)
- An abort and a real network failure both surface as a bare `TypeError: Failed to fetch`, so the message cannot tell them apart. Track the document teardown instead (`pagehide`/`beforeunload`), and defer the warning by one task so it is discarded along with a document that is going away — the rejection can be delivered before either event runs, so the flag alone is not enough. **The promise still rejects in every case**; callers (`efmformmanager`'s `csrfToken()`, the `csrf-token.jspf` bootstrap) branch on that and are unchanged.

## Related Issues

No issue filed — reported directly by an alpha tester against the packaged 2026.08.0-alpha10 install.

## Target Branch

`release/2026.08`. This is a supported-release fix for a defect reported against 2026.08.0-alpha10, matching the alpha-tester fix rounds already on this branch (#3565, #3587, #3588, #3590). The branch is planted directly on `release/2026.08` and carries no version or SCM metadata change.

## How Was This Tested?

Everything below ran against a **packaged `.deb` install built from this change**, through nginx + ModSecurity on :443 — not the devcontainer.

- Built `carlos-emr_2026.09.0~snapshot18_all.deb` in the same digest-pinned `ubuntu:26.04` image CI uses, installed it into a systemd container (nginx 1.28 + ModSecurity CRS 3.3.8 with `SecRuleEngine On` + tomcat11 + MariaDB 11.8). `carlos-ctl check`: all checks passed, including *"ModSecurity rule engine is On (blocking)"*.
- **New** `scripts/schedule-setting-playwright-checks.js` (`npm run test:schedule-setting-playwright`) drives all three wizard steps and asserts each step advances, the new step's top is in the viewport, the framed document is not clipped, the chosen template actually reached the generated schedule dates, and the sibling Schedule Management pages that call `resizeIframe()` load without a browser exception. It scrolls the shell to the bottom before each Next — the defect is invisible from a shell already at the top, which is why a first draft of the check passed against the broken build.
  - **Red before / green after**, both on the packaged front door: pre-fix it reports `shell still scrolled 252px down, so the new step loaded off-screen` plus the reported `parent.parent.resizeIframe is not a function`; post-fix `findings: []`, 4 consecutive runs.
  - Persistence asserted in the database: `rschedule` row with the real `<MON>…</MON>` payload plus 20 generated `scheduledate` rows (Mon–Fri × 4 weeks).
- **WAF**: zero ModSecurity denials across every run. Probing the same route directly, `avail_hour=<MON>Standard</MON>…` passes CRS at paranoia level 1 while an XSS payload and a SQLi payload on that route are both blocked (anomaly score 23) — so the rules are inspecting the route and the wizard needs no exclusion. Recorded in the new doc.
- **CSRF fix**: instrumented on the packaged install, all five observed failures were `net::ERR_ABORTED` on `/carlos/csrfguard`, delivered 1 ms before the main frame navigated, alongside the page's other in-flight subresources; with no navigation the fetch succeeded 8/8 and the token populated. After the fix the aborts still occur 1–2 per run and produce no warning, and a genuine 500 and a genuine connection failure both still warn and still reject. `eform-admin-schedule-navigation-playwright-checks.js` now passes **8/8** on the deb (3/3 unmodified, 5/5 instrumented) where it was 1 pass / 2 fail.
- **New** `scripts/csrf-token-fetch.test.js` (`npm run test:scripts`) pins all four behaviours in a `vm` context; it fails 2/5 against the pre-fix helper.
- Adjacent checks re-run green on the deb: `eform-admin-playwright-checks.js`, `eform-admin-schedule-navigation-playwright-checks.js`.
- Lints: JSP taglib, encoder null-safety, and struts-DTD all pass.

## Screenshots

Verified visually on the packaged install over HTTPS, but the images live in the working session rather than in this PR, so this section is described rather than shown:

- **Before** — after pressing Next, the shell is still scrolled 252px down: the viewport shows the bottom edge of the calendar and a large empty ivory area, with the heading, provider name and month navigation all above the fold. Indistinguishable at a glance from the page you were just on.
- **After** — the same click lands on the calendar step rendered from its top, with the applied template visible on every weekday of the effective range.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014APeWBL179NbNDkehxVECL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the alpha10 report where the Schedule Setting wizard's Next button appeared to do nothing (the schedule saved, but the next step loaded off-screen), and stops `fetchCsrfToken()` from logging a console warning when a navigation cancels the request.

- The shell now sizes `#myFrame` to its content on every frame load and follows later height changes with a `ResizeObserver` on both the framed document root and body, then scrolls back to the top so the newly loaded step is in view.
- The frame only grows, resets when a section switches to AJAX mode or a new section opens, and stops queued scroll animations (including the click-time one), so repeated in-frame navigations no longer accumulate height.
- The six remaining unguarded `parent.parent.resizeIframe()` call sites are guarded, so those pages no longer throw when opened standalone or under another shell.
- The CSRF promise still rejects in every case and genuine failures still warn; the warning is suppressed only while the document is going away, and the flag resets on `pageshow` so back/forward-cache restores keep reporting real failures.
- Adds `schedule-setting-playwright-checks.js` (which scrolls the shell down before each Next, since the defect only reproduces from that state, redacts provider identifiers from its diagnostics, and verifies TLS for any non-loopback target since it logs in with real credentials) and `csrf-token-fetch.test.js`, wired as `test:schedule-setting-playwright` and `test:scripts`, plus `docs/administration-shell-framing.md`.

<sup>Written for commit d41bb724f9cc674502c9ddf306c13270a324d214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Restore reliable framed Administration navigation and sizing, and distinguish cancelled CSRF requests from genuine fetch failures.

Bug Fixes:
- Restore Administration framed-page sizing and scroll reset so multi-step wizards visibly advance and legacy resize requests no longer trigger browser errors.
- Suppress CSRF fetch warnings caused by requests cancelled during page teardown while preserving warnings and rejected promises for genuine failures.

Enhancements:
- Improve framed Administration content sizing, including resets between sections and continued growth as content changes.
- Document the Administration shell’s framed-page hosting and sizing contract.

Documentation:
- Add documentation describing Administration shell framing behavior and its regression-check usage.

Tests:
- Add Playwright coverage for the Schedule Setting wizard, frame visibility and sizing, resizeIframe callers, and schedule persistence.
- Add unit tests covering CSRF fetch success, genuine failures, cancellation during unload, and back/forward-cache restoration.