### PR TITLE
test(billing): browser check for Ontario 3rd-party/bonus-codes bill entry

### DIFF
--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -261,6 +261,14 @@ export PRESCRIPTION_SCRIPT_ID=45 PRESCRIPTION_DEMOGRAPHIC_NO=1
 export CONSULT_DEMO_NO=1 CONSULT_SERVICE_ID=1 CONSULT_REQUEST_ID=1
 export CONSULT_STAMP_PROVIDER_NO=999998 CONSULT_UNSIGNED_REQUEST_ID=3
 export PATIENT_LIST_FIXTURE_PROFILE=local-seed-obec-report-v1
+# Ontario 3rd-Party / Bonus-Codes bill entry (billing-on-third-party-playwright-checks.js).
+# Read-only: it opens the Ontario bill form for this appointment and switches the bill
+# type, but never submits a bill, so it seeds nothing and cleans nothing up. It asserts
+# billRegion travels on every self-navigation, which is what #3588 pinned -- an install
+# that has the `billregion` property set still routes correctly with the parameter
+# missing, so a status-only assertion would pass on a re-broken page.
+export BILLING_APPOINTMENT_NO=11 BILLING_DEMOGRAPHIC_NO=1 BILLING_PROVIDER_NO=999998
+export BILLING_APPOINTMENT_DATE=2024-04-16 BILLING_START_TIME=12:00:00
 # Rich Text Letter print/PDF check (fixture c above); omit to skip only its template step.
 export RTL_TEMPLATE_NAME=MissedAppointment.rtl
 # Rx signature-stamp fax check (rx-fax-signature-stamp-playwright-checks.js). It writes and then

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "test:report-demographic-navigation-playwright": "node scripts/report-demographic-navigation-playwright-checks.js",
     "test:flowsheet-admin-playwright": "node scripts/flowsheet-admin-playwright-checks.js",
     "test:select-forms-panel-playwright": "node scripts/select-forms-panel-playwright-checks.js",
-    "test:flu-billing-report-playwright": "node scripts/flu-billing-report-playwright-checks.js"
+    "test:flu-billing-report-playwright": "node scripts/flu-billing-report-playwright-checks.js",
+    "test:billing-on-third-party-playwright": "node scripts/billing-on-third-party-playwright-checks.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/billing-on-third-party-playwright-checks.js
+++ b/scripts/billing-on-third-party-playwright-checks.js
@@ -28,17 +28,25 @@
  * navigation query string WITHOUT billRegion, and Billing2Action's fall-back
  * read a holder nothing populated, so the router answered "BC" and handed an
  * Ontario request to billingBC.jsp -- which queries the BC-only billingvisit
- * table. The bill entry was lost with the 500. The same release also prefixed
- * the Ontario unbilled "Bill" links with the context path (they 404'd at the
- * host root) and put billRegion=ON on them.
+ * table. The bill entry was lost with the 500. The same release prefixed the
+ * Ontario unbilled "Bill" links with the context path (they 404'd at the host
+ * root) and put billRegion=ON on them.
  *
  * Why the region assertion and not just "no 500": the fall-back is a property,
  * `billregion`, and an install that HAS it set (the packaged Ontario install
  * does) still routes correctly with the query parameter missing. Asserting only
- * the status code would therefore pass on a re-broken page. This check asserts
- * the thing the fix actually pins -- billRegion travelling on every self
- * navigation -- and treats the rendered Ontario form and the absence of an
- * error page as the user-visible corroboration.
+ * the status code would therefore pass on a re-broken page.
+ *
+ * Page identity is asserted from the Ontario bill-type CODES (ODP/BON), not
+ * from the presence of a control named xml_billtype: billingBC.jsp carries an
+ * xml_billtype field of its own, so that control cannot tell the two forms
+ * apart. The codes can -- BC offers ICBC/WCB/Pri. Codes are also locale
+ * independent, unlike the page title.
+ *
+ * Each bill-type switch must actually navigate. A swallowed navigation would
+ * leave the browser on the entry URL, which already carries billRegion=ON and
+ * already renders the Ontario form, so every assertion would pass without the
+ * branch having run at all.
  *
  * READ-ONLY: it switches the bill type and reads links. It never submits a
  * bill, so it seeds nothing and has nothing to clean up.
@@ -53,77 +61,65 @@
  *   Record pointers into the demo dataset (an appointment that can be billed):
  *     BILLING_APPOINTMENT_NO=11 BILLING_DEMOGRAPHIC_NO=1 BILLING_PROVIDER_NO=999998
  *     BILLING_APPOINTMENT_DATE=2024-04-16 BILLING_START_TIME=12:00:00
- *   BILLING_ON_SCREENSHOT_DIR=/tmp/carlos-billing-on-playwright
+ *   BILLING_ON_ARTIFACT_DIR=/tmp/carlos-billing-on-playwright
  *   ALLOW_NON_LOCAL_BASE_URL=true for any target that is not loopback
  */
-const { chromium } = require('playwright');
 const fs = require('fs');
-const path = require('path');
-const { buildArtifactPath } = require('./eform-local-playwright-utils');
-
-/*
- * Hosts this script will browse without an explicit opt-in. It logs in as an
- * administrator, so anything that is not plainly this machine or its compose
- * network has to be opted into.
- */
-const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'db', 'carlos']);
-const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
-
-function normalizeHost(rawHost) {
-  return rawHost.toLowerCase().replace(/^\[|\]$/g, '');
-}
-
-function isLocalHost(rawHost) {
-  return LOCAL_HOSTS.has(normalizeHost(rawHost));
-}
-
-function isExactLocalHost(rawHost) {
-  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
-}
-
-function validateBaseUrl(rawBaseUrl) {
-  const parsed = new URL(rawBaseUrl);
-  if (!['http:', 'https:'].includes(parsed.protocol)) {
-    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
-  }
-  // Credentials in the URL would travel into navigations and can surface in
-  // failure logging, so reject them outright.
-  if (parsed.username || parsed.password) {
-    throw new Error('BASE_URL must not contain embedded credentials');
-  }
-  if (!isLocalHost(parsed.hostname) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
-    throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
-  }
-  // This script logs in with real credentials, so anything that is not plainly
-  // loopback has to prove its certificate.
-  if (!isExactLocalHost(parsed.hostname) && parsed.protocol !== 'https:') {
-    throw new Error(`Non-loopback BASE_URL host ${parsed.hostname} must use https`);
-  }
-  parsed.pathname = parsed.pathname.replace(/\/$/, '');
-  return parsed.toString().replace(/\/$/, '');
-}
+const { chromium } = require('playwright');
+const {
+  assert,
+  buildArtifactPath,
+  getLaunchOptions,
+  gotoApp,
+  validateBaseUrl,
+} = require('./eform-local-playwright-utils');
 
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
-const contextPath = new URL(baseUrl).pathname || '';
+// validateBaseUrl strips a trailing slash, so a root deployment yields '' here
+// rather than '/' -- the link prefix below would otherwise look for '//billing?'.
+const contextPath = baseUrl.pathname;
 const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
-const screenshotDir = process.env.BILLING_ON_SCREENSHOT_DIR || '/tmp/carlos-billing-on-playwright';
-
-const appointmentNo = process.env.BILLING_APPOINTMENT_NO || '11';
-const demographicNo = process.env.BILLING_DEMOGRAPHIC_NO || '1';
-const providerNo = process.env.BILLING_PROVIDER_NO || '999998';
-const appointmentDate = process.env.BILLING_APPOINTMENT_DATE || '2024-04-16';
-const startTime = process.env.BILLING_START_TIME || '12:00:00';
+const artifactDir = process.env.BILLING_ON_ARTIFACT_DIR || '/tmp/carlos-billing-on-playwright';
 
 /*
- * The bill types whose onChangePrivate() branch rebuilds the URL — these are
- * exactly the ones that lost billRegion. PAT/OCF/ODS/CPP/STD route through
- * curBillForm=PRI ("3rd party"), BON through the primary-care-incentive view
- * ("Bonus Codes").
+ * Record pointers are interpolated into navigation URLs, so they are shape
+ * checked before use: only digits and ISO dates/times reach the query string.
+ */
+function digits(name, raw, fallback) {
+  const value = raw === undefined || raw === '' ? fallback : raw;
+  assert(/^\d{1,10}$/.test(value), `${name} must be 1-10 digits, got ${value}`);
+  return value;
+}
+
+function isoDate(name, raw, fallback) {
+  const value = raw === undefined || raw === '' ? fallback : raw;
+  assert(/^\d{4}-\d{2}-\d{2}$/.test(value), `${name} must be YYYY-MM-DD, got ${value}`);
+  return value;
+}
+
+function isoTime(name, raw, fallback) {
+  const value = raw === undefined || raw === '' ? fallback : raw;
+  assert(/^\d{2}:\d{2}:\d{2}$/.test(value), `${name} must be HH:MM:SS, got ${value}`);
+  return value;
+}
+
+const appointmentNo = digits('BILLING_APPOINTMENT_NO', process.env.BILLING_APPOINTMENT_NO, '11');
+const demographicNo = digits('BILLING_DEMOGRAPHIC_NO', process.env.BILLING_DEMOGRAPHIC_NO, '1');
+const providerNo = digits('BILLING_PROVIDER_NO', process.env.BILLING_PROVIDER_NO, '999998');
+const appointmentDate = isoDate('BILLING_APPOINTMENT_DATE', process.env.BILLING_APPOINTMENT_DATE, '2024-04-16');
+const startTime = isoTime('BILLING_START_TIME', process.env.BILLING_START_TIME, '12:00:00');
+
+/*
+ * The bill types whose onChangePrivate() branch rebuilds the URL -- exactly the
+ * ones that lost billRegion. PAT/OCF/ODS/CPP/STD route through curBillForm=PRI
+ * ("3rd party"), BON through the primary-care-incentive view ("Bonus Codes").
  */
 const THIRD_PARTY_PREFIXES = ['PAT', 'OCF', 'ODS', 'CPP', 'STD'];
 const BONUS_PREFIX = 'BON';
+/* Ontario-only bill-type codes; billingBC.jsp offers ICBC/WCB/Pri instead. */
+const ONTARIO_MARKER_PREFIXES = ['ODP', 'BON'];
 
 const results = [];
 
@@ -132,7 +128,7 @@ function check(name, ok, detail) {
   console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${ok || !detail ? '' : `: ${detail}`}`);
 }
 
-function billEntryUrl() {
+function billEntryPath() {
   const params = new URLSearchParams({
     billRegion: 'ON',
     hotclick: '',
@@ -145,11 +141,11 @@ function billEntryUrl() {
     start_time: startTime,
     bNewForm: '1',
   });
-  return `./billing?${params.toString()}`;
+  return `/billing?${params.toString()}`;
 }
 
 async function login(page) {
-  await page.goto('./', { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await gotoApp(page, baseUrl, '/');
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
   await page.locator('#pin').fill(testPin);
@@ -157,20 +153,28 @@ async function login(page) {
   await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
 }
 
-/* The Ontario bill form is identified by its own bill-type control; billingBC.jsp
-   has no xml_billtype select, which is precisely how the misroute showed up. */
+async function billTypeCodes(page) {
+  const values = await page.locator('select[name="xml_billtype"] option')
+    .evaluateAll((nodes) => nodes.map((node) => node.value))
+    .catch(() => []);
+  return values.map((value) => value.slice(0, 3));
+}
+
 async function describeBillPage(page) {
-  const body = await page.content();
+  const codes = await billTypeCodes(page);
   return {
     url: page.url(),
-    isOntarioForm: (await page.locator('select[name="xml_billtype"]').count()) > 0,
-    hasErrorPage: /CARLOS Error/i.test(body),
-    mentionsBcTable: /billingvisit/i.test(body),
+    codes,
+    // Positive identity: the Ontario code set. The bare presence of an
+    // xml_billtype control does NOT distinguish the forms (see header).
+    isOntarioForm: ONTARIO_MARKER_PREFIXES.every((prefix) => codes.includes(prefix)),
+    hasErrorPage: /CARLOS Error/i.test(await page.content()),
   };
 }
 
-async function switchBillType(page, optionValue) {
-  await page.goto(billEntryUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+async function switchBillType(page, optionValue, expectedCode) {
+  await gotoApp(page, baseUrl, billEntryPath());
+  const entryUrl = page.url();
   const select = page.locator('select[name="xml_billtype"]');
   await select.waitFor({ state: 'attached', timeout: 60000 });
 
@@ -179,56 +183,105 @@ async function switchBillType(page, optionValue) {
     if (response.request().resourceType() === 'document') documentStatus = response.status();
   };
   page.on('response', onResponse);
-  await Promise.all([
-    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => null),
-    select.selectOption(optionValue),
-  ]);
-  page.off('response', onResponse);
+  let navigated = true;
+  try {
+    // NOT swallowed: a branch that stops navigating would leave us on the entry
+    // URL, which already satisfies every assertion below.
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 }),
+      select.selectOption(optionValue),
+    ]);
+  } catch (error) {
+    navigated = false;
+  } finally {
+    page.off('response', onResponse);
+  }
 
-  return { documentStatus, ...(await describeBillPage(page)) };
+  const described = await describeBillPage(page);
+  return {
+    documentStatus,
+    navigated: navigated && described.url !== entryUrl,
+    carriesSelectedType: new RegExp(`[?&]xml_billtype=${expectedCode}(&|$)`).test(described.url),
+    ...described,
+  };
+}
+
+/*
+ * The report's "Bill" anchors are href="#"; the real URL -- the one #3588
+ * fixed -- is the third argument of their onclick popupPage(h, w, "URL")
+ * handler, so an href selector finds nothing and would skip forever.
+ *
+ * Two details the markup forces on us: the URL may be single- OR double-quoted,
+ * and it is written through <carlos:encode context="javaScriptAttribute">, so
+ * its separators arrive escaped (`&` as `\x26`). Decode before asserting, or a
+ * literal `&billRegion=ON` test can never match.
+ */
+function decodeJsAttribute(raw) {
+  return raw
+    .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/\\(['"/\\])/g, '$1');
+}
+
+async function unbilledBillLinks(page) {
+  const handlers = await page.locator('a[onclick*="popupPage"]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('onclick') || ''));
+  const urls = [];
+  for (const handler of handlers) {
+    const match = handler.match(/popupPage\s*\([^,]*,[^,]*,\s*(['"])((?:\\.|(?!\1).)*)\1/);
+    if (!match) continue;
+    const url = decodeJsAttribute(match[2]);
+    if (url.includes('/billing?')) urls.push(url);
+  }
+  return urls;
 }
 
 async function run() {
-  const browser = await chromium.launch({
-    executablePath: process.env.CHROME_PATH || undefined,
-    args: ['--no-sandbox'],
+  const browser = await chromium.launch(getLaunchOptions(process.env.CHROME_PATH || undefined));
+  // Certificate verification is only relaxed for loopback, where the packaged
+  // install serves its own self-signed cert. A non-local target opted in via
+  // ALLOW_NON_LOCAL_BASE_URL must still prove its certificate, because this
+  // script submits administrator credentials to it.
+  const loopback = new Set(['localhost', '127.0.0.1', '::1', '0:0:0:0:0:0:0:1']);
+  const host = baseUrl.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  const context = await browser.newContext({
+    ignoreHTTPSErrors: loopback.has(host),
+    baseURL: `${baseUrl.toString().replace(/\/$/, '')}/`,
   });
-  const context = await browser.newContext({ ignoreHTTPSErrors: true, baseURL: `${baseUrl}/` });
   const page = await context.newPage();
 
   try {
     await login(page);
 
-    await page.goto(billEntryUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await gotoApp(page, baseUrl, billEntryPath());
     const entry = await describeBillPage(page);
     check('the Ontario bill form opens for the configured appointment', entry.isOntarioForm,
-      `not the Ontario form at ${entry.url}; set BILLING_APPOINTMENT_NO/BILLING_DEMOGRAPHIC_NO to a billable appointment`);
+      `codes=${JSON.stringify(entry.codes)} at ${entry.url}; set BILLING_APPOINTMENT_NO/BILLING_DEMOGRAPHIC_NO to a billable appointment`);
     if (!entry.isOntarioForm) return;
 
     const options = await page.locator('select[name="xml_billtype"] option')
       .evaluateAll((nodes) => nodes.map((node) => node.value));
-
     const wanted = [...THIRD_PARTY_PREFIXES, BONUS_PREFIX]
       .map((prefix) => ({ prefix, value: options.find((value) => value.startsWith(prefix)) }))
-      .filter((entryOption) => Boolean(entryOption.value));
+      .filter((option) => Boolean(option.value));
 
     check('the bill-type control offers 3rd-party and bonus-code types',
       wanted.some((o) => THIRD_PARTY_PREFIXES.includes(o.prefix)) && wanted.some((o) => o.prefix === BONUS_PREFIX),
       `offered: ${JSON.stringify(options)}`);
 
     for (const { prefix, value } of wanted) {
-      const outcome = await switchBillType(page, value);
+      const outcome = await switchBillType(page, value, prefix);
       const label = prefix === BONUS_PREFIX ? `bonus codes (${prefix})` : `3rd party (${prefix})`;
 
+      check(`${label} actually navigates on selection`,
+        outcome.navigated && outcome.carriesSelectedType,
+        `navigated=${outcome.navigated} carriesType=${outcome.carriesSelectedType} url=${outcome.url}`);
       // The fix itself: the self-navigation must carry the region forward.
       check(`${label} keeps billRegion=ON on its navigation`,
-        /[?&]billRegion=ON(&|$)/.test(outcome.url),
-        `url was ${outcome.url}`);
-
+        /[?&]billRegion=ON(&|$)/.test(outcome.url), `url was ${outcome.url}`);
       // What the user saw when it did not: a 500, or the BC form.
-      check(`${label} stays on the Ontario bill form`,
-        outcome.isOntarioForm && !outcome.mentionsBcTable,
-        `ontarioForm=${outcome.isOntarioForm} bcTable=${outcome.mentionsBcTable} url=${outcome.url}`);
+      check(`${label} stays on the Ontario bill form`, outcome.isOntarioForm,
+        `codes=${JSON.stringify(outcome.codes)} url=${outcome.url}`);
       check(`${label} does not render an error page`,
         !outcome.hasErrorPage && (outcome.documentStatus === null || outcome.documentStatus < 400),
         `status=${outcome.documentStatus} errorPage=${outcome.hasErrorPage}`);
@@ -236,21 +289,31 @@ async function run() {
 
     // The sibling fix: Ontario unbilled "Bill" links are context-path prefixed
     // (they used to resolve at the host root and 404) and carry the region.
-    for (const report of ['./billing/CA/ON/ViewBillingONNewReport', './billing/CA/ON/ViewBillingReportControl']) {
-      await page.goto(report, { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => null);
-      const billLinks = await page.locator('a[href*="/billing?"]')
-        .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('href')).filter(Boolean));
-      const entryLinks = billLinks.filter((href) => /billForm=/.test(href));
-      if (entryLinks.length === 0) {
-        console.log(`SKIP ${report} exposes no unbilled "Bill" link on this dataset`);
+    // reportAction=unbilled is what populates the rows; without it the
+    // assembler returns an empty model and the report renders nothing.
+    const reportParams = new URLSearchParams({ reportAction: 'unbilled', providerview: providerNo });
+    for (const report of ['/billing/CA/ON/ViewBillingONNewReport', '/billing/CA/ON/ViewBillingReportControl']) {
+      const path = `${report}?${reportParams.toString()}`;
+      let loaded = true;
+      try {
+        await gotoApp(page, baseUrl, path);
+      } catch (error) {
+        loaded = false;
+      }
+      check(`${report} loads its unbilled report`, loaded, 'navigation failed');
+      if (!loaded) continue;
+
+      const links = await unbilledBillLinks(page);
+      if (links.length === 0) {
+        console.log(`SKIP ${report} produced no unbilled "Bill" link for provider ${providerNo}`);
         continue;
       }
       check(`${report} "Bill" links are context-path prefixed`,
-        entryLinks.every((href) => href.startsWith(`${contextPath}/billing?`) || /^https?:\/\//.test(href)),
-        `hrefs: ${JSON.stringify(entryLinks.slice(0, 3))}`);
+        links.every((href) => href.startsWith(`${contextPath}/billing?`)),
+        `hrefs: ${JSON.stringify(links.slice(0, 3))}`);
       check(`${report} "Bill" links carry billRegion=ON`,
-        entryLinks.every((href) => /[?&]billRegion=ON(&|$)/.test(href)),
-        `hrefs: ${JSON.stringify(entryLinks.slice(0, 3))}`);
+        links.every((href) => /[?&]billRegion=ON(&|$)/.test(href)),
+        `hrefs: ${JSON.stringify(links.slice(0, 3))}`);
     }
   } finally {
     await browser.close();
@@ -260,8 +323,9 @@ async function run() {
 run()
   .catch((error) => check('script completed without error', false, error.message))
   .finally(() => {
-    fs.mkdirSync(screenshotDir, { recursive: true });
-    fs.writeFileSync(buildArtifactPath(screenshotDir, 'results', '.json'), JSON.stringify(results, null, 2));
+    // buildArtifactPath validates the directory (restricted to /tmp or the
+    // workspace) and creates it; no unvalidated mkdir here.
+    fs.writeFileSync(buildArtifactPath(artifactDir, 'results', '.json'), JSON.stringify(results, null, 2));
     const failed = results.filter((result) => !result.ok);
     console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
     process.exit(failed.length ? 1 : 0);

--- a/scripts/billing-on-third-party-playwright-checks.js
+++ b/scripts/billing-on-third-party-playwright-checks.js
@@ -144,11 +144,47 @@ function billEntryPath() {
   return `/billing?${params.toString()}`;
 }
 
+/*
+ * Identifiers that correlate back to a patient or a provider stay out of console
+ * output and the results file. A routing failure needs billRegion, xml_billtype
+ * and curBillForm; appointment_no, demographic_no/name, providerview and user_no
+ * add nothing to the diagnosis, so the query string is filtered to the former.
+ */
+const DIAGNOSTIC_PARAMS = new Set(['billRegion', 'xml_billtype', 'curBillForm', 'billForm', 'reportAction']);
+
+function queryParam(rawUrl, name) {
+  try {
+    return new URL(rawUrl, baseUrl).searchParams.get(name);
+  } catch (error) {
+    return null;
+  }
+}
+
+function redactUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl, baseUrl);
+  } catch (error) {
+    return '(unparseable url)';
+  }
+  const kept = new URLSearchParams();
+  for (const [key, value] of parsed.searchParams) {
+    if (DIAGNOSTIC_PARAMS.has(key)) kept.set(key, value);
+  }
+  const query = kept.toString();
+  const dropped = [...parsed.searchParams.keys()].some((key) => !DIAGNOSTIC_PARAMS.has(key));
+  return `${parsed.pathname}${query ? `?${query}` : ''}${dropped ? ' (identifiers redacted)' : ''}`;
+}
+
 async function login(page) {
   await gotoApp(page, baseUrl, '/');
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
-  await page.locator('#pin').fill(testPin);
+  // login/index.jsp renders #pin only when MfaManager.isOscarLegacyPinEnabled().
+  // Filling it unconditionally throws on an install with legacy PIN disabled,
+  // and the check would never run there.
+  const pin = page.locator('#pin');
+  if ((await pin.count()) > 0) await pin.fill(testPin);
   await page.locator('input[type="submit"], button[type="submit"]').first().click();
   await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
 }
@@ -201,7 +237,9 @@ async function switchBillType(page, optionValue, expectedCode) {
   return {
     documentStatus,
     navigated: navigated && described.url !== entryUrl,
-    carriesSelectedType: new RegExp(`[?&]xml_billtype=${expectedCode}(&|$)`).test(described.url),
+    // Parsed, not pattern-matched: building a RegExp from the code would be a
+    // dynamic expression for no gain (and Semgrep flags it as a ReDoS shape).
+    carriesSelectedType: queryParam(described.url, 'xml_billtype') === expectedCode,
     ...described,
   };
 }
@@ -256,7 +294,7 @@ async function run() {
     await gotoApp(page, baseUrl, billEntryPath());
     const entry = await describeBillPage(page);
     check('the Ontario bill form opens for the configured appointment', entry.isOntarioForm,
-      `codes=${JSON.stringify(entry.codes)} at ${entry.url}; set BILLING_APPOINTMENT_NO/BILLING_DEMOGRAPHIC_NO to a billable appointment`);
+      `codes=${JSON.stringify(entry.codes)} at ${redactUrl(entry.url)}; set BILLING_APPOINTMENT_NO/BILLING_DEMOGRAPHIC_NO to a billable appointment`);
     if (!entry.isOntarioForm) return;
 
     const options = await page.locator('select[name="xml_billtype"] option')
@@ -265,9 +303,14 @@ async function run() {
       .map((prefix) => ({ prefix, value: options.find((value) => value.startsWith(prefix)) }))
       .filter((option) => Boolean(option.value));
 
-    check('the bill-type control offers 3rd-party and bonus-code types',
-      wanted.some((o) => THIRD_PARTY_PREFIXES.includes(o.prefix)) && wanted.some((o) => o.prefix === BONUS_PREFIX),
-      `offered: ${JSON.stringify(options)}`);
+    // Every expected code must be present. A `some()` here would let a code
+    // disappear (OCF, STD...) while the check still passed and the loop below
+    // silently stopped covering that branch.
+    const expected = [...THIRD_PARTY_PREFIXES, BONUS_PREFIX];
+    const missing = expected.filter((prefix) => !wanted.some((o) => o.prefix === prefix));
+    check('the bill-type control offers every 3rd-party and bonus-code type',
+      missing.length === 0,
+      `missing: ${JSON.stringify(missing)}; offered: ${JSON.stringify(options)}`);
 
     for (const { prefix, value } of wanted) {
       const outcome = await switchBillType(page, value, prefix);
@@ -275,13 +318,13 @@ async function run() {
 
       check(`${label} actually navigates on selection`,
         outcome.navigated && outcome.carriesSelectedType,
-        `navigated=${outcome.navigated} carriesType=${outcome.carriesSelectedType} url=${outcome.url}`);
+        `navigated=${outcome.navigated} carriesType=${outcome.carriesSelectedType} url=${redactUrl(outcome.url)}`);
       // The fix itself: the self-navigation must carry the region forward.
       check(`${label} keeps billRegion=ON on its navigation`,
-        /[?&]billRegion=ON(&|$)/.test(outcome.url), `url was ${outcome.url}`);
+        queryParam(outcome.url, 'billRegion') === 'ON', `url was ${redactUrl(outcome.url)}`);
       // What the user saw when it did not: a 500, or the BC form.
       check(`${label} stays on the Ontario bill form`, outcome.isOntarioForm,
-        `codes=${JSON.stringify(outcome.codes)} url=${outcome.url}`);
+        `codes=${JSON.stringify(outcome.codes)} url=${redactUrl(outcome.url)}`);
       check(`${label} does not render an error page`,
         !outcome.hasErrorPage && (outcome.documentStatus === null || outcome.documentStatus < 400),
         `status=${outcome.documentStatus} errorPage=${outcome.hasErrorPage}`);
@@ -294,26 +337,31 @@ async function run() {
     const reportParams = new URLSearchParams({ reportAction: 'unbilled', providerview: providerNo });
     for (const report of ['/billing/CA/ON/ViewBillingONNewReport', '/billing/CA/ON/ViewBillingReportControl']) {
       const path = `${report}?${reportParams.toString()}`;
-      let loaded = true;
+      // An unreachable route or an error page must fail, not fall through to
+      // the empty-list branch and be reported as a dataset skip.
+      let status = null;
       try {
-        await gotoApp(page, baseUrl, path);
+        const response = await gotoApp(page, baseUrl, path);
+        status = response ? response.status() : null;
       } catch (error) {
-        loaded = false;
+        status = null;
       }
-      check(`${report} loads its unbilled report`, loaded, 'navigation failed');
+      const loaded = status !== null && status < 400;
+      check(`${report} loads its unbilled report`, loaded, `status=${status === null ? 'no response' : status}`);
       if (!loaded) continue;
 
       const links = await unbilledBillLinks(page);
       if (links.length === 0) {
-        console.log(`SKIP ${report} produced no unbilled "Bill" link for provider ${providerNo}`);
+        console.log(`SKIP ${report} produced no unbilled "Bill" link on this dataset`);
         continue;
       }
+      const redacted = links.slice(0, 3).map(redactUrl);
       check(`${report} "Bill" links are context-path prefixed`,
         links.every((href) => href.startsWith(`${contextPath}/billing?`)),
-        `hrefs: ${JSON.stringify(links.slice(0, 3))}`);
+        `hrefs: ${JSON.stringify(redacted)}`);
       check(`${report} "Bill" links carry billRegion=ON`,
-        links.every((href) => /[?&]billRegion=ON(&|$)/.test(href)),
-        `hrefs: ${JSON.stringify(links.slice(0, 3))}`);
+        links.every((href) => queryParam(href, 'billRegion') === 'ON'),
+        `hrefs: ${JSON.stringify(redacted)}`);
     }
   } finally {
     await browser.close();

--- a/scripts/billing-on-third-party-playwright-checks.js
+++ b/scripts/billing-on-third-party-playwright-checks.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+/*
+ * Browser check for the Ontario 3rd-Party / Bonus-Codes bill-entry path.
+ *
+ * An alpha tester on 2026.08.0-alpha10 hit "CARLOS Error: 500" when switching
+ * the bill type on the Ontario bill form. billingON.jsp rebuilt its own
+ * navigation query string WITHOUT billRegion, and Billing2Action's fall-back
+ * read a holder nothing populated, so the router answered "BC" and handed an
+ * Ontario request to billingBC.jsp -- which queries the BC-only billingvisit
+ * table. The bill entry was lost with the 500. The same release also prefixed
+ * the Ontario unbilled "Bill" links with the context path (they 404'd at the
+ * host root) and put billRegion=ON on them.
+ *
+ * Why the region assertion and not just "no 500": the fall-back is a property,
+ * `billregion`, and an install that HAS it set (the packaged Ontario install
+ * does) still routes correctly with the query parameter missing. Asserting only
+ * the status code would therefore pass on a re-broken page. This check asserts
+ * the thing the fix actually pins -- billRegion travelling on every self
+ * navigation -- and treats the rendered Ontario form and the absence of an
+ * error page as the user-visible corroboration.
+ *
+ * READ-ONLY: it switches the bill type and reads links. It never submits a
+ * bill, so it seeds nothing and has nothing to clean up.
+ *
+ * Defaults are for the local devcontainer:
+ *   npm run test:billing-on-third-party-playwright
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc TEST_PASSWORD=carlos2026 TEST_PIN=2026
+ *   Record pointers into the demo dataset (an appointment that can be billed):
+ *     BILLING_APPOINTMENT_NO=11 BILLING_DEMOGRAPHIC_NO=1 BILLING_PROVIDER_NO=999998
+ *     BILLING_APPOINTMENT_DATE=2024-04-16 BILLING_START_TIME=12:00:00
+ *   BILLING_ON_SCREENSHOT_DIR=/tmp/carlos-billing-on-playwright
+ *   ALLOW_NON_LOCAL_BASE_URL=true for any target that is not loopback
+ */
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+const { buildArtifactPath } = require('./eform-local-playwright-utils');
+
+/*
+ * Hosts this script will browse without an explicit opt-in. It logs in as an
+ * administrator, so anything that is not plainly this machine or its compose
+ * network has to be opted into.
+ */
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'db', 'carlos']);
+const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
+
+function normalizeHost(rawHost) {
+  return rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+function isLocalHost(rawHost) {
+  return LOCAL_HOSTS.has(normalizeHost(rawHost));
+}
+
+function isExactLocalHost(rawHost) {
+  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
+}
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+  // Credentials in the URL would travel into navigations and can surface in
+  // failure logging, so reject them outright.
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not contain embedded credentials');
+  }
+  if (!isLocalHost(parsed.hostname) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  // This script logs in with real credentials, so anything that is not plainly
+  // loopback has to prove its certificate.
+  if (!isExactLocalHost(parsed.hostname) && parsed.protocol !== 'https:') {
+    throw new Error(`Non-loopback BASE_URL host ${parsed.hostname} must use https`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed.toString().replace(/\/$/, '');
+}
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const contextPath = new URL(baseUrl).pathname || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+const screenshotDir = process.env.BILLING_ON_SCREENSHOT_DIR || '/tmp/carlos-billing-on-playwright';
+
+const appointmentNo = process.env.BILLING_APPOINTMENT_NO || '11';
+const demographicNo = process.env.BILLING_DEMOGRAPHIC_NO || '1';
+const providerNo = process.env.BILLING_PROVIDER_NO || '999998';
+const appointmentDate = process.env.BILLING_APPOINTMENT_DATE || '2024-04-16';
+const startTime = process.env.BILLING_START_TIME || '12:00:00';
+
+/*
+ * The bill types whose onChangePrivate() branch rebuilds the URL — these are
+ * exactly the ones that lost billRegion. PAT/OCF/ODS/CPP/STD route through
+ * curBillForm=PRI ("3rd party"), BON through the primary-care-incentive view
+ * ("Bonus Codes").
+ */
+const THIRD_PARTY_PREFIXES = ['PAT', 'OCF', 'ODS', 'CPP', 'STD'];
+const BONUS_PREFIX = 'BON';
+
+const results = [];
+
+function check(name, ok, detail) {
+  results.push({ name, ok: Boolean(ok), detail: detail || '' });
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${ok || !detail ? '' : `: ${detail}`}`);
+}
+
+function billEntryUrl() {
+  const params = new URLSearchParams({
+    billRegion: 'ON',
+    hotclick: '',
+    appointment_no: appointmentNo,
+    demographic_no: demographicNo,
+    apptProvider_no: providerNo,
+    providerview: providerNo,
+    appointment_date: appointmentDate,
+    status: 't',
+    start_time: startTime,
+    bNewForm: '1',
+  });
+  return `./billing?${params.toString()}`;
+}
+
+async function login(page) {
+  await page.goto('./', { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await page.locator('input[type="submit"], button[type="submit"]').first().click();
+  await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
+}
+
+/* The Ontario bill form is identified by its own bill-type control; billingBC.jsp
+   has no xml_billtype select, which is precisely how the misroute showed up. */
+async function describeBillPage(page) {
+  const body = await page.content();
+  return {
+    url: page.url(),
+    isOntarioForm: (await page.locator('select[name="xml_billtype"]').count()) > 0,
+    hasErrorPage: /CARLOS Error/i.test(body),
+    mentionsBcTable: /billingvisit/i.test(body),
+  };
+}
+
+async function switchBillType(page, optionValue) {
+  await page.goto(billEntryUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  const select = page.locator('select[name="xml_billtype"]');
+  await select.waitFor({ state: 'attached', timeout: 60000 });
+
+  let documentStatus = null;
+  const onResponse = (response) => {
+    if (response.request().resourceType() === 'document') documentStatus = response.status();
+  };
+  page.on('response', onResponse);
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => null),
+    select.selectOption(optionValue),
+  ]);
+  page.off('response', onResponse);
+
+  return { documentStatus, ...(await describeBillPage(page)) };
+}
+
+async function run() {
+  const browser = await chromium.launch({
+    executablePath: process.env.CHROME_PATH || undefined,
+    args: ['--no-sandbox'],
+  });
+  const context = await browser.newContext({ ignoreHTTPSErrors: true, baseURL: `${baseUrl}/` });
+  const page = await context.newPage();
+
+  try {
+    await login(page);
+
+    await page.goto(billEntryUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    const entry = await describeBillPage(page);
+    check('the Ontario bill form opens for the configured appointment', entry.isOntarioForm,
+      `not the Ontario form at ${entry.url}; set BILLING_APPOINTMENT_NO/BILLING_DEMOGRAPHIC_NO to a billable appointment`);
+    if (!entry.isOntarioForm) return;
+
+    const options = await page.locator('select[name="xml_billtype"] option')
+      .evaluateAll((nodes) => nodes.map((node) => node.value));
+
+    const wanted = [...THIRD_PARTY_PREFIXES, BONUS_PREFIX]
+      .map((prefix) => ({ prefix, value: options.find((value) => value.startsWith(prefix)) }))
+      .filter((entryOption) => Boolean(entryOption.value));
+
+    check('the bill-type control offers 3rd-party and bonus-code types',
+      wanted.some((o) => THIRD_PARTY_PREFIXES.includes(o.prefix)) && wanted.some((o) => o.prefix === BONUS_PREFIX),
+      `offered: ${JSON.stringify(options)}`);
+
+    for (const { prefix, value } of wanted) {
+      const outcome = await switchBillType(page, value);
+      const label = prefix === BONUS_PREFIX ? `bonus codes (${prefix})` : `3rd party (${prefix})`;
+
+      // The fix itself: the self-navigation must carry the region forward.
+      check(`${label} keeps billRegion=ON on its navigation`,
+        /[?&]billRegion=ON(&|$)/.test(outcome.url),
+        `url was ${outcome.url}`);
+
+      // What the user saw when it did not: a 500, or the BC form.
+      check(`${label} stays on the Ontario bill form`,
+        outcome.isOntarioForm && !outcome.mentionsBcTable,
+        `ontarioForm=${outcome.isOntarioForm} bcTable=${outcome.mentionsBcTable} url=${outcome.url}`);
+      check(`${label} does not render an error page`,
+        !outcome.hasErrorPage && (outcome.documentStatus === null || outcome.documentStatus < 400),
+        `status=${outcome.documentStatus} errorPage=${outcome.hasErrorPage}`);
+    }
+
+    // The sibling fix: Ontario unbilled "Bill" links are context-path prefixed
+    // (they used to resolve at the host root and 404) and carry the region.
+    for (const report of ['./billing/CA/ON/ViewBillingONNewReport', './billing/CA/ON/ViewBillingReportControl']) {
+      await page.goto(report, { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => null);
+      const billLinks = await page.locator('a[href*="/billing?"]')
+        .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('href')).filter(Boolean));
+      const entryLinks = billLinks.filter((href) => /billForm=/.test(href));
+      if (entryLinks.length === 0) {
+        console.log(`SKIP ${report} exposes no unbilled "Bill" link on this dataset`);
+        continue;
+      }
+      check(`${report} "Bill" links are context-path prefixed`,
+        entryLinks.every((href) => href.startsWith(`${contextPath}/billing?`) || /^https?:\/\//.test(href)),
+        `hrefs: ${JSON.stringify(entryLinks.slice(0, 3))}`);
+      check(`${report} "Bill" links carry billRegion=ON`,
+        entryLinks.every((href) => /[?&]billRegion=ON(&|$)/.test(href)),
+        `hrefs: ${JSON.stringify(entryLinks.slice(0, 3))}`);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+run()
+  .catch((error) => check('script completed without error', false, error.message))
+  .finally(() => {
+    fs.mkdirSync(screenshotDir, { recursive: true });
+    fs.writeFileSync(buildArtifactPath(screenshotDir, 'results', '.json'), JSON.stringify(results, null, 2));
+    const failed = results.filter((result) => !result.ok);
+    console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+    process.exit(failed.length ? 1 : 0);
+  });


### PR DESCRIPTION
## Description

#3588 fixed several "CARLOS Error: 500" failures on the Ontario bill workflow but shipped no browser coverage for the path a biller actually drives. This adds that coverage.

The routing defect: `billingON.jsp` rebuilt its own navigation query string without `billRegion`, so `Billing2Action` fell back to a holder nothing populated, answered "BC", and handed the request to `billingBC.jsp` — which queries the BC-only `billingvisit` table. The bill entry was lost along with the 500.

The check logs in, opens the Ontario bill form for a demo appointment, and switches the bill type through every option whose `onChangePrivate()` branch rebuilds the URL: `PAT`/`OCF`/`ODS`/`CPP`/`STD` (3rd party) and `BON` (bonus codes). Per type it asserts:

- `billRegion=ON` survives the self-navigation,
- the Ontario form is still the page served (`billingBC.jsp` has no `xml_billtype` control, which is exactly how the misroute presented),
- no error page renders.

It also asserts the Ontario unbilled "Bill" links are context-path prefixed and carry the region — the sibling fix in the same PR — skipping cleanly when the dataset exposes none.

**Why the region assertion is the load-bearing one.** The fall-back is the `billregion` property, and an install that has it set — the packaged Ontario install does — still routes correctly with the parameter missing. A status-only assertion would therefore pass on a re-broken page.

The check is **read-only**: it never submits a bill, so it seeds nothing and has nothing to clean up.

## Related Issues

Related to #3588 (adds the browser regression coverage for that fix). No issue is closed by this PR.

## Target Branch

Targets `release/2026.08` because it guards a fix that lives on that line and is intended to ship with the same release. It is test-only — a new `scripts/` check, its `package.json` entry, and runbook notes — so it carries no application change and leaves the branch's version and SCM metadata untouched (`2026.08.0-alpha11-SNAPSHOT` / `HEAD`).

## How Was This Tested?

Verified **both directions** against a packaged Ubuntu 26.04 `.deb` install (published `2026.08.0~alpha10` upgraded to a locally built `2026.08.0~alpha11`, nginx + ModSecurity front door, MariaDB, Ontario demo dataset):

```bash
npm run test:billing-on-third-party-playwright
```

| State of the deployed `billingON.jsp` | Result |
| --- | --- |
| As shipped (fix present) | **20/20 checks passed** |
| `billRegion=ON` token reverted out of `__commonQs` | **14/20** — exactly the six region assertions fail |

While reverted, the status and Ontario-form assertions still passed, because this install has `billregion` set and the property fall-back masked the misroute. That is precisely the masking the region assertion exists to defeat, and it is why the check does not rely on the status code alone. The JSP was restored and the suite re-run to 20/20 afterwards.

The two unbilled-"Bill"-link assertions report `SKIP` on this dataset, which exposes no unbilled items — they skip rather than record a false pass.

Not covered here: bill review (the `ServiceCodeLoader` null-description NPE). The demo dataset carries the 11 null-description Ontario `billingservice` rows but no `billing` rows, so reviewing one would mean seeding a bill and turning this into a write-with-cleanup check. That path keeps its `ServiceCodeLoaderUnitTest` coverage.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhEotcrscmDa2ztS3kzKs3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhEotcrscmDa2ztS3kzKs3)_

## Summary by Sourcery

Add browser regression coverage for Ontario bill-entry navigation across third-party and bonus-code bill types.

New Features:
- Add a read-only Playwright browser check covering Ontario third-party and bonus-code bill-type navigation.

Enhancements:
- Verify Ontario bill navigation preserves the region and remains on the correct form without rendering errors.
- Validate Ontario unbilled Bill links include the deployment context path and Ontario region, while skipping cleanly when no links exist.

Documentation:
- Document the billing browser-check configuration and required demo appointment environment variables in the Debian install validation runbook.

Tests:
- Add a package script for running the Ontario billing Playwright regression check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds browser regression coverage for the Ontario 3rd-party/bonus-codes bill entry fix from #3588, guarding the routing defect that dropped `billRegion` and misrouted Ontario requests to the BC form.

- Asserts `billRegion=ON` survives each navigation, the switch actually navigated with the selected type, the Ontario form is still served, and no error page renders.
- The region assertion is load-bearing: the fallback is the `billregion` property, so a status-only assertion would pass on a re-broken page.
- Form identity uses the Ontario bill-type codes (`ODP`/`BON`) because `billingBC.jsp` carries its own `xml_billtype` control.
- Requires every expected bill-type code to be present, so a disappearing one fails instead of silently dropping coverage.
- Asserts Ontario unbilled "Bill" links are context-path prefixed and carry the region; erroring report routes fail outright rather than masquerading as a dataset skip.
- Read-only: never submits a bill, so it seeds nothing and has nothing to clean up. TLS verification is only relaxed for loopback hosts.
- The PIN fill is conditional on the field being present, so the check runs even with legacy PIN disabled.
- Failure diagnostics redact PHI-correlating identifiers, keeping only routing parameters.
- Verified against a packaged Ubuntu .deb install: 30/30 pass with the fix; reverting `billRegion=ON` from the deployed JSP drops to 24/30 with exactly the six region assertions failing.
- Bill review (the `ServiceCodeLoader` null-description NPE) is not covered because the demo dataset has no `billing` rows; that path keeps its `ServiceCodeLoaderUnitTest` coverage.

<sup>Written for commit 60281b114a1dfd8b00015f1ca52ff62baba1f5a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

