### PR TITLE
fix(rx): bind the faxed prescription to its record — identity, dose lines, notes, header; fax by POST only

### DIFF
--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -302,6 +302,16 @@ export RX_FAX_PROVIDER_NO=999998 RX_FAX_DEMOGRAPHIC_NO=1
 # "<pom version> (carlos-emr-deb <debian/changelog version>)", e.g.
 #   export RX_EXPECTED_BUILD_TAG='2026.08.0-alpha11-SNAPSHOT (carlos-emr-deb 2026.09.0~snapshot18)'
 # Leave it unset when validating a WAR you did not build through the packaging.
+# Rx fax record-binding check (rx-fax-record-binding-playwright-checks.js). Pins the three
+# guarantees of PR #3606: a forged patient identity on the fax POST never reaches the faxed PDF
+# (the prescription's own demographic does), a standalone one-character direction line survives,
+# and a note typed immediately before Fax is on the fax (the save is deliberately delayed so the
+# race is deterministic). Same prerequisites and the same seed-then-delete fixtures as the two Rx
+# checks above; it asserts on the PDF the servlet writes, so it must be able to READ DOCUMENT_DIR
+# -- run it as root on the VM, and point RX_FAX_DOCUMENT_DIR at the install's DOCUMENT_DIR as this
+# process sees it. It leaves two prescription_<pdfId>.pdf files there per run (one from the Fax
+# button, one from the forged POST) plus their fax-spool pairs; nothing from a PDF is printed.
+export RX_FAX_DOCUMENT_DIR=/var/lib/carlos-emr/CarlosDocument/carlos/document
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -302,11 +302,12 @@ export RX_FAX_PROVIDER_NO=999998 RX_FAX_DEMOGRAPHIC_NO=1
 # "<pom version> (carlos-emr-deb <debian/changelog version>)", e.g.
 #   export RX_EXPECTED_BUILD_TAG='2026.08.0-alpha11-SNAPSHOT (carlos-emr-deb 2026.09.0~snapshot18)'
 # Leave it unset when validating a WAR you did not build through the packaging.
-# Rx fax record-binding check (rx-fax-record-binding-playwright-checks.js). Pins the three
+# Rx fax record-binding check (rx-fax-record-binding-playwright-checks.js). Pins the four
 # guarantees of PR #3606: a forged patient identity on the fax POST never reaches the faxed PDF
 # (the prescription's own demographic does), a standalone one-character direction line survives,
-# and a note typed immediately before Fax is on the fax (the save is deliberately delayed so the
-# race is deterministic). Same prerequisites and the same seed-then-delete fixtures as the two Rx
+# a note typed immediately before Fax is on the fax (the save is deliberately delayed so the race
+# is deterministic), and the clinic header renders its name, address and city on separate lines
+# rather than glued with the letter n. Same prerequisites and the same seed-then-delete fixtures as the two Rx
 # checks above; it asserts on the PDF the servlet writes, so it must be able to READ DOCUMENT_DIR
 # -- run it as root on the VM, and point RX_FAX_DOCUMENT_DIR at the install's DOCUMENT_DIR as this
 # process sees it. It leaves two prescription_<pdfId>.pdf files there per run (one from the Fax

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -306,8 +306,8 @@ export RX_FAX_PROVIDER_NO=999998 RX_FAX_DEMOGRAPHIC_NO=1
 # guarantees of PR #3606: a forged patient identity on the fax POST never reaches the faxed PDF
 # (the prescription's own demographic does), a standalone one-character direction line survives,
 # a note typed immediately before Fax is on the fax (the save is deliberately delayed so the race
-# is deterministic), and the clinic header renders its name, address and city on separate lines
-# rather than glued with the letter n. Same prerequisites and the same seed-then-delete fixtures as the two Rx
+# is deterministic), and the clinic header is submitted as separate lines with the clinic name
+# rendered as its own line (the glued-letter-n defect collapsed it to one line). Same prerequisites and the same seed-then-delete fixtures as the two Rx
 # checks above; it asserts on the PDF the servlet writes, so it must be able to READ DOCUMENT_DIR
 # -- run it as root on the VM, and point RX_FAX_DOCUMENT_DIR at the install's DOCUMENT_DIR as this
 # process sees it. It leaves two prescription_<pdfId>.pdf files there per run (one from the Fax

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -322,7 +322,10 @@ export RX_FAX_ROUND_TRIP_TIMEOUT_MS=180000
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below
-  timeout 300 node "$s" && echo "PASS $s" || echo "FAIL $s"
+  # The record-binding check waits up to RX_FAX_ROUND_TRIP_TIMEOUT_MS twice on a cold server and
+  # must still reach its fixture cleanup; a SIGTERM from the wrapper would skip that.
+  t=300; case "$s" in *rx-fax-record-binding*) t=900 ;; esac
+  timeout "$t" node "$s" && echo "PASS $s" || echo "FAIL $s"
 done
 ```
 

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -324,7 +324,7 @@ for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below
   # The record-binding check waits up to RX_FAX_ROUND_TRIP_TIMEOUT_MS twice on a cold server and
   # must still reach its fixture cleanup; a SIGTERM from the wrapper would skip that.
-  t=300; case "$s" in *rx-fax-record-binding*) t=900 ;; esac
+  t=300; case "$s" in *rx-fax-record-binding*) t=$((2 * ${RX_FAX_ROUND_TRIP_TIMEOUT_MS:-45000} / 1000 + 300)) ;; esac
   timeout "$t" node "$s" && echo "PASS $s" || echo "FAIL $s"
 done
 ```

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -307,8 +307,9 @@ export RX_FAX_PROVIDER_NO=999998 RX_FAX_DEMOGRAPHIC_NO=1
 # (the prescription's own demographic does), a standalone one-character direction line survives,
 # a note typed immediately before Fax is on the fax (the save is deliberately delayed so the race
 # is deterministic), and the clinic header is submitted as separate lines with the clinic name
-# rendered as its own line (the glued-letter-n defect collapsed it to one line). Same prerequisites and the same seed-then-delete fixtures as the two Rx
-# checks above; it asserts on the PDF the servlet writes, so it must be able to READ DOCUMENT_DIR
+# rendered as its own line (the glued-letter-n defect collapsed it to one line). Same
+# prerequisites and the same seed-then-delete fixtures as the two Rx checks above; it asserts on
+# the PDF the servlet writes, so it must be able to READ DOCUMENT_DIR
 # -- run it as root on the VM, and point RX_FAX_DOCUMENT_DIR at the install's DOCUMENT_DIR as this
 # process sees it. It leaves two prescription_<pdfId>.pdf files there per run (one from the Fax
 # button, one from the forged POST) plus their fax-spool pairs; nothing from a PDF is printed.

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -302,9 +302,10 @@ export RX_FAX_PROVIDER_NO=999998 RX_FAX_DEMOGRAPHIC_NO=1
 # "<pom version> (carlos-emr-deb <debian/changelog version>)", e.g.
 #   export RX_EXPECTED_BUILD_TAG='2026.08.0-alpha11-SNAPSHOT (carlos-emr-deb 2026.09.0~snapshot18)'
 # Leave it unset when validating a WAR you did not build through the packaging.
-# Rx fax record-binding check (rx-fax-record-binding-playwright-checks.js). Pins the four
-# guarantees of PR #3606: a forged patient identity on the fax POST never reaches the faxed PDF
-# (the prescription's own demographic does), a standalone one-character direction line survives,
+# Rx fax record-binding check (rx-fax-record-binding-playwright-checks.js). Pins the
+# guarantees of PR #3606: a forged patient identity, prescription date, clinic block, reprint
+# annotation or satellite-clinic block on the fax POST never reaches the faxed PDF (the
+# prescription record's own values do), a standalone one-character direction line survives,
 # a note typed immediately before Fax is on the fax (the save is deliberately delayed so the race
 # is deterministic), and the clinic header is submitted as separate lines with the clinic name
 # rendered as its own line (the glued-letter-n defect collapsed it to one line). Same
@@ -314,6 +315,10 @@ export RX_FAX_PROVIDER_NO=999998 RX_FAX_DEMOGRAPHIC_NO=1
 # process sees it. It leaves two prescription_<pdfId>.pdf files there per run (one from the Fax
 # button, one from the forged POST) plus their fax-spool pairs; nothing from a PDF is printed.
 export RX_FAX_DOCUMENT_DIR=/var/lib/carlos-emr/CarlosDocument/carlos/document
+# Straight after `carlos-ctl restart`, Tomcat compiles the Rx JSPs on first hit and one Fax
+# click can take longer than the check's default 45 s round-trip allowance; raise it for a
+# cold server rather than reading the timeout as a fax failure.
+export RX_FAX_ROUND_TRIP_TIMEOUT_MS=180000
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:consultation-signature-submit-playwright": "node scripts/consultation-signature-submit-playwright-checks.js",
     "test:prescription-signature-playwright": "node scripts/prescription-signature-playwright-checks.js",
     "test:rx-fax-signature-stamp-playwright": "node scripts/rx-fax-signature-stamp-playwright-checks.js",
+    "test:rx-fax-record-binding-playwright": "node scripts/rx-fax-record-binding-playwright-checks.js",
     "test:rx-fax-reprint-represcribe-playwright": "node scripts/rx-fax-reprint-represcribe-playwright-checks.js",
     "test:report-demographic-navigation-playwright": "node scripts/report-demographic-navigation-playwright-checks.js",
     "test:flowsheet-admin-playwright": "node scripts/flowsheet-admin-playwright-checks.js",

--- a/scripts/assign-role-playwright-checks.js
+++ b/scripts/assign-role-playwright-checks.js
@@ -244,7 +244,10 @@ async function login(page) {
   await page.goto('./', { waitUntil: 'domcontentloaded', timeout: 60000 });
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
-  await page.locator('#pin').fill(testPin);
+  // login/index.jsp renders #pin only when MfaManager.isOscarLegacyPinEnabled(); filling it
+  // unconditionally throws on an install with the legacy PIN disabled and the check never runs.
+  const pin = page.locator('#pin');
+  if ((await pin.count()) > 0) await pin.fill(testPin);
   await page.locator('input[type="submit"], button[type="submit"]').first().click();
   await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
 }

--- a/scripts/echart-new-patient-notes-playwright-checks.js
+++ b/scripts/echart-new-patient-notes-playwright-checks.js
@@ -105,6 +105,8 @@ function initMysqlDefaults() {
   try {
     // Option-file values are quoted: an unquoted password ending at a '#' or containing a space
     // is silently truncated by the mysql client and the check fails as an access denial.
+    // A line break would end the option and start another; quoting cannot neutralize it.
+    if (/[\r\n]/.test(mysqlPassword)) throw new Error('MYSQL_PASSWORD must not contain a newline');
     const quoted = `"${mysqlPassword.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
     fs.writeFileSync(file, `[client]\npassword=${quoted}\n`, { mode: 0o600 });
   } catch (error) {

--- a/scripts/echart-new-patient-notes-playwright-checks.js
+++ b/scripts/echart-new-patient-notes-playwright-checks.js
@@ -103,7 +103,10 @@ function initMysqlDefaults() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'echart-new-patient-'));
   const file = path.join(dir, 'mysql-defaults.cnf');
   try {
-    fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+    // Option-file values are quoted: an unquoted password ending at a '#' or containing a space
+    // is silently truncated by the mysql client and the check fails as an access denial.
+    const quoted = `"${mysqlPassword.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    fs.writeFileSync(file, `[client]\npassword=${quoted}\n`, { mode: 0o600 });
   } catch (error) {
     // Never leave a half-written file holding the database password behind.
     fs.rmSync(dir, { recursive: true, force: true });

--- a/scripts/echart-playwright-checks.js
+++ b/scripts/echart-playwright-checks.js
@@ -141,7 +141,10 @@ async function loginAndOpenSearch(context) {
   await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded' }); // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- appUrl rejects non-root-relative paths and validateBaseUrl restricts hosts to local/private by default
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
-  await page.locator('#pin').fill(testPin);
+  // login/index.jsp renders #pin only when MfaManager.isOscarLegacyPinEnabled(); filling it
+  // unconditionally throws on an install with the legacy PIN disabled and the check never runs.
+  const pin = page.locator('#pin');
+  if ((await pin.count()) > 0) await pin.fill(testPin);
   await Promise.all([
     page.waitForURL(/providercontrol/, { timeout: 30000 }),
     page.locator('input[type="submit"], button[type="submit"]').first().click(),

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -96,6 +96,10 @@ const notesSaveDelayMs = Number(process.env.RX_FAX_NOTES_SAVE_DELAY_MS || '2500'
 // default is generous for a warm server; a freshly restarted Tomcat compiling the Rx JSPs on
 // first hit can need more, so the deb-install runbook raises it rather than lowering the bar.
 const faxRoundTripTimeoutMs = Number(process.env.RX_FAX_ROUND_TRIP_TIMEOUT_MS || '45000');
+// Playwright reads NaN and 0 as "no timeout", so a malformed value would make the fax waits unbounded.
+if (!Number.isInteger(faxRoundTripTimeoutMs) || faxRoundTripTimeoutMs < 1000 || faxRoundTripTimeoutMs > 600000) {
+  throw new Error('RX_FAX_ROUND_TRIP_TIMEOUT_MS must be an integer between 1000 and 600000');
+}
 const artifactDir = process.env.ARTIFACT_DIR || '/tmp/carlos-playwright-artifacts';
 const documentDir = validateDocumentDir(process.env.RX_FAX_DOCUMENT_DIR);
 
@@ -655,15 +659,18 @@ function assertHeaderBound(runs) {
       findings.push({ label: 'header', type: 'forged-value-rendered', field, text: `the faxed PDF rendered the request's ${field}, not the record's` });
     }
   }
-  // The record's date is the fixture prescription's rx_date, written today, in the page's own
-  // "MMMM d, yyyy" shape; the date cell is one PDF phrase, so it is one text run.
-  const today = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-  const dateBound = runs.some((r) => r.trim() === today);
+  // The record's date is the fixture drug's stored rx_date in the page's own "MMMM d, yyyy" shape,
+  // read back from the database (not this process's clock, which may sit in another time zone or
+  // on the other side of midnight from Tomcat); the date cell is one PDF phrase, so one text run.
+  const recordDate = sql(`SELECT DATE_FORMAT(MAX(rx_date), '%M %e, %Y') FROM drugs WHERE customName='${customDrugName}' AND demographic_no=${demographicNo};`).trim();
+  const dateBound = recordDate.length > 0 && runs.some((r) => r.trim() === recordDate);
   // The record's clinic header is whatever the page itself posted for the UI fax (the page composes
   // it from the same record), so its first line must be a rendered line of the forged-request fax.
-  const recordClinicLine = ((submittedClinicHeader || '').split(/\r?\n/)[0] || '').trim();
+  // Not when the UI fax used a satellite clinic: that header was the satellite block, while the
+  // forged request's unoffered block correctly falls back to the main clinic.
+  const recordClinicLine = headerComposedByServlet ? '' : ((submittedClinicHeader || '').split(/\r?\n/)[0] || '').trim();
   const clinicBound = recordClinicLine.length > 0 && runs.map((r) => r.trim()).includes(recordClinicLine);
-  visited.push({ label: 'header', dateBound, clinicBound, recordClinicKnown: recordClinicLine.length > 0 });
+  visited.push({ label: 'header', dateBound, clinicBound, recordClinicKnown: recordClinicLine.length > 0, satelliteHeader: headerComposedByServlet });
   if (!dateBound) findings.push({ label: 'header', type: 'record-date-absent', text: 'the forged-request fax does not carry the prescription record\'s own date' });
   if (recordClinicLine.length > 0 && !clinicBound) findings.push({ label: 'header', type: 'record-clinic-absent', text: 'the forged-request fax does not carry the clinic header the page itself posted for the same prescription' });
 }

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -1,0 +1,666 @@
+#!/usr/bin/env node
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (C) 2026 CARLOS Contributors
+ *
+ * Rx stamp-signed fax: the document is the RECORD, not the request.
+ *
+ * Browser regression check for the three record-binding guarantees of the
+ * signed prescription fax (FrmCustomedPDFServlet.bindFaxContentToRecord and
+ * rx/ViewScript2.jsp, PR #3606). It drives the real UI to write and stamp-sign
+ * a prescription, faxes it the way a clinician does, and then reads the PDF the
+ * servlet wrote to DOCUMENT_DIR and asserts on the text actually rendered:
+ *
+ *   A. identity — an oscarRxFax POST carrying a FORGED patientName/HIN/DOB/
+ *      address/phone/chartNo for a signed script must fax the prescription's
+ *      own demographic, never the forged values. Without the fix the verified
+ *      drugs and the prescriber's stored signature went out under whatever
+ *      identity the request named.
+ *   B. one-character line — a standalone one-character line in a drug's
+ *      directions (a dose such as "1") must survive into the faxed PDF.
+ *      Without the fix splitRenderedRxBlocks treated any length-1 line as a
+ *      block separator and silently dropped it.
+ *   C. notes race — a note typed immediately before clicking Fax must appear
+ *      in the faxed PDF. The save is deliberately DELAYED here (route
+ *      interception) so the race is deterministic: without the fix the fax POST
+ *      won and rendered the stored (old) note; with it, the fax waits.
+ *
+ * B and C are observed on one UI-driven fax; A is a second, direct POST for the
+ * same signed script, made from inside the page so it carries the session and a
+ * real CSRFGuard token exactly as the browser's own submit does.
+ *
+ * The check reads the generated PDF from disk (the servlet's only durable
+ * output) with a small text-run extractor over the content streams; OpenPDF
+ * writes each rendered line as its own `(...) Tj`, so a rendered line is a run.
+ * Nothing from the PDF is printed: identity is reported as present/absent.
+ *
+ * Fixtures this run seeds and REMOVES (keyed on per-run-unique values, never a
+ * range, so a concurrent run's rows are never touched): one custom-drug
+ * prescription with its drug row and stamp signature, a fax_config account for
+ * the "from" line when no active SRFAX row exists on that number, the fax job
+ * rows on that line with their FaxClientLog audit rows, and the destination fax
+ * number seeded on the patient's active pharmacies (restored exactly, NULL vs
+ * '' preserved). Files are NOT removed: two small PDFs are left under
+ * DOCUMENT_DIR (prescription_<pdfId>.pdf) plus the pair each leaves in the fax
+ * spool, which the fax scheduler consumes.
+ *
+ * Prerequisites on the install (docs/ui-tests/deb-install-validation.md §6):
+ *   - rx_fax_enabled=true and rx_signature_enabled=true in carlos.properties,
+ *   - the session facility has digital signatures enabled (demo default),
+ *   - a provider stamp PNG consult_sig_<provider>.png in the eForm image dir,
+ *   - this process can READ the install's DOCUMENT_DIR.
+ *
+ * Env contract:
+ *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN,
+ *   MYSQL_HOST/USER/PASSWORD/DATABASE,
+ *   RX_FAX_DOCUMENT_DIR — the install's DOCUMENT_DIR as seen by this process
+ *                         (absolute; on a packaged install
+ *                         /var/lib/carlos-emr/CarlosDocument/carlos/document).
+ * Optional:
+ *   RX_FAX_DEMOGRAPHIC_NO (default 1), RX_FAX_PROVIDER_NO (default 999998),
+ *   RX_FAX_NOTES_SAVE_DELAY_MS (default 2500), CHROME_PATH, ARTIFACT_DIR,
+ *   ALLOW_NON_LOCAL_BASE_URL.
+ *
+ * Run: npm run test:rx-fax-record-binding-playwright
+ */
+
+const { chromium } = require('playwright');
+const { execFileSync } = require('child_process');
+const { randomInt } = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const zlib = require('zlib');
+const {
+  appUrl,
+  buildArtifactPath,
+  getLaunchOptions,
+  gotoApp,
+  validateBaseUrl,
+} = require('./eform-local-playwright-utils');
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+const demographicNo = String(process.env.RX_FAX_DEMOGRAPHIC_NO || '1').trim();
+const providerNo = String(process.env.RX_FAX_PROVIDER_NO || '999998').trim();
+const notesSaveDelayMs = Number(process.env.RX_FAX_NOTES_SAVE_DELAY_MS || '2500');
+const artifactDir = process.env.ARTIFACT_DIR || '/tmp/carlos-playwright-artifacts';
+const documentDir = validateDocumentDir(process.env.RX_FAX_DOCUMENT_DIR);
+
+const mysqlHost = validateMysqlHost(process.env.MYSQL_HOST || 'localhost');
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || '';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'carlos';
+
+if (!/^\d+$/.test(demographicNo)) throw new Error(`RX_FAX_DEMOGRAPHIC_NO must be numeric, got ${demographicNo}`);
+if (!/^\d+$/.test(providerNo)) throw new Error(`RX_FAX_PROVIDER_NO must be numeric, got ${providerNo}`);
+if (!Number.isInteger(notesSaveDelayMs) || notesSaveDelayMs < 0 || notesSaveDelayMs > 20000) {
+  throw new Error('RX_FAX_NOTES_SAVE_DELAY_MS must be an integer between 0 and 20000');
+}
+
+// Per-run identifiers, same rationale as rx-fax-signature-stamp-playwright-checks.js: the "from"
+// fax number must be exactly 10 chars (fax_config.faxNumber varchar(10), matched by equality), the
+// destination must be unroutable (NPA 555), and the drug name identifies THIS run's prescription.
+const runSuffix = String(randomInt(1000000, 10000000)); // 7 digits, crypto RNG
+const pharmacyFaxNumber = `555${runSuffix}`;
+const faxNumber = `416${runSuffix}`;
+const customDrugName = `PW FAX BIND ${Date.now()}${runSuffix}`;
+// Probes. Each is a string that cannot occur in a legitimate render of the demo data, so presence
+// or absence in the PDF is unambiguous. The one-character probe is a letter rather than a digit
+// because page and count fields legitimately render single digits.
+const probeLine = 'Z';
+const probeLineContext = `PW PROBE ${runSuffix}`;
+const noteText = `PW NOTE ${runSuffix}`;
+const forged = {
+  patientName: `ZQFORGEDNAME${runSuffix}`,
+  patientHIN: '9999999999',
+  patientDOB: 'Jan 1, 1900',
+  patientAddress: `999 FORGED AVE ${runSuffix}`,
+  patientCityPostal: 'FORGEDVILLE ZZ 0Z0 0Z0',
+  patientPhone: 'Tel: 4165559999',
+  patientChartNo: `FORGEDCHART${runSuffix}`,
+};
+
+const findings = [];
+const visited = [];
+let expectingCustomDrugConfirm = false;
+const mysqlBin = resolveMysqlBinary();
+const mysqlDefaultsFile = createMysqlDefaultsFile();
+
+// --- validation helpers -------------------------------------------------------
+
+function validateMysqlHost(host) {
+  if (!/^[A-Za-z0-9.\-:\[\]]+$/.test(host)) {
+    throw new Error('MYSQL_HOST contains unsupported characters');
+  }
+  return host;
+}
+
+function validateDocumentDir(rawDir) {
+  if (!rawDir || typeof rawDir !== 'string') {
+    throw new Error('RX_FAX_DOCUMENT_DIR is required: the install\'s DOCUMENT_DIR as seen by this process');
+  }
+  if (!path.isAbsolute(rawDir)) throw new Error('RX_FAX_DOCUMENT_DIR must be an absolute path');
+  const resolved = path.resolve(rawDir); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- operator-supplied read-only directory, checked to exist and be a directory; file names under it are built from a digits-validated pdfId
+  let stat;
+  try { stat = fs.statSync(resolved); } catch (error) { throw new Error('RX_FAX_DOCUMENT_DIR does not exist or is not readable'); }
+  if (!stat.isDirectory()) throw new Error('RX_FAX_DOCUMENT_DIR is not a directory');
+  return resolved;
+}
+
+function resolveMysqlBinary() {
+  for (const candidate of ['/usr/bin/mysql', '/usr/local/bin/mysql', '/usr/bin/mariadb', '/opt/homebrew/bin/mysql']) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error('mysql client not found (looked in /usr/bin, /usr/local/bin, /opt/homebrew/bin)');
+}
+
+function encodeOptionFileValue(value) {
+  // MySQL option files take double-quoted values with backslash escapes.
+  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function createMysqlDefaultsFile() {
+  for (const [name, value] of [['MYSQL_USER', mysqlUser], ['MYSQL_PASSWORD', mysqlPassword], ['MYSQL_HOST', mysqlHost]]) {
+    if (/[\r\n]/.test(value)) throw new Error(`${name} must not contain a newline`);
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rx-fax-bind-'));
+  const file = path.join(dir, 'mysql-defaults.cnf');
+  try {
+    fs.writeFileSync(file, `[client]\nuser=${encodeOptionFileValue(mysqlUser)}\npassword=${encodeOptionFileValue(mysqlPassword)}\nhost=${encodeOptionFileValue(mysqlHost)}\n`, { mode: 0o600 });
+  } catch (error) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (cleanupError) { /* best effort */ }
+    throw error;
+  }
+  return file;
+}
+
+function removeSecretsDir() {
+  try { fs.rmSync(path.dirname(mysqlDefaultsFile), { recursive: true, force: true }); } catch (error) { /* best effort */ }
+}
+
+function sql(query) {
+  try {
+    return execFileSync(
+      mysqlBin,
+      [`--defaults-extra-file=${mysqlDefaultsFile}`, '-N', '-B', mysqlDatabase, '-e', query],
+      { encoding: 'utf8', timeout: 30000 },
+    ).trim();
+  } catch (error) {
+    // Neither the query nor raw stderr may reach the log: queries carry demographic and script
+    // numbers and the client echoes the statement before its ERROR line.
+    const reason = (error && error.code === 'ETIMEDOUT') ? 'timed out' : 'failed';
+    throw new Error(`database query ${reason}`);
+  }
+}
+
+function safeUrl(rawUrl) {
+  try {
+    const u = new URL(rawUrl);
+    return `${u.pathname}${u.search ? ' (query redacted)' : ''}`;
+  } catch (error) {
+    return '(unparseable url)';
+  }
+}
+
+// --- PDF text runs --------------------------------------------------------------
+
+/**
+ * Every string shown by a `Tj` / `TJ` operator in every content stream of the PDF, in stream order.
+ * OpenPDF (the servlet's writer) positions each rendered line with `Tm` and shows it with one `Tj`,
+ * so one rendered line is one run. Handles FlateDecode streams and the ()-string escapes; that is
+ * all this writer emits. Not a general PDF text extractor and not meant to be one.
+ */
+function pdfTextRuns(buf) {
+  const runs = [];
+  const text = buf.toString('latin1');
+  const streamRe = /(<<(?:(?!<<)[\s\S]){0,400}?>>)\s*stream\r?\n/g;
+  let m;
+  while ((m = streamRe.exec(text))) {
+    const dict = m[1];
+    const start = m.index + m[0].length;
+    const end = text.indexOf('endstream', start);
+    if (end < 0) break;
+    let data = buf.subarray(start, end);
+    if (/FlateDecode/.test(dict)) {
+      let inflated = null;
+      // The stream may carry a trailing EOL before `endstream`; try the exact length first.
+      for (const cut of [0, 1, 2]) {
+        try { inflated = zlib.inflateSync(buf.subarray(start, end - cut)); break; } catch (error) { /* try shorter */ }
+      }
+      if (!inflated) continue;
+      data = inflated;
+    }
+    const content = data.toString('latin1');
+    if (!/\bT[jJ]\b/.test(content)) continue;
+    const opRe = /\((?:\\.|[^\\)])*\)\s*Tj|\[(?:\((?:\\.|[^\\)])*\)|[^\]])*\]\s*TJ/g;
+    let op;
+    while ((op = opRe.exec(content))) {
+      const parts = [];
+      const strRe = /\(((?:\\.|[^\\)])*)\)/g;
+      let s;
+      while ((s = strRe.exec(op[0]))) {
+        parts.push(s[1]
+          .replace(/\\([()\\])/g, '$1')
+          .replace(/\\(\d{1,3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8))));
+      }
+      runs.push(parts.join(''));
+    }
+  }
+  return runs;
+}
+
+/** The servlet's PDF for this pdfId, once it is fully written (exists, %PDF header, size stable). */
+async function waitForPdf(pdfId, label) {
+  if (!/^[A-Za-z0-9]{1,64}$/.test(pdfId)) {
+    throw new Error(`${label}: pdfId is not a plain identifier`);
+  }
+  const file = path.join(documentDir, `prescription_${pdfId}.pdf`); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- documentDir is a validated operator-supplied directory and pdfId is restricted to [A-Za-z0-9]
+  const deadline = Date.now() + 20000;
+  let lastSize = -1;
+  while (Date.now() < deadline) {
+    try {
+      const stat = fs.statSync(file);
+      if (stat.size > 0 && stat.size === lastSize) {
+        const buf = fs.readFileSync(file);
+        if (buf.subarray(0, 4).toString() === '%PDF') return buf;
+      }
+      lastSize = stat.size;
+    } catch (error) {
+      lastSize = -1;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`${label}: prescription_<pdfId>.pdf did not appear under RX_FAX_DOCUMENT_DIR within 20s`);
+}
+
+// --- fixtures ---------------------------------------------------------------------
+
+let faxConfig = null;
+const seededPharmacyFaxes = [];
+
+function stageFaxConfig() {
+  const existing = sql(`SELECT id FROM fax_config WHERE faxNumber='${faxNumber}' AND active=1 AND providerType='SRFAX' LIMIT 1;`).trim();
+  if (/^\d+$/.test(existing)) return { id: existing, created: false };
+  const id = sql(
+    `INSERT INTO fax_config (providerType, active, faxNumber, faxReply, accountName, senderEmail, faxUser, siteUser, passwd, faxPasswd, gatewayName, queue, url, download) `
+    + `VALUES ('SRFAX', 1, '${faxNumber}', '${faxNumber}', 'Playwright Fax', 'fax@example.ca', 'faxuser', 'siteuser', 'x', 'x', 'srfax', '0', '', 1); SELECT LAST_INSERT_ID();`,
+  ).trim();
+  return { id, created: true };
+}
+
+function seedPharmacyFax() {
+  // Same predicate and NULL/'' fidelity as the sibling stamp check; see its seedPharmacyFax().
+  const rows = sql(`SELECT p.recordId, IF(p.fax IS NULL, 1, 0), IFNULL(p.fax, '') FROM pharmacyInfo p
+    JOIN demographicPharmacy dp ON dp.pharmacyID = p.recordId
+    WHERE dp.demographic_no = ${demographicNo} AND dp.status = '1'
+      AND (p.status IS NULL OR p.status <> '0');`)
+    .split('\n').map((r) => r.split('\t')).filter((r) => /^\d+$/.test((r[0] || '').trim()));
+  for (const [rawId, rawWasNull, rawFax] of rows) {
+    const recordId = rawId.trim();
+    if ((rawFax || '').trim()) continue;
+    sql(`UPDATE pharmacyInfo SET fax = '${pharmacyFaxNumber}' WHERE recordId = ${recordId};`);
+    seededPharmacyFaxes.push({ recordId, wasNull: String(rawWasNull).trim() === '1' });
+  }
+  visited.push({ label: 'pharmacy-fax', seeded: seededPharmacyFaxes.length, active: rows.length });
+  if (!rows.length) {
+    findings.push({ label: 'pharmacy-fax', type: 'no-active-pharmacy', text: `patient ${demographicNo} has no active pharmacy, so a prescription for them can never be faxed` });
+  }
+}
+
+function cleanupFixtures() {
+  const attempt = (label, fn) => {
+    try { fn(); } catch (error) {
+      findings.push({ label: 'cleanup', type: 'cleanup-error', text: `${label}: ${(error && error.message) || 'failed'}` });
+    }
+  };
+  let ourScriptNos = [];
+  attempt('list fixture scripts', () => {
+    ourScriptNos = sql(`SELECT DISTINCT script_no FROM drugs WHERE customName='${customDrugName}' AND demographic_no=${demographicNo};`)
+      .split('\n').map((r) => r.trim()).filter((r) => /^\d+$/.test(r));
+  });
+  for (const scriptNo of ourScriptNos) {
+    attempt(`prescription ${scriptNo}`, () => {
+      const sigId = sql(`SELECT COALESCE(digital_signature_id,'') FROM prescription WHERE script_no=${scriptNo};`).trim();
+      sql(`DELETE FROM drugs WHERE script_no=${scriptNo};`);
+      sql(`DELETE FROM prescription WHERE script_no=${scriptNo};`);
+      if (/^\d+$/.test(sigId)) sql(`DELETE FROM DigitalSignature WHERE id=${sigId};`);
+    });
+  }
+  attempt('faxes', () => {
+    const faxIds = sql(`SELECT id FROM faxes WHERE faxline='${faxNumber}';`)
+      .split('\n').map((r) => r.trim()).filter((r) => /^\d+$/.test(r));
+    if (faxIds.length) {
+      sql(`DELETE FROM FaxClientLog WHERE transactionType='RX' AND faxId IN (${faxIds.map((id) => `'${id}'`).join(',')});`);
+    }
+    sql(`DELETE FROM faxes WHERE faxline='${faxNumber}';`);
+  });
+  attempt('fax_config', () => {
+    if (faxConfig && faxConfig.created) sql(`DELETE FROM fax_config WHERE id=${faxConfig.id};`);
+  });
+  while (seededPharmacyFaxes.length) {
+    const { recordId, wasNull } = seededPharmacyFaxes.pop();
+    attempt(`pharmacy-fax ${recordId}`, () => sql(
+      `UPDATE pharmacyInfo SET fax = ${wasNull ? 'NULL' : "''"} WHERE recordId = ${recordId} AND fax = '${pharmacyFaxNumber}';`));
+  }
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => { cleanupFixtures(); removeSecretsDir(); process.exit(130); });
+}
+
+// --- browser plumbing -------------------------------------------------------------
+
+function wirePage(page, label) {
+  page.on('pageerror', (error) => {
+    const text = error.stack || error.message || '';
+    // Pre-existing, tracked by issue #3578 (expandPreview writes into the preview iframe before it
+    // has parsed on some render orders). Named so the suppression stays auditable.
+    if (/Cannot set properties of null \(setting 'innerHTML'\)/.test(text) && /expandPreview/.test(text)) return;
+    findings.push({ label, type: 'pageerror', text: text.slice(0, 300) });
+  });
+  page.on('dialog', async (dialog) => {
+    // Accept only the custom-drug confirm(), and only while clicking that button. Anything else is a
+    // blocking finding: the check must not pass while a dialog is dismissed unseen.
+    if (dialog.type() === 'confirm' && expectingCustomDrugConfirm) {
+      await dialog.accept().catch(() => {});
+      return;
+    }
+    findings.push({ label, type: 'unexpected-dialog', text: `${dialog.type()}: ${dialog.message()}`.slice(0, 200) });
+    await dialog.dismiss().catch(() => dialog.accept().catch(() => {}));
+  });
+}
+
+async function login(context) {
+  const page = await context.newPage();
+  wirePage(page, 'login');
+  await gotoApp(page, baseUrl, '/');
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  // login/index.jsp renders #pin only when the legacy PIN is enabled.
+  if (await page.locator('#pin').count()) {
+    await page.locator('#pin').fill(testPin);
+  }
+  await Promise.all([
+    page.waitForURL(/providercontrol|appointment/i, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  visited.push({ label: 'login', url: safeUrl(page.url()) });
+  return page;
+}
+
+/** A CSRFGuard master token for this session, read the way the page's own script does. */
+async function csrfToken(page) {
+  return page.evaluate(async (tokenUrl) => {
+    const resp = await fetch(tokenUrl, { credentials: 'same-origin' });
+    const js = await resp.text();
+    const m = js.match(/masterTokenValue\s*=\s*["']([^"']+)["']/);
+    return m ? m[1] : '';
+  }, appUrl(baseUrl, '/csrfguard'));
+}
+
+// --- the journey ------------------------------------------------------------------
+
+async function writeCustomRxThroughUi(page) {
+  await gotoApp(page, baseUrl, `/rx/choosePatient?demographicNo=${demographicNo}`);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  visited.push({ label: 'rx-search', url: safeUrl(page.url()) });
+
+  const rangeStart = Number(sql(`SELECT COALESCE(MAX(script_no),0) FROM prescription WHERE provider_no='${providerNo}' AND demographic_no=${demographicNo};`) || '0');
+
+  await page.locator('#searchString').waitFor({ state: 'visible', timeout: 30000 });
+  await page.locator('#searchString').fill(customDrugName);
+  expectingCustomDrugConfirm = true;
+  try {
+    await page.locator('#customDrug').click();
+  } finally {
+    expectingCustomDrugConfirm = false;
+  }
+  await page.locator("[id^='drugName_'], [id^='quantity_']").first().waitFor({ state: 'attached', timeout: 30000 });
+
+  // "Save And Print": writes and stamp-signs the script and opens ViewScript2 in the modal.
+  await page.locator('#saveButton').click();
+  const modalFrame = page.frameLocator('#carlosModalBody iframe');
+  await modalFrame.locator('#faxButton').waitFor({ state: 'attached', timeout: 30000 });
+
+  const created = sql(`SELECT DISTINCT script_no FROM drugs WHERE customName='${customDrugName}' AND demographic_no=${demographicNo} AND script_no>${rangeStart};`)
+    .split('\n').map((r) => r.trim()).filter((r) => /^\d+$/.test(r));
+  if (!created.length) throw new Error('No new prescription row was created for the fixture custom drug');
+  const scriptId = String(Math.max(...created.map(Number)));
+  return { modalFrame, scriptId };
+}
+
+/**
+ * Put the one-character probe into the RECORD's directions. The fax body is rebuilt from
+ * drugs.special (recordBlock), so this is exactly the data path under test; the preview on screen
+ * still shows the pre-probe text, which is also exactly the mismatch the servlet resolves in favour
+ * of the record.
+ */
+function addProbeLineToRecord(scriptId) {
+  sql(`UPDATE drugs SET special = CONCAT(IFNULL(special,''), '\\n${probeLine}\\n${probeLineContext}') WHERE script_no=${scriptId} AND customName='${customDrugName}';`);
+  const check = sql(`SELECT COUNT(*) FROM drugs WHERE script_no=${scriptId} AND customName='${customDrugName}' AND special LIKE '%${probeLineContext}%';`).trim();
+  if (check !== '1') throw new Error('probe line was not written to the fixture drug row');
+}
+
+async function faxThroughUi(page, modalFrame, scriptId) {
+  // Deterministic race: hold the notes save so the fax POST can only carry the note if the page
+  // waited for it. The route covers the modal iframe's requests too.
+  let saveRequested = false;
+  await page.route(/\/rx\/ViewAddRxComment/, async (route) => {
+    saveRequested = true;
+    await new Promise((resolve) => setTimeout(resolve, notesSaveDelayMs));
+    await route.continue();
+  });
+
+  await modalFrame.locator('#additionalNotes').waitFor({ state: 'visible', timeout: 30000 });
+  await modalFrame.locator('#additionalNotes').fill(noteText);
+
+  const faxRequestPromise = page.waitForRequest((req) => /form\/createcustomedpdf/.test(req.url()) && /__method=oscarRxFax/.test(req.url()), { timeout: 45000 });
+  const faxResponsePromise = page.waitForResponse((res) => /form\/createcustomedpdf/.test(res.url()) && /__method=oscarRxFax/.test(res.url()), { timeout: 45000 });
+  // The click moves focus off the textarea, firing its onchange (addNotes -> delayed save) before
+  // the click handler faxes: the same order a clinician's click produces.
+  await modalFrame.locator('#faxButton').click();
+
+  let pdfId = null;
+  let status = 0;
+  let body = '';
+  try {
+    const request = await faxRequestPromise;
+    const response = await faxResponsePromise;
+    status = response.status();
+    body = await response.text().catch(() => '');
+    const post = new URLSearchParams(request.postData() || '');
+    pdfId = post.get('pdfId');
+    if (post.get('scriptId') !== scriptId && new URL(request.url()).searchParams.get('scriptId') !== scriptId) {
+      findings.push({ label: 'ui-fax', type: 'wrong-script', text: 'the Fax button posted a different scriptId than the prescription just written' });
+    }
+  } catch (error) {
+    findings.push({ label: 'ui-fax', type: 'no-request', text: `Fax click produced no createcustomedpdf round trip: ${error.message}` });
+  } finally {
+    await page.unroute(/\/rx\/ViewAddRxComment/).catch(() => {});
+  }
+  visited.push({ label: 'ui-fax', status, saveRequested, hadPdfId: Boolean(pdfId) });
+
+  if (!saveRequested) {
+    // Without a save request the race cannot be observed; say so distinctly rather than let the
+    // note assertion below read as the race failing.
+    findings.push({ label: 'notes-race', type: 'save-not-triggered', text: 'clicking Fax did not fire the Additional Notes save (textarea onchange); the race could not be exercised' });
+  }
+  if (status < 200 || status >= 300) {
+    findings.push({ label: 'ui-fax', type: 'http-error', status, text: `signed fax returned HTTP ${status}` });
+  } else if (/not signed/i.test(body)) {
+    findings.push({ label: 'ui-fax', type: 'signed-refused', text: 'the freshly stamp-signed prescription was refused as unsigned' });
+  } else if (!/fax-success/i.test(body)) {
+    findings.push({ label: 'ui-fax', type: 'not-successful', text: `fax did not report fax-success: ${body.replace(/\s+/g, ' ').slice(0, 160)}` });
+  }
+  return pdfId;
+}
+
+async function faxWithForgedIdentity(page, scriptId) {
+  const token = await csrfToken(page);
+  if (!token) findings.push({ label: 'forged-fax', type: 'no-csrf-token', text: 'could not obtain a CSRFGuard token for the forged-identity POST' });
+  const pdfId = `pwbind${runSuffix}`;
+  const result = await page.evaluate(async ({ postUrl, token: t, params }) => {
+    const resp = await fetch(postUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest',
+        'CSRF-TOKEN': t,
+      },
+      credentials: 'same-origin',
+      body: new URLSearchParams(params).toString(),
+    });
+    const body = await resp.text().catch(() => '');
+    return { status: resp.status, body: body.slice(0, 400) };
+  }, {
+    postUrl: appUrl(baseUrl, '/form/createcustomedpdf'),
+    token,
+    params: {
+      __title: 'Rx',
+      __method: 'oscarRxFax',
+      scriptId,
+      pdfId,
+      pharmaFax: pharmacyFaxNumber,
+      clinicFax: faxNumber,
+      pharmaName: 'Playwright Pharmacy',
+      demographic_no: demographicNo,
+      rxPageSize: 'PageSize.Letter',
+      rx: 'ignored: the servlet faxes the record',
+      rxDate: 'January 1, 2026',
+      sigDoctorName: 'Dr Forged',
+      showPatientDOB: 'true',
+      ...forged,
+    },
+  });
+  visited.push({ label: 'forged-fax', status: result.status });
+  if (result.status < 200 || result.status >= 300) {
+    findings.push({ label: 'forged-fax', type: 'http-error', status: result.status, text: `forged-identity fax returned HTTP ${result.status}` });
+    return null;
+  }
+  if (/csrf|token/i.test(result.body) && /reject|forbidden|invalid/i.test(result.body)) {
+    findings.push({ label: 'forged-fax', type: 'csrf-rejected', text: 'forged-identity POST was rejected by CSRF, so the binding was not exercised' });
+    return null;
+  }
+  if (!/fax-success/i.test(result.body)) {
+    findings.push({ label: 'forged-fax', type: 'not-successful', text: `forged-identity fax did not report fax-success: ${result.body.replace(/\s+/g, ' ').slice(0, 160)}` });
+    return null;
+  }
+  return pdfId;
+}
+
+// --- assertions on the rendered PDFs ---------------------------------------------
+
+function recordIdentity() {
+  const row = sql(`SELECT IFNULL(first_name,''), IFNULL(last_name,''), IFNULL(hin,'') FROM demographic WHERE demographic_no=${demographicNo};`).split('\t');
+  const first = (row[0] || '').trim();
+  const last = (row[1] || '').trim();
+  return { name: `${first} ${last}`.trim(), hin: (row[2] || '').trim() };
+}
+
+function assertIdentityBound(runs, identity) {
+  const joined = runs.join('\n');
+  for (const [field, value] of Object.entries(forged)) {
+    // The forged phone carries the "Tel: " prefix the page adds; match on the number.
+    const needle = field === 'patientPhone' ? '4165559999' : value;
+    if (joined.includes(needle)) {
+      findings.push({ label: 'identity', type: 'forged-value-rendered', field, text: `the faxed PDF rendered the request's ${field}, not the record's` });
+    }
+  }
+  const nameBound = identity.name.length > 0 && runs.includes(identity.name);
+  const hinBound = identity.hin.length === 0 || runs.some((r) => r.endsWith(identity.hin));
+  visited.push({ label: 'identity', nameBound, hinBound, recordHasHin: identity.hin.length > 0 });
+  if (!nameBound) findings.push({ label: 'identity', type: 'record-name-absent', text: 'the faxed PDF does not carry the prescription demographic\'s name as its own line' });
+  if (!hinBound) findings.push({ label: 'identity', type: 'record-hin-absent', text: 'the faxed PDF does not carry the prescription demographic\'s health number' });
+}
+
+function assertProbeLine(runs) {
+  const contextPresent = runs.some((r) => r.includes(probeLineContext));
+  const probePresent = runs.includes(probeLine);
+  visited.push({ label: 'one-char-line', contextPresent, probePresent });
+  if (!contextPresent) {
+    findings.push({ label: 'one-char-line', type: 'context-absent', text: 'the record directions written for this run did not reach the faxed PDF at all (the fax body did not come from the record)' });
+  } else if (!probePresent) {
+    findings.push({ label: 'one-char-line', type: 'dropped', text: 'the standalone one-character direction line was dropped from the faxed PDF' });
+  }
+}
+
+function assertNoteRendered(runs) {
+  const present = runs.some((r) => r.includes(noteText));
+  visited.push({ label: 'notes-race', notePresent: present });
+  if (!present) {
+    findings.push({ label: 'notes-race', type: 'note-omitted', text: `a note typed immediately before Fax (save delayed ${notesSaveDelayMs} ms) is absent from the faxed PDF` });
+  }
+}
+
+async function runChecks(context) {
+  const page = await login(context);
+  try {
+    faxConfig = stageFaxConfig();
+    seedPharmacyFax();
+
+    const { modalFrame, scriptId } = await writeCustomRxThroughUi(page);
+    visited.push({ label: 'prescription', created: true });
+    addProbeLineToRecord(scriptId);
+
+    // B + C on one real click.
+    const uiPdfId = await faxThroughUi(page, modalFrame, scriptId);
+    if (uiPdfId) {
+      const runs = pdfTextRuns(await waitForPdf(uiPdfId, 'ui-fax'));
+      visited.push({ label: 'ui-fax-pdf', runs: runs.length });
+      if (!runs.length) findings.push({ label: 'ui-fax', type: 'no-text', text: 'the faxed PDF has no text runs' });
+      assertProbeLine(runs);
+      assertNoteRendered(runs);
+    }
+
+    // A: the same signed script, posted with a forged identity.
+    const forgedPdfId = await faxWithForgedIdentity(page, scriptId);
+    if (forgedPdfId) {
+      const runs = pdfTextRuns(await waitForPdf(forgedPdfId, 'forged-fax'));
+      visited.push({ label: 'forged-fax-pdf', runs: runs.length });
+      if (!runs.length) findings.push({ label: 'forged-fax', type: 'no-text', text: 'the forged-identity fax PDF has no text runs' });
+      assertIdentityBound(runs, recordIdentity());
+    }
+  } finally {
+    cleanupFixtures();
+    await page.close().catch(() => {});
+  }
+}
+
+(async () => {
+  const browser = await chromium.launch(getLaunchOptions(process.env.CHROME_PATH || ''));
+  let exitCode = 0;
+  try {
+    const host = baseUrl.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    const isLoopback = ['localhost', '127.0.0.1', '::1', '0:0:0:0:0:0:0:1'].includes(host);
+    const context = await browser.newContext({ ignoreHTTPSErrors: isLoopback && baseUrl.protocol === 'https:' });
+    await runChecks(context);
+    await context.close();
+  } catch (error) {
+    findings.push({ label: 'run', type: 'exception', text: (error && error.message) || String(error) });
+  } finally {
+    await browser.close().catch(() => {});
+    removeSecretsDir();
+  }
+
+  const summary = { baseUrl: `${baseUrl.origin}${baseUrl.pathname}`, visited, findings };
+  try {
+    const out = buildArtifactPath(artifactDir, 'rx-fax-record-binding', '.json');
+    fs.writeFileSync(out, JSON.stringify(summary, null, 2));
+    console.log(`artifact: ${out}`);
+  } catch (error) {
+    console.log(`artifact not written: ${(error && error.message) || 'unknown error'}`);
+  }
+  console.log(JSON.stringify({ visited }, null, 2));
+  if (findings.length) {
+    exitCode = 1;
+    console.error(`FAIL: ${findings.length} finding(s)`);
+    for (const f of findings) console.error(` - [${f.label}] ${f.type}: ${f.text || ''}`);
+  } else {
+    console.log('PASS: identity, one-character line and notes are all bound to the prescription record');
+  }
+  process.exit(exitCode);
+})();

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -24,8 +24,13 @@
  *      in the faxed PDF. The save is deliberately DELAYED here (route
  *      interception) so the race is deterministic: without the fix the fax POST
  *      won and rendered the stored (old) note; with it, the fax waits.
+ *   D. clinic header — the clinic name must render on its own line. Preview2.jsp
+ *      joined the header's lines with <br> and converted them for the PDF with a
+ *      replaceAll whose replacement, after JSP attribute unescaping, was an
+ *      escaped literal 'n': every line break became the letter n and the header
+ *      rendered glued ("ClinicnAddressnCity") on every faxed prescription.
  *
- * B and C are observed on one UI-driven fax; A is a second, direct POST for the
+ * B, C and D are observed on one UI-driven fax; A is a second, direct POST for the
  * same signed script, made from inside the page so it carries the session and a
  * real CSRFGuard token exactly as the browser's own submit does.
  *
@@ -242,9 +247,19 @@ function pdfTextRuns(buf) {
       const strRe = /\(((?:\\.|[^\\)])*)\)/g;
       let s;
       while ((s = strRe.exec(op[0]))) {
-        parts.push(s[1]
-          .replace(/\\([()\\])/g, '$1')
-          .replace(/\\(\d{1,3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8))));
+        // PDF literal-string escapes (ISO 32000 7.3.4.2): \n \r \t \b \f, the three delimiters,
+        // and \ddd octal. Decoding them here keeps a run's text equal to what was rendered.
+        parts.push(s[1].replace(/\\(\d{1,3}|[nrtbf()\\])/g, (_, esc) => {
+          switch (esc) {
+            case 'n': return '\n';
+            case 'r': return '\r';
+            case 't': return '\t';
+            case 'b': return '\b';
+            case 'f': return '\f';
+            case '(': case ')': case '\\': return esc;
+            default: return String.fromCharCode(parseInt(esc, 8));
+          }
+        }));
       }
       runs.push(parts.join(''));
     }
@@ -588,6 +603,37 @@ function assertProbeLine(runs) {
   }
 }
 
+/**
+ * The clinic name exactly as rx/Preview2.jsp puts it at the top of the prescriber header: the
+ * single clinic row's name with a trailing "(nnnnnn)" site code removed. Empty when the install has
+ * no clinic row, in which case the header assertion is skipped and says so.
+ */
+function expectedClinicName() {
+  const raw = sql('SELECT IFNULL(clinic_name, \'\') FROM clinic ORDER BY clinic_no LIMIT 1;').trim();
+  return raw.replace(/\(\d{6}\)/g, '').trim();
+}
+
+function assertClinicHeader(runs) {
+  const clinicName = expectedClinicName();
+  if (!clinicName) {
+    visited.push({ label: 'clinic-header', skipped: 'no clinic row' });
+    return;
+  }
+  const trimmed = runs.map((r) => r.trim());
+  const ownLine = trimmed.includes(clinicName);
+  // The defect's signature: the name is there but the address is glued onto the same rendered line.
+  const glued = trimmed.some((r) => r.startsWith(clinicName) && r.length > clinicName.length);
+  visited.push({ label: 'clinic-header', ownLine, glued });
+  if (ownLine) return;
+  if (glued) {
+    findings.push({ label: 'clinic-header', type: 'lines-glued', text: 'the faxed clinic header renders the clinic name and its address on one glued line (the <br> to line-break conversion lost the break)' });
+  } else {
+    // Not this defect. A specialist-address (useSC) fax composes the header server-side; on the
+    // demo install the header is the clinic's, so its absence is still worth a look.
+    findings.push({ label: 'clinic-header', type: 'absent', text: 'the faxed PDF has no line carrying the clinic name at all' });
+  }
+}
+
 function assertNoteRendered(runs) {
   const present = runs.some((r) => r.includes(noteText));
   visited.push({ label: 'notes-race', notePresent: present });
@@ -614,6 +660,7 @@ async function runChecks(context) {
       if (!runs.length) findings.push({ label: 'ui-fax', type: 'no-text', text: 'the faxed PDF has no text runs' });
       assertProbeLine(runs);
       assertNoteRendered(runs);
+      assertClinicHeader(runs);
     }
 
     // A: the same signed script, posted with a forged identity.
@@ -660,7 +707,7 @@ async function runChecks(context) {
     console.error(`FAIL: ${findings.length} finding(s)`);
     for (const f of findings) console.error(` - [${f.label}] ${f.type}: ${f.text || ''}`);
   } else {
-    console.log('PASS: identity, one-character line and notes are all bound to the prescription record');
+    console.log('PASS: identity, one-character line and notes are bound to the prescription record; the clinic header renders on its own lines');
   }
   process.exit(exitCode);
 })();

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -665,7 +665,13 @@ function assertHeaderBound(runs) {
   // The record's date is the fixture drug's stored rx_date in the page's own "MMMM d, yyyy" shape,
   // read back from the database (not this process's clock, which may sit in another time zone or
   // on the other side of midnight from Tomcat); the date cell is one PDF phrase, so one text run.
-  const recordDate = sql(`SELECT DATE_FORMAT(MAX(rx_date), '%M %e, %Y') FROM drugs WHERE customName='${customDrugName}' AND demographic_no=${demographicNo};`).trim();
+  // Numeric parts from SQL, English month name from the runner: DATE_FORMAT('%M') follows the
+  // server's lc_time_names, while the servlet's "MMMM d, yyyy" is always English.
+  const ymd = sql(`SELECT DATE_FORMAT(MAX(rx_date), '%Y-%m-%d') FROM drugs WHERE customName='${customDrugName}' AND demographic_no=${demographicNo};`).trim();
+  const ymdMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd);
+  const recordDate = ymdMatch
+    ? new Date(Number(ymdMatch[1]), Number(ymdMatch[2]) - 1, Number(ymdMatch[3])).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+    : '';
   const dateBound = recordDate.length > 0 && runs.some((r) => r.trim() === recordDate);
   // The record's clinic header is whatever the page itself posted for the UI fax (the page composes
   // it from the same record), so its first line must be a rendered line of the forged-request fax.

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -648,6 +648,9 @@ function recordIdentity() {
 function assertHeaderBound(runs) {
   const joined = runs.join('\n');
   const markers = {
+    // The outgoing fax line this run staged in fax_config: it selects the sending line and must
+    // never print as the clinic's call-back fax (the header carries the clinic's official number).
+    clinicFax: faxNumber,
     rxDate: forgedHeader.rxDate,
     clinicName: forgedHeader.clinicName.split('\n')[0],
     clinicPhone: forgedHeader.clinicPhone,

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -92,6 +92,10 @@ const testPin = process.env.TEST_PIN || '2026';
 const demographicNo = String(process.env.RX_FAX_DEMOGRAPHIC_NO || '1').trim();
 const providerNo = String(process.env.RX_FAX_PROVIDER_NO || '999998').trim();
 const notesSaveDelayMs = Number(process.env.RX_FAX_NOTES_SAVE_DELAY_MS || '2500');
+// How long one Fax click may take to produce its createcustomedpdf request and response. The
+// default is generous for a warm server; a freshly restarted Tomcat compiling the Rx JSPs on
+// first hit can need more, so the deb-install runbook raises it rather than lowering the bar.
+const faxRoundTripTimeoutMs = Number(process.env.RX_FAX_ROUND_TRIP_TIMEOUT_MS || '45000');
 const artifactDir = process.env.ARTIFACT_DIR || '/tmp/carlos-playwright-artifacts';
 const documentDir = validateDocumentDir(process.env.RX_FAX_DOCUMENT_DIR);
 
@@ -119,6 +123,19 @@ const customDrugName = `PW FAX BIND ${Date.now()}${runSuffix}`;
 const probeLine = 'Z';
 const probeLineContext = `PW PROBE ${runSuffix}`;
 const noteText = `PW NOTE ${runSuffix}`;
+// Header values with record sources the servlet must bind the same way: the prescription date,
+// the clinic block, the reprint annotation, and a satellite-clinic block (useSC/scAddress) the
+// provider was never offered. Distinct markers so a rendered one names the field that leaked.
+const forgedHeader = {
+  rxDate: 'January 1, 1900',
+  clinicName: `ZQFORGEDCLINIC${runSuffix}\n1 Forged Way\nForgedville   Z0Z 0Z0`,
+  clinicPhone: '4165550001',
+  rxReprint: 'true',
+  origPrintDate: `ZQFORGEDPRINT${runSuffix}`,
+  numPrints: '77',
+  useSC: 'true',
+  scAddress: `<b>Dr F</b><br>ZQFORGEDSAT${runSuffix}<br>2 Forged Rd<br>Forgedville, ZZ Z0Z 0Z0<br>Tel: 4165550002<br>Fax: 4165550003`,
+};
 const forged = {
   patientName: `ZQFORGEDNAME${runSuffix}`,
   patientHIN: '9999999999',
@@ -502,10 +519,15 @@ async function faxThroughUi(page, modalFrame, scriptId) {
   });
 
   await modalFrame.locator('#additionalNotes').waitFor({ state: 'visible', timeout: 30000 });
+  // The Fax button's handler writes into the preview iframe (finalFax, pdfId) before it submits the
+  // iframe's form, so a click that lands before ViewPreview2 has rendered throws inside the page and
+  // no request is ever made. A clinician cannot click that fast on a warm server; a headless run
+  // against a cold one can, so wait for the form the click needs.
+  await modalFrame.frameLocator('#preview').locator('#preview2Form').waitFor({ state: 'attached', timeout: faxRoundTripTimeoutMs });
   await modalFrame.locator('#additionalNotes').fill(noteText);
 
-  const faxRequestPromise = page.waitForRequest((req) => /form\/createcustomedpdf/.test(req.url()) && /__method=oscarRxFax/.test(req.url()), { timeout: 45000 });
-  const faxResponsePromise = page.waitForResponse((res) => /form\/createcustomedpdf/.test(res.url()) && /__method=oscarRxFax/.test(res.url()), { timeout: 45000 });
+  const faxRequestPromise = page.waitForRequest((req) => /form\/createcustomedpdf/.test(req.url()) && /__method=oscarRxFax/.test(req.url()), { timeout: faxRoundTripTimeoutMs });
+  const faxResponsePromise = page.waitForResponse((res) => /form\/createcustomedpdf/.test(res.url()) && /__method=oscarRxFax/.test(res.url()), { timeout: faxRoundTripTimeoutMs });
   // The click moves focus off the textarea, firing its onchange (addNotes -> delayed save) before
   // the click handler faxes: the same order a clinician's click produces.
   await modalFrame.locator('#faxButton').click();
@@ -514,8 +536,12 @@ async function faxThroughUi(page, modalFrame, scriptId) {
   let status = 0;
   let body = '';
   try {
-    const request = await faxRequestPromise;
-    const response = await faxResponsePromise;
+    // Await BOTH together. Awaiting them one after the other leaves the second promise with no
+    // handler while the first is pending; when the click produces no round trip at all, both time
+    // out at once and the un-awaited rejection is an unhandled rejection that kills the process --
+    // before the finally-block cleanup below has run, leaving the pharmacy fax numbers, the
+    // fax_config row and the fixture prescription in the database.
+    const [request, response] = await Promise.all([faxRequestPromise, faxResponsePromise]);
     status = response.status();
     body = await response.text().catch(() => '');
     const post = new URLSearchParams(request.postData() || '');
@@ -586,6 +612,7 @@ async function faxWithForgedIdentity(page, scriptId) {
       rxDate: 'January 1, 2026',
       sigDoctorName: 'Dr Forged',
       showPatientDOB: 'true',
+      ...forgedHeader,
       ...forged,
     },
   });
@@ -614,6 +641,32 @@ function recordIdentity() {
   return { name: `${first} ${last}`.trim(), hin: (row[2] || '').trim() };
 }
 
+function assertHeaderBound(runs) {
+  const joined = runs.join('\n');
+  const markers = {
+    rxDate: forgedHeader.rxDate,
+    clinicName: forgedHeader.clinicName.split('\n')[0],
+    clinicPhone: forgedHeader.clinicPhone,
+    origPrintDate: forgedHeader.origPrintDate,
+    scAddress: `ZQFORGEDSAT${runSuffix}`,
+  };
+  for (const [field, needle] of Object.entries(markers)) {
+    if (joined.includes(needle)) {
+      findings.push({ label: 'header', type: 'forged-value-rendered', field, text: `the faxed PDF rendered the request's ${field}, not the record's` });
+    }
+  }
+  // The record's date is the fixture prescription's rx_date, written today, in the page's own
+  // "MMMM d, yyyy" shape; the date cell is one PDF phrase, so it is one text run.
+  const today = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  const dateBound = runs.some((r) => r.trim() === today);
+  // The record's clinic header is whatever the page itself posted for the UI fax (the page composes
+  // it from the same record), so its first line must be a rendered line of the forged-request fax.
+  const recordClinicLine = ((submittedClinicHeader || '').split(/\r?\n/)[0] || '').trim();
+  const clinicBound = recordClinicLine.length > 0 && runs.map((r) => r.trim()).includes(recordClinicLine);
+  visited.push({ label: 'header', dateBound, clinicBound, recordClinicKnown: recordClinicLine.length > 0 });
+  if (!dateBound) findings.push({ label: 'header', type: 'record-date-absent', text: 'the forged-request fax does not carry the prescription record\'s own date' });
+  if (recordClinicLine.length > 0 && !clinicBound) findings.push({ label: 'header', type: 'record-clinic-absent', text: 'the forged-request fax does not carry the clinic header the page itself posted for the same prescription' });
+}
 function assertIdentityBound(runs, identity) {
   const joined = runs.join('\n');
   for (const [field, value] of Object.entries(forged)) {
@@ -646,9 +699,12 @@ function assertProbeLine(runs) {
  * clinic row's name with a trailing "(nnnnnn)" site code removed. Used only to tell the letter-n
  * defect apart from a legitimately single-line header (a program address is one line by design).
  */
-function clinicRowName() {
-  const raw = sql('SELECT IFNULL(clinic_name, \'\') FROM clinic ORDER BY clinic_no LIMIT 1;').trim();
-  return raw.replace(/\(\d{6}\)/g, '').trim();
+// Every clinic row's name (suffix "(nnnnnn)" stripped as the page strips it). ClinicDAO.getClinic()
+// takes the first row of an unordered query, so no single ORDER BY reproduces which row the page
+// used; any row's name being a proper prefix of the one-line header is enough to call it glued.
+function clinicRowNames() {
+  return sql('SELECT IFNULL(clinic_name, \'\') FROM clinic;').split('\n')
+    .map((raw) => raw.replace(/\(\d{6}\)/g, '').trim()).filter((name) => name.length > 0);
 }
 
 /**
@@ -677,8 +733,7 @@ function assertClinicHeader(runs) {
   const firstLine = lines[0] || '';
   const multiLine = lines.length >= 2;
   if (!multiLine) {
-    const clinicName = clinicRowName();
-    const glued = clinicName.length > 0 && firstLine.startsWith(clinicName) && firstLine.length > clinicName.length;
+    const glued = clinicRowNames().some((clinicName) => firstLine.startsWith(clinicName) && firstLine.length > clinicName.length);
     visited.push({ label: 'clinic-header', multiLine: false, glued });
     if (glued) {
       findings.push({ label: 'clinic-header', type: 'lines-glued', text: 'the page submitted the clinic header as a single line beginning with the clinic name: the <br> to line-break conversion lost the breaks (the letter-n defect)' });
@@ -729,6 +784,7 @@ async function runChecks(context) {
       visited.push({ label: 'forged-fax-pdf', runs: runs.length });
       if (!runs.length) findings.push({ label: 'forged-fax', type: 'no-text', text: 'the forged-identity fax PDF has no text runs' });
       assertIdentityBound(runs, recordIdentity());
+      assertHeaderBound(runs);
     }
   } finally {
     cleanupFixtures();
@@ -766,7 +822,7 @@ async function runChecks(context) {
     console.error(`FAIL: ${findings.length} finding(s)`);
     for (const f of findings) console.error(` - [${f.label}] ${f.type}: ${f.text || ''}`);
   } else {
-    console.log('PASS: identity, one-character line and notes are bound to the prescription record; the clinic header renders on its own lines');
+    console.log('PASS: identity, header (date, clinic, reprint), one-character line and notes are bound to the prescription record; the clinic header renders on its own lines');
   }
   process.exit(exitCode);
 })();

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -359,7 +359,7 @@ function seedPharmacyFax() {
   }
   visited.push({ label: 'pharmacy-fax', seeded: seededPharmacyFaxes.length, active: rows.length });
   if (!rows.length) {
-    findings.push({ label: 'pharmacy-fax', type: 'no-active-pharmacy', text: `patient ${demographicNo} has no active pharmacy, so a prescription for them can never be faxed` });
+    findings.push({ label: 'pharmacy-fax', type: 'no-active-pharmacy', text: 'the configured RX_FAX_DEMOGRAPHIC_NO patient has no active pharmacy, so a prescription for them can never be faxed' });
   }
 }
 

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -24,7 +24,8 @@
  *      in the faxed PDF. The save is deliberately DELAYED here (route
  *      interception) so the race is deterministic: without the fix the fax POST
  *      won and rendered the stored (old) note; with it, the fax waits.
- *   D. clinic header — the clinic name must render on its own line. Preview2.jsp
+ *   D. clinic header — the page must submit the header as separate lines and the
+ *      clinic name must render as its own line. Preview2.jsp
  *      joined the header's lines with <br> and converted them for the PDF with a
  *      replaceAll whose replacement, after JSP attribute unescaping, was an
  *      escaped literal 'n': every line break became the letter n and the header
@@ -44,8 +45,8 @@
  * prescription with its drug row and stamp signature, a fax_config account for
  * the "from" line when no active SRFAX row exists on that number, the fax job
  * rows on that line with their FaxClientLog audit rows, and the destination fax
- * number seeded on the patient's active pharmacies (restored exactly, NULL vs
- * '' preserved). Files are NOT removed: two small PDFs are left under
+ * number substituted on EVERY active pharmacy of the patient so no fixture can
+ * leave for a real machine (each original restored exactly, NULL vs '' preserved). Files are NOT removed: two small PDFs are left under
  * DOCUMENT_DIR (prescription_<pdfId>.pdf) plus the pair each leaves in the fax
  * spool, which the fax scheduler consumes.
  *
@@ -140,6 +141,12 @@ function validateMysqlHost(host) {
   if (!/^[A-Za-z0-9.\-:\[\]]+$/.test(host)) {
     throw new Error('MYSQL_HOST contains unsupported characters');
   }
+  // This check seeds and deletes prescription, signature, fax and pharmacy rows, so it must target
+  // a local disposable database. Same opt-in as the sibling Rx checks for an intentional remote one.
+  const loopback = new Set(['localhost', '127.0.0.1', '::1', 'carlos', 'db']);
+  if (!loopback.has(host.toLowerCase()) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
+    throw new Error(`Refusing non-local MYSQL_HOST "${host}"; set ALLOW_NON_LOCAL_MYSQL_HOST=true for an intentional test database`);
+  }
   return host;
 }
 
@@ -148,7 +155,7 @@ function validateDocumentDir(rawDir) {
     throw new Error('RX_FAX_DOCUMENT_DIR is required: the install\'s DOCUMENT_DIR as seen by this process');
   }
   if (!path.isAbsolute(rawDir)) throw new Error('RX_FAX_DOCUMENT_DIR must be an absolute path');
-  const resolved = path.resolve(rawDir); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- operator-supplied read-only directory, checked to exist and be a directory; file names under it are built from a digits-validated pdfId
+  const resolved = path.resolve(rawDir); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- operator-supplied read-only directory, checked to exist and be a directory; file names under it are built from a pdfId restricted to [A-Za-z0-9_-]
   let stat;
   try { stat = fs.statSync(resolved); } catch (error) { throw new Error('RX_FAX_DOCUMENT_DIR does not exist or is not readable'); }
   if (!stat.isDirectory()) throw new Error('RX_FAX_DOCUMENT_DIR is not a directory');
@@ -240,7 +247,11 @@ function pdfTextRuns(buf) {
     }
     const content = data.toString('latin1');
     if (!/\bT[jJ]\b/.test(content)) continue;
-    const opRe = /\((?:\\.|[^\\)])*\)\s*Tj|\[(?:\((?:\\.|[^\\)])*\)|[^\]])*\]\s*TJ/g;
+    // The TJ array alternative keeps its two repeated branches DISJOINT: a string branch that
+    // consumes "(...)" and a filler branch that may consume anything except "]" and "(". Letting the
+    // filler also eat "(" gave the engine two ways to match every parenthesis and made a "[" with
+    // many "()" and no closing "] TJ" backtrack exponentially (CodeQL js/redos).
+    const opRe = /\((?:\\.|[^\\)])*\)\s*Tj|\[(?:\((?:\\.|[^\\)])*\)|[^\]\(])*\]\s*TJ/g;
     let op;
     while ((op = opRe.exec(content))) {
       const parts = [];
@@ -269,10 +280,12 @@ function pdfTextRuns(buf) {
 
 /** The servlet's PDF for this pdfId, once it is fully written (exists, %PDF header, size stable). */
 async function waitForPdf(pdfId, label) {
-  if (!/^[A-Za-z0-9]{1,64}$/.test(pdfId)) {
+  // The servlet strips everything outside [a-zA-Z0-9_-] from pdfId before naming the file; accept
+  // exactly that set so a dashed or underscored id from the page is not a false failure here.
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(pdfId)) {
     throw new Error(`${label}: pdfId is not a plain identifier`);
   }
-  const file = path.join(documentDir, `prescription_${pdfId}.pdf`); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- documentDir is a validated operator-supplied directory and pdfId is restricted to [A-Za-z0-9]
+  const file = path.join(documentDir, `prescription_${pdfId}.pdf`); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- documentDir is a validated operator-supplied directory and pdfId is restricted to [A-Za-z0-9_-]
   const deadline = Date.now() + 20000;
   let lastSize = -1;
   while (Date.now() < deadline) {
@@ -307,7 +320,11 @@ function stageFaxConfig() {
 }
 
 function seedPharmacyFax() {
-  // Same predicate and NULL/'' fidelity as the sibling stamp check; see its seedPharmacyFax().
+  // Same active-pharmacy predicate as the sibling stamp check. Unlike it, EVERY active destination
+  // is replaced for the run, not only blank ones: the Fax button queues a real job to whatever
+  // number the patient's pharmacy carries, and a fixture prescription must never be able to leave
+  // for a real fax machine. Each original value is remembered exactly (NULL and '' are distinct
+  // states) and restored by cleanupFixtures only while the column still holds this run's number.
   const rows = sql(`SELECT p.recordId, IF(p.fax IS NULL, 1, 0), IFNULL(p.fax, '') FROM pharmacyInfo p
     JOIN demographicPharmacy dp ON dp.pharmacyID = p.recordId
     WHERE dp.demographic_no = ${demographicNo} AND dp.status = '1'
@@ -315,9 +332,13 @@ function seedPharmacyFax() {
     .split('\n').map((r) => r.split('\t')).filter((r) => /^\d+$/.test((r[0] || '').trim()));
   for (const [rawId, rawWasNull, rawFax] of rows) {
     const recordId = rawId.trim();
-    if ((rawFax || '').trim()) continue;
+    const wasNull = String(rawWasNull).trim() === '1';
+    const originalFax = wasNull ? null : String(rawFax || '');
+    if (originalFax !== null && !/^[0-9A-Za-z .()+-]{0,32}$/.test(originalFax)) {
+      throw new Error('a pharmacy fax value has an unexpected shape; refusing to rewrite it');
+    }
     sql(`UPDATE pharmacyInfo SET fax = '${pharmacyFaxNumber}' WHERE recordId = ${recordId};`);
-    seededPharmacyFaxes.push({ recordId, wasNull: String(rawWasNull).trim() === '1' });
+    seededPharmacyFaxes.push({ recordId, wasNull, originalFax });
   }
   visited.push({ label: 'pharmacy-fax', seeded: seededPharmacyFaxes.length, active: rows.length });
   if (!rows.length) {
@@ -356,9 +377,10 @@ function cleanupFixtures() {
     if (faxConfig && faxConfig.created) sql(`DELETE FROM fax_config WHERE id=${faxConfig.id};`);
   });
   while (seededPharmacyFaxes.length) {
-    const { recordId, wasNull } = seededPharmacyFaxes.pop();
+    const { recordId, wasNull, originalFax } = seededPharmacyFaxes.pop();
+    const restored = wasNull ? 'NULL' : `'${originalFax}'`; // shape-validated before the rewrite
     attempt(`pharmacy-fax ${recordId}`, () => sql(
-      `UPDATE pharmacyInfo SET fax = ${wasNull ? 'NULL' : "''"} WHERE recordId = ${recordId} AND fax = '${pharmacyFaxNumber}';`));
+      `UPDATE pharmacyInfo SET fax = ${restored} WHERE recordId = ${recordId} AND fax = '${pharmacyFaxNumber}';`));
   }
 }
 
@@ -374,7 +396,11 @@ function wirePage(page, label) {
     // Pre-existing, tracked by issue #3578 (expandPreview writes into the preview iframe before it
     // has parsed on some render orders). Named so the suppression stays auditable.
     if (/Cannot set properties of null \(setting 'innerHTML'\)/.test(text) && /expandPreview/.test(text)) return;
-    findings.push({ label, type: 'pageerror', text: text.slice(0, 300) });
+    // Record the error CLASS only. A page error's message or stack can quote page content -- a
+    // patient name in a DOM path, a demographic number in a URL -- and this goes to stderr and the
+    // artifact file, so it must never carry the text itself.
+    const errorClass = /^([A-Za-z]+Error)\b/.exec(text);
+    findings.push({ label, type: 'pageerror', text: errorClass ? errorClass[1] : 'browser page error' });
   });
   page.on('dialog', async (dialog) => {
     // Accept only the custom-drug confirm(), and only while clicking that button. Anything else is a
@@ -409,7 +435,7 @@ async function login(context) {
 
 /** A CSRFGuard master token for this session, read the way the page's own script does. */
 async function csrfToken(page) {
-  return page.evaluate(async (tokenUrl) => {
+  return page.evaluate(async (tokenUrl) => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection -- tokenUrl is passed as a Playwright argument, not interpolated into code, and is built by appUrl from the loopback-restricted validateBaseUrl result
     const resp = await fetch(tokenUrl, { credentials: 'same-origin' });
     const js = await resp.text();
     const m = js.match(/masterTokenValue\s*=\s*["']([^"']+)["']/);
@@ -460,6 +486,10 @@ function addProbeLineToRecord(scriptId) {
   if (check !== '1') throw new Error('probe line was not written to the fixture drug row');
 }
 
+// Captured from the Fax button's POST for the clinic-header assertion (see assertClinicHeader).
+let submittedClinicHeader = null;
+let headerComposedByServlet = false;
+
 async function faxThroughUi(page, modalFrame, scriptId) {
   // Deterministic race: hold the notes save so the fax POST can only carry the note if the page
   // waited for it. The route covers the modal iframe's requests too.
@@ -489,6 +519,11 @@ async function faxThroughUi(page, modalFrame, scriptId) {
     body = await response.text().catch(() => '');
     const post = new URLSearchParams(request.postData() || '');
     pdfId = post.get('pdfId');
+    // What the page put on the wire for the clinic header, and whether the servlet will use it. A
+    // specialist/satellite address (useSC=true) makes the servlet compose the header itself, so
+    // only the submitted value, not the rendered lines, can be judged in that case.
+    submittedClinicHeader = post.get('clinicName');
+    headerComposedByServlet = /[?&]useSC=true(&|$)/.test(request.url());
     if (post.get('scriptId') !== scriptId && new URL(request.url()).searchParams.get('scriptId') !== scriptId) {
       findings.push({ label: 'ui-fax', type: 'wrong-script', text: 'the Fax button posted a different scriptId than the prescription just written' });
     }
@@ -518,7 +553,7 @@ async function faxWithForgedIdentity(page, scriptId) {
   const token = await csrfToken(page);
   if (!token) findings.push({ label: 'forged-fax', type: 'no-csrf-token', text: 'could not obtain a CSRFGuard token for the forged-identity POST' });
   const pdfId = `pwbind${runSuffix}`;
-  const result = await page.evaluate(async ({ postUrl, token: t, params }) => {
+  const result = await page.evaluate(async ({ postUrl, token: t, params }) => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection -- all values are passed as Playwright arguments, not interpolated into code: postUrl comes from the loopback-restricted validateBaseUrl, token from the app's own /csrfguard, and params are digits-validated ids plus this script's fixed probe strings
     const resp = await fetch(postUrl, {
       method: 'POST',
       headers: {
@@ -604,33 +639,36 @@ function assertProbeLine(runs) {
 }
 
 /**
- * The clinic name exactly as rx/Preview2.jsp puts it at the top of the prescriber header: the
- * single clinic row's name with a trailing "(nnnnnn)" site code removed. Empty when the install has
- * no clinic row, in which case the header assertion is skipped and says so.
+ * The clinic header must reach the servlet as separate lines and render that way.
+ *
+ * <p>Judged from what the page actually POSTed rather than from the clinic table: Preview2.jsp
+ * composes {@code name<br>address<br>city   postal} and converts the joins to line breaks for the
+ * hidden {@code clinicName} input, so a correct submission has at least two lines and its first
+ * line is the clinic name. The defect this pins produced ONE line with the letter n where each
+ * break belonged, so a single-line submission whose text is longer than a name is the signature.
+ * That judgement holds for a program or satellite address too; only the rendered-line check is
+ * skipped then, because the servlet composes the header itself when useSC=true.</p>
  */
-function expectedClinicName() {
-  const raw = sql('SELECT IFNULL(clinic_name, \'\') FROM clinic ORDER BY clinic_no LIMIT 1;').trim();
-  return raw.replace(/\(\d{6}\)/g, '').trim();
-}
-
 function assertClinicHeader(runs) {
-  const clinicName = expectedClinicName();
-  if (!clinicName) {
-    visited.push({ label: 'clinic-header', skipped: 'no clinic row' });
+  if (submittedClinicHeader === null) {
+    visited.push({ label: 'clinic-header', skipped: 'no clinicName on the fax POST' });
+    return;
+  }
+  const lines = submittedClinicHeader.split(/\r?\n/).map((l) => l.trim());
+  const firstLine = lines[0] || '';
+  const multiLine = lines.length >= 2;
+  if (!multiLine && firstLine.length > 0) {
+    findings.push({ label: 'clinic-header', type: 'lines-glued', text: 'the page submitted the clinic header as a single line: the <br> to line-break conversion lost the breaks (the letter-n defect)' });
+  }
+  if (headerComposedByServlet) {
+    visited.push({ label: 'clinic-header', multiLine, rendered: 'skipped (useSC: servlet composes the header)' });
     return;
   }
   const trimmed = runs.map((r) => r.trim());
-  const ownLine = trimmed.includes(clinicName);
-  // The defect's signature: the name is there but the address is glued onto the same rendered line.
-  const glued = trimmed.some((r) => r.startsWith(clinicName) && r.length > clinicName.length);
-  visited.push({ label: 'clinic-header', ownLine, glued });
-  if (ownLine) return;
-  if (glued) {
-    findings.push({ label: 'clinic-header', type: 'lines-glued', text: 'the faxed clinic header renders the clinic name and its address on one glued line (the <br> to line-break conversion lost the break)' });
-  } else {
-    // Not this defect. A specialist-address (useSC) fax composes the header server-side; on the
-    // demo install the header is the clinic's, so its absence is still worth a look.
-    findings.push({ label: 'clinic-header', type: 'absent', text: 'the faxed PDF has no line carrying the clinic name at all' });
+  const ownLine = firstLine.length > 0 && trimmed.includes(firstLine);
+  visited.push({ label: 'clinic-header', multiLine, ownLine });
+  if (multiLine && !ownLine) {
+    findings.push({ label: 'clinic-header', type: 'name-not-rendered', text: 'the clinic name submitted on the fax POST is not a rendered line of the faxed PDF' });
   }
 }
 

--- a/scripts/rx-fax-record-binding-playwright-checks.js
+++ b/scripts/rx-fax-record-binding-playwright-checks.js
@@ -409,7 +409,8 @@ function wirePage(page, label) {
       await dialog.accept().catch(() => {});
       return;
     }
-    findings.push({ label, type: 'unexpected-dialog', text: `${dialog.type()}: ${dialog.message()}`.slice(0, 200) });
+    // Type only: a dialog's text can quote page content, and findings reach stderr and the artifact.
+    findings.push({ label, type: 'unexpected-dialog', text: `unexpected ${dialog.type()} dialog` });
     await dialog.dismiss().catch(() => dialog.accept().catch(() => {}));
   });
 }
@@ -544,7 +545,9 @@ async function faxThroughUi(page, modalFrame, scriptId) {
   } else if (/not signed/i.test(body)) {
     findings.push({ label: 'ui-fax', type: 'signed-refused', text: 'the freshly stamp-signed prescription was refused as unsigned' });
   } else if (!/fax-success/i.test(body)) {
-    findings.push({ label: 'ui-fax', type: 'not-successful', text: `fax did not report fax-success: ${body.replace(/\s+/g, ' ').slice(0, 160)}` });
+    // Classify the response; never quote it. An error page can carry patient-identifying content
+    // and findings are printed and persisted.
+    findings.push({ label: 'ui-fax', type: 'not-successful', text: /fax-failure/i.test(body) ? 'the servlet reported fax-failure' : 'the response carried neither fax-success nor fax-failure' });
   }
   return pdfId;
 }
@@ -596,7 +599,7 @@ async function faxWithForgedIdentity(page, scriptId) {
     return null;
   }
   if (!/fax-success/i.test(result.body)) {
-    findings.push({ label: 'forged-fax', type: 'not-successful', text: `forged-identity fax did not report fax-success: ${result.body.replace(/\s+/g, ' ').slice(0, 160)}` });
+    findings.push({ label: 'forged-fax', type: 'not-successful', text: /fax-failure/i.test(result.body) ? 'the servlet reported fax-failure for the forged-identity POST' : 'the forged-identity POST response carried neither fax-success nor fax-failure' });
     return null;
   }
   return pdfId;
@@ -639,36 +642,54 @@ function assertProbeLine(runs) {
 }
 
 /**
+ * The clinic name as rx/Preview2.jsp puts it at the head of the clinic-address header: the single
+ * clinic row's name with a trailing "(nnnnnn)" site code removed. Used only to tell the letter-n
+ * defect apart from a legitimately single-line header (a program address is one line by design).
+ */
+function clinicRowName() {
+  const raw = sql('SELECT IFNULL(clinic_name, \'\') FROM clinic ORDER BY clinic_no LIMIT 1;').trim();
+  return raw.replace(/\(\d{6}\)/g, '').trim();
+}
+
+/**
  * The clinic header must reach the servlet as separate lines and render that way.
  *
- * <p>Judged from what the page actually POSTed rather than from the clinic table: Preview2.jsp
- * composes {@code name<br>address<br>city   postal} and converts the joins to line breaks for the
- * hidden {@code clinicName} input, so a correct submission has at least two lines and its first
- * line is the clinic name. The defect this pins produced ONE line with the letter n where each
- * break belonged, so a single-line submission whose text is longer than a name is the signature.
- * That judgement holds for a program or satellite address too; only the rendered-line check is
- * skipped then, because the servlet composes the header itself when useSC=true.</p>
+ * <p>Judged from what the page actually POSTed. Preview2.jsp composes {@code name<br>address<br>
+ * city   postal} and converts the joins to line breaks for the hidden {@code clinicName} input, so
+ * a correct submission has at least two lines and its first line is the clinic name. The defect this
+ * pins produced ONE line with the letter n where each break belonged. A single line is only called
+ * glued when the clinic row's name is a proper prefix of it -- a program address is legitimately one
+ * line and must not fail the check. A missing or empty header on the normal path is a finding, not a
+ * skip. When {@code useSC=true} the servlet composes the header itself and ignores the submitted
+ * value, so nothing is judged.</p>
  */
 function assertClinicHeader(runs) {
-  if (submittedClinicHeader === null) {
-    visited.push({ label: 'clinic-header', skipped: 'no clinicName on the fax POST' });
+  if (headerComposedByServlet) {
+    visited.push({ label: 'clinic-header', skipped: 'useSC: the servlet composes the header' });
     return;
   }
-  const lines = submittedClinicHeader.split(/\r?\n/).map((l) => l.trim());
+  const submitted = (submittedClinicHeader || '').trim();
+  if (!submitted) {
+    findings.push({ label: 'clinic-header', type: 'absent', text: 'the Fax POST carried no clinicName, so the faxed prescription has no clinic header' });
+    return;
+  }
+  const lines = submitted.split(/\r?\n/).map((l) => l.trim());
   const firstLine = lines[0] || '';
   const multiLine = lines.length >= 2;
-  if (!multiLine && firstLine.length > 0) {
-    findings.push({ label: 'clinic-header', type: 'lines-glued', text: 'the page submitted the clinic header as a single line: the <br> to line-break conversion lost the breaks (the letter-n defect)' });
-  }
-  if (headerComposedByServlet) {
-    visited.push({ label: 'clinic-header', multiLine, rendered: 'skipped (useSC: servlet composes the header)' });
+  if (!multiLine) {
+    const clinicName = clinicRowName();
+    const glued = clinicName.length > 0 && firstLine.startsWith(clinicName) && firstLine.length > clinicName.length;
+    visited.push({ label: 'clinic-header', multiLine: false, glued });
+    if (glued) {
+      findings.push({ label: 'clinic-header', type: 'lines-glued', text: 'the page submitted the clinic header as a single line beginning with the clinic name: the <br> to line-break conversion lost the breaks (the letter-n defect)' });
+    }
     return;
   }
   const trimmed = runs.map((r) => r.trim());
   const ownLine = firstLine.length > 0 && trimmed.includes(firstLine);
-  visited.push({ label: 'clinic-header', multiLine, ownLine });
-  if (multiLine && !ownLine) {
-    findings.push({ label: 'clinic-header', type: 'name-not-rendered', text: 'the clinic name submitted on the fax POST is not a rendered line of the faxed PDF' });
+  visited.push({ label: 'clinic-header', multiLine: true, ownLine });
+  if (!ownLine) {
+    findings.push({ label: 'clinic-header', type: 'name-not-rendered', text: 'the first line of the clinic header submitted on the fax POST is not a rendered line of the faxed PDF' });
   }
 }
 

--- a/scripts/rx-fax-signature-stamp-playwright-checks.js
+++ b/scripts/rx-fax-signature-stamp-playwright-checks.js
@@ -565,8 +565,12 @@ async function runChecks(context) {
       // Await both together: awaited one after the other, a click that produces no round trip
       // times both out at once and the second, still-unhandled rejection kills the process before
       // the fixture cleanup runs.
-      const [request, faxResponse] = await Promise.all([faxRequestPromise, faxResponsePromise]);
-      faxRequest = request;
+      // Capture the request the moment its waiter resolves, so a fax whose response never comes
+      // still records which script it posted.
+      const [, faxResponse] = await Promise.all([
+        faxRequestPromise.then((captured) => { faxRequest = captured; return captured; }),
+        faxResponsePromise,
+      ]);
       faxStatus = faxResponse.status();
       faxBody = await faxResponse.text().catch(() => '');
       // Path only: the query carries scriptId and the satellite-clinic block, and this goes to the artifact file.

--- a/scripts/rx-fax-signature-stamp-playwright-checks.js
+++ b/scripts/rx-fax-signature-stamp-playwright-checks.js
@@ -576,7 +576,9 @@ async function runChecks(context) {
       // Path only: the query carries scriptId and the satellite-clinic block, and this goes to the artifact file.
       visited.push({ label: 'fax-request', url: new URL(faxRequest.url()).pathname + ' (query redacted)', status: faxStatus });
     } catch (error) {
-      findings.push({ label: 'fax-click', type: 'no-request', text: `Fax click produced no createcustomedpdf request: ${error.message}` });
+      // A captured request whose response never came is a different failure from no request at all.
+      if (faxRequest) findings.push({ label: 'fax-click', type: 'no-response', text: `the Fax click's createcustomedpdf request got no response: ${error.message}` });
+      else findings.push({ label: 'fax-click', type: 'no-request', text: `Fax click produced no createcustomedpdf request: ${error.message}` });
     }
 
     if (faxRequest) {

--- a/scripts/rx-fax-signature-stamp-playwright-checks.js
+++ b/scripts/rx-fax-signature-stamp-playwright-checks.js
@@ -562,11 +562,15 @@ async function runChecks(context) {
     let faxBody = '';
     let faxStatus = 0;
     try {
-      faxRequest = await faxRequestPromise;
-      const faxResponse = await faxResponsePromise;
+      // Await both together: awaited one after the other, a click that produces no round trip
+      // times both out at once and the second, still-unhandled rejection kills the process before
+      // the fixture cleanup runs.
+      const [request, faxResponse] = await Promise.all([faxRequestPromise, faxResponsePromise]);
+      faxRequest = request;
       faxStatus = faxResponse.status();
       faxBody = await faxResponse.text().catch(() => '');
-      visited.push({ label: 'fax-request', url: faxRequest.url(), status: faxStatus });
+      // Path only: the query carries scriptId and the satellite-clinic block, and this goes to the artifact file.
+      visited.push({ label: 'fax-request', url: new URL(faxRequest.url()).pathname + ' (query redacted)', status: faxStatus });
     } catch (error) {
       findings.push({ label: 'fax-click', type: 'no-request', text: `Fax click produced no createcustomedpdf request: ${error.message}` });
     }

--- a/scripts/schedule-setting-playwright-checks.js
+++ b/scripts/schedule-setting-playwright-checks.js
@@ -236,7 +236,10 @@ async function login(context) {
   await safeGoto(page, '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
-  await page.locator('#pin').fill(testPin);
+  // login/index.jsp renders #pin only when MfaManager.isOscarLegacyPinEnabled(); filling it
+  // unconditionally throws on an install with the legacy PIN disabled and the check never runs.
+  const pin = page.locator('#pin');
+  if ((await pin.count()) > 0) await pin.fill(testPin);
   await Promise.all([
     page.waitForURL(/providercontrol/, { timeout: 30000 }),
     page.locator('input[type="submit"], button[type="submit"]').first().click(),

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -963,22 +963,23 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         // exactly when scAddress is a block this provider's page could have sent, so neither a
         // differently-cased flag nor a made-up block can reach parseSCAddress. Anything else renders
         // the main clinic bound above.
-        boolean offered = false;
+        String offeredBlock = null;
         if (RxSatelliteClinicAddress.clinicPart(req.getParameter("scAddress")) != null) {
             LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(req);
             String user = loggedInInfo == null ? null : loggedInInfo.getLoggedInProviderNo();
             String tel = SafeEncode.forHtml(LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgTel"));
             String fax = SafeEncode.forHtml(LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgFax"));
-            offered = RxSatelliteClinicAddress.offers(RxSatelliteClinicAddress.blocksFor(user, tel, fax), req.getParameter("scAddress"));
-            if (!offered) {
+            offeredBlock = RxSatelliteClinicAddress.offeredBlock(RxSatelliteClinicAddress.blocksFor(user, tel, fax), req.getParameter("scAddress"));
+            if (offeredBlock == null) {
                 logger.warn("Fax for prescription {} named a satellite clinic block this provider is not offered; using the main clinic header",
                         LogSafe.sanitize(String.valueOf(prescription.getId())));
             }
         }
-        bound.put("useSC", offered ? "true" : "false");
-        if (!offered) {
-            bound.put("scAddress", "");
-        }
+        // Render the OFFERED block, not the request's copy of it: the match decodes entities on both
+        // sides, so the request may spell the same clinic with entity text that parseSCAddress would
+        // otherwise print verbatim.
+        bound.put("useSC", offeredBlock != null ? "true" : "false");
+        bound.put("scAddress", offeredBlock != null ? offeredBlock : "");
 
         // Reprint annotation. The preview decides "is this a reprint" from the session flag the
         // reprint action sets, and prints the first drug's stored print date and count.

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -935,10 +935,20 @@ public class FrmCustomedPDFServlet extends HttpServlet {
     }
 
     /**
-     * The city/province/postal line exactly as {@code rx/Preview2.jsp} composes it: ", " between a
-     * city and a province when both are present, a single space when only the province is, and
-     * nothing between when only the city is. Reproduced rather than simplified so that binding the
-     * field does not visibly change a legitimate fax.
+     * The city/province/postal line exactly as {@code rx/Preview2.jsp} composes it, separator
+     * chosen by which of the two parts are present:
+     *
+     * <ul>
+     *   <li>both city and province: {@code ", "} — {@code "Hamilton, ON L8S 4L8"};</li>
+     *   <li>province only: nothing, so the line starts at the province — {@code "ON L8S 4L8"};</li>
+     *   <li>city only (or neither): a single space, which the empty province leaves as a double
+     *       space before the postal code — {@code "Hamilton  L8S 4L8"}.</li>
+     * </ul>
+     *
+     * <p>That last case looks like a typo and is not: it is what the page emits today, and the
+     * point of reproducing the rule rather than tidying it is that binding this field must not
+     * visibly change a legitimate fax. Fix it in {@code Preview2.jsp} and here together, or not at
+     * all.</p>
      */
     static String formatCityPostal(String city, String province, String postal) {
         int check = (city.trim().isEmpty() ? 0 : 1) | (province.trim().isEmpty() ? 0 : 2);
@@ -1122,7 +1132,11 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             // newlines and has no sentinel at all, so under the old "s.length() == 1" test a
             // genuine one-character prescription line -- a standalone dose such as "1" -- was
             // treated as a block break and silently dropped from the faxed script.
-            if (s.equals("") || s.equals(newline) || s.equals("\r")) {
+            //
+            // The former "s.equals(newline)" branch is gone with it: split(newline) never yields a
+            // segment equal to its own delimiter, so it was unreachable and only made the separator
+            // contract read as though a literal newline token could arrive here.
+            if (s.isEmpty() || s.equals("\r")) {
                 listRx.add(listElem);
                 listElem = "";
             } else {

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -61,8 +61,11 @@ import io.github.carlos_emr.carlos.commn.model.Prescription;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData;
+import io.github.carlos_emr.carlos.prescript.util.RxUtil;
 import io.github.carlos_emr.carlos.providers.data.ProSignatureData;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.DigitalSignatureManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.commn.model.FaxConfig;
@@ -118,6 +121,12 @@ public class FrmCustomedPDFServlet extends HttpServlet {
     private final DigitalSignatureManager digitalSignatureManager = SpringUtils.getBean(DigitalSignatureManager.class);
     private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private final ProviderDao providerDao = SpringUtils.getBean(ProviderDao.class);
+    private final DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
+
+    /** Every request parameter that names or locates the patient on the rendered page. */
+    private static final List<String> IDENTITY_PARAMETERS = List.of(
+            "patientName", "patientDOB", "patientAddress", "patientCityPostal",
+            "patientHIN", "patientPhone", "patientChartNo");
 
     /** Parses a positive script number (prescription.script_no is a signed int); -1 when invalid. */
     private static int parsePositiveInt(String value) {
@@ -862,8 +871,81 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         bound.put("additNotes", prescription.getComments() == null ? "" : prescription.getComments());
         bound.put("pracNo", collegeId);
         bound.put("billingNumber", billingNo);
+        bindPatientIdentity(req, prescription.getDemographicId(), bound);
         return new RecordBoundRequest(req, bound);
     }
+
+    /**
+     * Binds the patient block of the fax to the prescription's own demographic.
+     *
+     * <p>The drugs, the signing name and the prescriber's numbers are already taken from the
+     * record, and {@link #resolveSignatureImage} has established that the caller holds {@code _rx}
+     * write for the prescription's patient and that {@code demographic_no} names that same patient.
+     * The identity PRINTED on the page was still whatever the request said: {@code patientName},
+     * {@code patientDOB}, {@code patientHIN}, {@code patientAddress}, {@code patientCityPostal} and
+     * {@code patientPhone} were read straight from parameters. A stale preview, or a tampered post
+     * from a caller who legitimately holds {@code _rx} write on the patient, could therefore send
+     * the verified drugs under the prescriber's stored signature while heading the page with a
+     * different person's name, date of birth and health number — a correctly signed prescription
+     * for the wrong patient. Bind them the same way as everything else.</p>
+     *
+     * <p>The formats reproduce what {@code rx/Preview2.jsp} posts for a legitimate render, so a
+     * bound fax is byte-identical to an untampered one: the city/province/postal line uses the
+     * page's own spacing rules, and the phone carries the localized {@code RxPreview.msgTel} label
+     * the page prefixes. {@code showPatientDOB} is deliberately NOT bound — it selects whether the
+     * clinic prints dates of birth at all, which is a display preference rather than identity, and
+     * the value it gates is now the record's either way.</p>
+     *
+     * <p>{@code patientChartNo} is bound to empty because the Rx preview never populates it: the
+     * faxed script has never shown a chart number, so the only thing the parameter could carry is
+     * text an attacker chose. Leaving it caller-controlled would reopen the same hole in the one
+     * identity slot that has no record source here.</p>
+     */
+    private void bindPatientIdentity(HttpServletRequest req, Integer demographicId, Map<String, String> bound) {
+        // Every identity slot is overridden, including the ones that come back empty. A field left
+        // unbound is a field the request still controls, so the blanks are part of the control:
+        // absent demographic data must print as absent, never as whatever the caller supplied.
+        for (String field : IDENTITY_PARAMETERS) {
+            bound.put(field, "");
+        }
+        // rx/Preview2.jsp reaches the same row through RxPatientData, which is a pass-through over
+        // DemographicManager; going straight to the manager keeps the consent and audit behaviour
+        // of the preview without RxPatientData's static bean plumbing.
+        Demographic demographic = demographicManager.getDemographic(LoggedInInfo.getLoggedInInfoFromSession(req),
+                demographicId);
+        if (demographic == null) {
+            logger.warn("Faxing prescription for demographic {} with a blank patient heading: its demographic row is missing",
+                    LogSafe.sanitize(String.valueOf(demographicId)));
+            return;
+        }
+        String first = demographic.getFirstName() == null ? "" : demographic.getFirstName();
+        String surname = demographic.getLastName() == null ? "" : demographic.getLastName();
+        String city = demographic.getCity() == null ? "" : demographic.getCity();
+        String province = demographic.getProvince() == null ? "" : demographic.getProvince();
+        String postal = demographic.getPostal() == null ? "" : demographic.getPostal();
+        String phone = demographic.getPhone() == null ? "" : demographic.getPhone();
+        Date dob = demographic.getBirthDay() == null ? null : demographic.getBirthDay().getTime();
+
+        bound.put("patientName", (first + " " + surname).trim());
+        bound.put("patientDOB", RxUtil.DateToString(dob, "MMM d, yyyy"));
+        bound.put("patientAddress", demographic.getAddress() == null ? "" : demographic.getAddress());
+        bound.put("patientCityPostal", formatCityPostal(city, province, postal));
+        bound.put("patientHIN", demographic.getHin() == null ? "" : demographic.getHin());
+        bound.put("patientPhone", LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgTel") + ": " + phone);
+    }
+
+    /**
+     * The city/province/postal line exactly as {@code rx/Preview2.jsp} composes it: ", " between a
+     * city and a province when both are present, a single space when only the province is, and
+     * nothing between when only the city is. Reproduced rather than simplified so that binding the
+     * field does not visibly change a legitimate fax.
+     */
+    static String formatCityPostal(String city, String province, String postal) {
+        int check = (city.trim().isEmpty() ? 0 : 1) | (province.trim().isEmpty() ? 0 : 2);
+        String separator = check == 3 ? ", " : check == 2 ? "" : " ";
+        return String.format("%s%s%s %s", city, separator, province, postal);
+    }
+
 
     /**
      * One drug's fax block, with the record's own line breaks restored.
@@ -1032,7 +1114,15 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         }
         String listElem = "";
         for (String s : rx.split(newline)) {
-            if (s.equals("") || s.equals(newline) || s.length() == 1) {
+            // ONLY the lone carriage return is a separator, never any one-character line. The
+            // sentinel this looks for is the "\r" left behind when a browser-submitted CRLF body is
+            // split on a "\n" platform separator; a bare one-character line cannot occur that way,
+            // because every line of such a body still carries its own trailing "\r". The
+            // record-bound fax body (bindFaxContentToRecord) is built server-side with plain
+            // newlines and has no sentinel at all, so under the old "s.length() == 1" test a
+            // genuine one-character prescription line -- a standalone dose such as "1" -- was
+            // treated as a block break and silently dropped from the faxed script.
+            if (s.equals("") || s.equals(newline) || s.equals("\r")) {
                 listRx.add(listElem);
                 listElem = "";
             } else {

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -47,6 +47,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.openpdf.text.*;
 import org.openpdf.text.pdf.*;
@@ -61,6 +62,8 @@ import io.github.carlos_emr.carlos.commn.model.Prescription;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData;
+import io.github.carlos_emr.carlos.prescript.data.RxProviderData;
+import io.github.carlos_emr.carlos.prescript.data.RxSatelliteClinicAddress;
 import io.github.carlos_emr.carlos.prescript.util.RxUtil;
 import io.github.carlos_emr.carlos.providers.data.ProSignatureData;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
@@ -80,6 +83,7 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
+import io.github.carlos_emr.carlos.utility.SafeEncode;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.web.PrescriptionQrCodeUIBean;
 
@@ -171,6 +175,19 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(req);
         boolean isFax = "oscarRxFax".equals(req.getParameter("__method"));
         boolean responseOutputStreamOpened = false;
+
+        // The fax path is a mutation with an outbound side effect: it writes the PDF under
+        // DOCUMENT_DIR, persists a FaxJob and hands a signed prescription to the fax provider at a
+        // caller-chosen number. This servlet answers every HTTP method through service(), and
+        // CSRFGuard protects POST only (ProtectedMethods=POST,PUT,DELETE,PATCH), so a GET carrying
+        // __method=oscarRxFax would be a token-free, cross-site-triggerable fax of a real patient's
+        // prescription to an attacker's number. Refuse anything but POST before any of that runs.
+        // The page's own Fax button submits a POST form, so nothing legitimate is turned away.
+        if (isFax && !"POST".equalsIgnoreCase(req.getMethod())) {
+            res.setHeader("Allow", "POST");
+            res.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Faxing a prescription requires POST");
+            return;
+        }
 
         // The prescription named by scriptId is loaded ONCE here and shared by the privilege
         // pre-check, the signature gate and the fax content binding below.
@@ -794,8 +811,9 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         int scriptNo = parsePositiveInt(req.getParameter("scriptId"));
         String newline = System.getProperty("line.separator");
         List<String> recordLines = new ArrayList<>();
-        for (RxPrescriptionData.Prescription drug
-                : new RxPrescriptionData().getPrescriptionsByScriptNo(scriptNo, prescription.getDemographicId())) {
+        List<RxPrescriptionData.Prescription> recordDrugs =
+                new RxPrescriptionData().getPrescriptionsByScriptNo(scriptNo, prescription.getDemographicId());
+        for (RxPrescriptionData.Prescription drug : recordDrugs) {
             String line = recordBlock(drug, newline);
             if (line != null && !line.isBlank()) {
                 recordLines.add(line);
@@ -873,7 +891,100 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         bound.put("pracNo", collegeId);
         bound.put("billingNumber", billingNo);
         bindPatientIdentity(req, prescription.getDemographicId(), bound);
+        bindFaxHeaderToRecord(req, prescription, recordDrugs, bound);
         return new RecordBoundRequest(req, bound);
+    }
+
+    /**
+     * Binds the remaining printed header of the fax to the record: the prescription date, the clinic
+     * block (name, address, telephone) and the reprint annotation.
+     *
+     * <p>With the drugs, prescriber, patient identity and notes already record-bound, these were the
+     * last rendered values still read straight from the request. Each is text on a document that
+     * goes out under the prescriber's stored signature: a forged {@code rxDate} back- or post-dates a
+     * controlled-substance script, a forged clinic block routes the pharmacy's call-back to a phone
+     * the caller chose, and {@code rxReprint}/{@code origPrintDate}/{@code numPrints} print verbatim
+     * as "Orig printed: ...; times printed: ..." above the signature. Each has the record source
+     * {@code rx/Preview2.jsp} itself renders from, so bind them the same way.</p>
+     *
+     * <ul>
+     *   <li>{@code rxDate}: the latest {@code rx_date} among the script's drugs, in the page's
+     *       {@code "MMMM d, yyyy"} format — the same "latest in the stash" rule the preview uses.</li>
+     *   <li>Clinic block: the prescriber's clinic as {@code RxProviderData} resolves it (clinic
+     *       table, overridden by the prescriber's own rxAddress/rxPhone preferences), composed as
+     *       the preview composes its {@code clinicName}. The preview's other branch — a program
+     *       address from an {@code infirmaryView_programAddress} attribute — has no remaining
+     *       setter in CARLOS, so it is not reproduced here. A satellite clinic ({@code useSC=true})
+     *       is honoured only when the posted {@code scAddress}
+     *       is one of the blocks the page could have offered this provider
+     *       ({@link RxSatelliteClinicAddress#blocksFor}); anything else falls back to the main
+     *       clinic and is logged, because {@code parseSCAddress} would otherwise print whatever the
+     *       caller sent as the clinic.</li>
+     *   <li>Reprint annotation: present only when this session is reprinting (the same session flag
+     *       the preview keys on) and the record has a print history, with the record's own first
+     *       print date and count; blank otherwise.</li>
+     * </ul>
+     */
+    private void bindFaxHeaderToRecord(HttpServletRequest req, Prescription prescription,
+                                       List<RxPrescriptionData.Prescription> recordDrugs, Map<String, String> bound) {
+        Date latest = null;
+        for (RxPrescriptionData.Prescription drug : recordDrugs) {
+            Date rxDate = drug.getRxDate();
+            if (rxDate != null && (latest == null || rxDate.after(latest))) {
+                latest = rxDate;
+            }
+        }
+        bound.put("rxDate", latest == null ? "" : RxUtil.DateToString(latest, "MMMM d, yyyy"));
+
+        String prescriber = prescription.getProviderNo();
+        HttpSession session = req.getSession(false);
+        RxProviderData.Provider clinic = prescriber == null ? null : new RxProviderData().getProvider(prescriber);
+        // The preview strips the "(nnnnnn)" clinic-number suffix from the name and joins name,
+        // address and "city   postal" with line breaks; RxProviderData has already applied the
+        // prescriber's rxAddress/rxPhone preferences to the clinic values.
+        String clinicName = clinic == null ? "" : nz(clinic.getClinicName()).replaceAll("\\(\\d{6}\\)", "") + "\n"
+                + nz(clinic.getClinicAddress()) + "\n"
+                + nz(clinic.getClinicCity()) + "   " + nz(clinic.getClinicPostal());
+        bound.put("clinicName", clinicName);
+        bound.put("clinicPhone", clinic == null ? "" : nz(clinic.getClinicPhone()));
+
+        // useSC/scAddress select a satellite clinic block that generatePDFDocumentBytes parses INSTEAD
+        // of clinicName/clinicPhone/clinicFax. Accept it only if it is a block this provider's page
+        // could have sent; otherwise switch the request to the main clinic bound above.
+        if ("true".equalsIgnoreCase(req.getParameter("useSC"))) {
+            String requested = RxSatelliteClinicAddress.clinicPart(req.getParameter("scAddress"));
+            LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(req);
+            String user = loggedInInfo == null ? null : loggedInInfo.getLoggedInProviderNo();
+            String tel = SafeEncode.forHtml(LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgTel"));
+            String fax = SafeEncode.forHtml(LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgFax"));
+            boolean offered = requested != null && RxSatelliteClinicAddress.blocksFor(user, tel, fax).stream()
+                    .map(RxSatelliteClinicAddress::clinicPart)
+                    .anyMatch(requested::equals);
+            if (!offered) {
+                logger.warn("Fax for prescription {} named a satellite clinic block this provider is not offered; using the main clinic header",
+                        LogSafe.sanitize(String.valueOf(prescription.getId())));
+                bound.put("useSC", "false");
+                bound.put("scAddress", "");
+            }
+        }
+
+        // Reprint annotation. The preview decides "is this a reprint" from the session flag the
+        // reprint action sets, and prints the first drug's stored print date and count.
+        boolean reprinting = session != null && "true".equalsIgnoreCase(String.valueOf(session.getAttribute("rePrint")));
+        RxPrescriptionData.Prescription first = recordDrugs.isEmpty() ? null : recordDrugs.get(0);
+        if (reprinting && first != null && first.getPrintDate() != null) {
+            bound.put("rxReprint", "true");
+            bound.put("origPrintDate", String.valueOf(first.getPrintDate()));
+            bound.put("numPrints", String.valueOf(first.getNumPrints()));
+        } else {
+            bound.put("rxReprint", "false");
+            bound.put("origPrintDate", "");
+            bound.put("numPrints", "");
+        }
+    }
+
+    private static String nz(String value) {
+        return value == null ? "" : value;
     }
 
     /**
@@ -1097,8 +1208,14 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         }
         String patient = String.valueOf(prescription.getDemographicId());
         try {
+            // The fax heads the page with the patient's name, date of birth and health number read
+            // from the demographic record (bindPatientIdentity), so faxing needs _demographic READ
+            // on the patient as well as _rx WRITE. Deciding that here, before any side effect, turns
+            // what would otherwise surface as DemographicManager's bare RuntimeException — a 500
+            // half-way through the fax — into the same deliberate permission refusal.
             return securityInfoManager.hasPrivilege(loggedInInfo, "_rx", SecurityInfoManager.READ, patient)
-                    && !securityInfoManager.hasPrivilege(loggedInInfo, "_rx", SecurityInfoManager.WRITE, patient);
+                    && (!securityInfoManager.hasPrivilege(loggedInInfo, "_rx", SecurityInfoManager.WRITE, patient)
+                        || !securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", SecurityInfoManager.READ, patient));
         } catch (RuntimeException e) {
             // hasPrivilege rethrows PatientDirectiveException (SecurityInfoManagerImpl); unguarded it
             // would crash the servlet instead of refusing the fax. Answer "not denied HERE" so the

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -913,8 +913,10 @@ public class FrmCustomedPDFServlet extends HttpServlet {
      *   <li>{@code rxDate}: the latest {@code rx_date} among the script's drugs, in the page's
      *       {@code "MMMM d, yyyy"} format — the same "latest in the stash" rule the preview uses.</li>
      *   <li>Clinic block: the prescriber's clinic as {@code RxProviderData} resolves it (clinic
-     *       table, overridden by the prescriber's own rxAddress/rxPhone preferences), composed as
-     *       the preview composes its {@code clinicName}. The preview's other branch — a program
+     *       table, overridden by the prescriber's own rxAddress/rxPhone/faxnumber preferences),
+     *       composed as the preview composes its {@code clinicName}; the printed fax is the
+     *       clinic's official number, never the outgoing line the request names in
+     *       {@code clinicFax} (that value still selects the sending line in {@code service()}). The preview's other branch — a program
      *       address from an {@code infirmaryView_programAddress} attribute — has no remaining
      *       setter in CARLOS, so it is not reproduced here. A satellite clinic ({@code useSC=true})
      *       is honoured only when the posted {@code scAddress}
@@ -949,13 +951,12 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 + nz(clinic.getClinicCity()) + "   " + nz(clinic.getClinicPostal());
         bound.put("clinicName", clinicName);
         bound.put("clinicPhone", clinic == null ? "" : nz(clinic.getClinicPhone()));
-        // clinicFax is the sending line the prescriber picked from the fax_config lines the page
-        // lists, and the header prints it as the pharmacy's call-back number. The fax itself only
-        // goes out when that value matches a configured line (the dispatch loop in service()), but
-        // the PDF is rendered and spooled before that match, so render the line only when it IS a
-        // configured one; anything else prints no fax number rather than a number the caller typed.
-        // Not the clinic's own fax on purpose: the page deliberately shows the line the fax left from.
-        bound.put("clinicFax", configuredFaxLine(req.getParameter("clinicFax")));
+        // The header's "Fax:" is the clinic's OFFICIAL fax number -- the clinic row's fax, or the
+        // prescriber's own "faxnumber" preference, exactly as RxProviderData resolves it for the
+        // preview -- not the outgoing line. The request's clinicFax is the fax_config line the fax
+        // is SENT from; service() still reads that from the original request to pick the line, but
+        // an outgoing line is only that, and it must not print as the pharmacy's call-back number.
+        bound.put("clinicFax", clinic == null ? "" : nz(clinic.getClinicFax()));
 
         // useSC/scAddress select a satellite clinic block that generatePDFDocumentBytes parses INSTEAD
         // of clinicName/clinicPhone/clinicFax. The flag is ALWAYS rebound, never read: it is true
@@ -993,30 +994,6 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             bound.put("origPrintDate", "");
             bound.put("numPrints", "");
         }
-    }
-
-    /**
-     * The digits of {@code requested} when they name a configured fax line ({@code fax_config.faxNumber},
-     * the same match the dispatch loop in {@link #service} applies), otherwise {@code ""}.
-     */
-    private String configuredFaxLine(String requested) {
-        if (requested == null) {
-            return "";
-        }
-        String digits = requested.trim().replaceAll("\\D", "");
-        if (digits.isEmpty()) {
-            return "";
-        }
-        List<FaxConfig> lines = faxConfigDao.findAll(null, null);
-        if (lines == null) {
-            return "";
-        }
-        for (FaxConfig line : lines) {
-            if (digits.equals(line.getFaxNumber())) {
-                return digits;
-            }
-        }
-        return "";
     }
 
     private static String nz(String value) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -64,6 +64,7 @@ import io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData;
 import io.github.carlos_emr.carlos.prescript.util.RxUtil;
 import io.github.carlos_emr.carlos.providers.data.ProSignatureData;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
+import io.github.carlos_emr.carlos.commn.exception.PatientDirectiveException;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.DigitalSignatureManager;
@@ -914,13 +915,14 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         Demographic demographic;
         try {
             demographic = demographicManager.getDemographic(LoggedInInfo.getLoggedInInfoFromSession(req), demographicId);
-        } catch (RuntimeException e) {
-            // The manager's own privilege check rethrows PatientDirectiveException. resolveSignatureImage
-            // has already authorized this caller for this patient, so a refusal here is a consent
-            // directive on the demographic read, not an authorization failure; unguarded it would turn
-            // an otherwise valid fax into a 500 after the signature gate passed. The heading stays
-            // blank -- the same outcome as a missing row, and never the request's values.
-            logger.warn("Faxing prescription for demographic {} with a blank patient heading: the demographic could not be read",
+        } catch (PatientDirectiveException e) {
+            // The manager's read is gated by its own privilege check, which surfaces a consent directive
+            // as PatientDirectiveException. resolveSignatureImage has already authorized this caller for
+            // this patient on the same check, so this is defence in depth rather than an expected path;
+            // when it does fire, the heading stays blank -- the same outcome as a missing row, and never
+            // the request's values. ONLY that exception is absorbed: a database or wiring failure must
+            // abort the fax loudly, not send a prescription with no patient on it.
+            logger.warn("Faxing prescription for demographic {} with a blank patient heading: a directive refused the demographic read",
                     LogSafe.sanitize(String.valueOf(demographicId)), e);
             return;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -183,7 +183,8 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         // __method=oscarRxFax would be a token-free, cross-site-triggerable fax of a real patient's
         // prescription to an attacker's number. Refuse anything but POST before any of that runs.
         // The page's own Fax button submits a POST form, so nothing legitimate is turned away.
-        if (isFax && !"POST".equalsIgnoreCase(req.getMethod())) {
+        // Method tokens are case-sensitive (RFC 9110) and every browser sends "POST"; no case fold.
+        if (isFax && !"POST".equals(req.getMethod())) {
             res.setHeader("Allow", "POST");
             res.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Faxing a prescription requires POST");
             return;
@@ -761,16 +762,17 @@ public class FrmCustomedPDFServlet extends HttpServlet {
      * @param s String the HTML-formatted satellite clinic address
      * @return HashMap containing "clinicName", "clinicTel", and "clinicFax" entries
      */
-    private HashMap<String, String> parseSCAddress(String s) {
+    static HashMap<String, String> parseSCAddress(String s) {
         HashMap<String, String> hm = new HashMap<String, String>();
         String[] ar = s.split("</b>");
         String[] ar2 = ar[1].split("<br>");
         ArrayList<String> lst = new ArrayList<String>(Arrays.asList(ar2));
         lst.remove(0);
-        String tel = lst.get(3);
-        tel = tel.replace("Tel: ", "");
-        String fax = lst.get(4);
-        fax = fax.replace("Fax: ", "");
+        // The block carries the page's LOCALIZED labels ("Tel", "Tél", "Telefone"...) and the header
+        // adds its own localized label when it prints these, so strip whatever label precedes the
+        // first colon rather than the English ones only -- the French page used to fax "Tél: Tél: ...".
+        String tel = lst.get(3).replaceFirst("^[^:]*:\\s*", "");
+        String fax = lst.get(4).replaceFirst("^[^:]*:\\s*", "");
         String clinicName = lst.get(0) + "\n" + lst.get(1) + "\n" + lst.get(2);
         logger.debug("tel: {}", LogSafe.sanitize(tel));
         logger.debug("fax: {}", LogSafe.sanitize(fax));
@@ -947,30 +949,40 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 + nz(clinic.getClinicCity()) + "   " + nz(clinic.getClinicPostal());
         bound.put("clinicName", clinicName);
         bound.put("clinicPhone", clinic == null ? "" : nz(clinic.getClinicPhone()));
+        // clinicFax is the sending line the prescriber picked from the fax_config lines the page
+        // lists, and the header prints it as the pharmacy's call-back number. The fax itself only
+        // goes out when that value matches a configured line (the dispatch loop in service()), but
+        // the PDF is rendered and spooled before that match, so render the line only when it IS a
+        // configured one; anything else prints no fax number rather than a number the caller typed.
+        // Not the clinic's own fax on purpose: the page deliberately shows the line the fax left from.
+        bound.put("clinicFax", configuredFaxLine(req.getParameter("clinicFax")));
 
         // useSC/scAddress select a satellite clinic block that generatePDFDocumentBytes parses INSTEAD
-        // of clinicName/clinicPhone/clinicFax. Accept it only if it is a block this provider's page
-        // could have sent; otherwise switch the request to the main clinic bound above.
-        if ("true".equalsIgnoreCase(req.getParameter("useSC"))) {
-            String requested = RxSatelliteClinicAddress.clinicPart(req.getParameter("scAddress"));
+        // of clinicName/clinicPhone/clinicFax. The flag is ALWAYS rebound, never read: it is true
+        // exactly when scAddress is a block this provider's page could have sent, so neither a
+        // differently-cased flag nor a made-up block can reach parseSCAddress. Anything else renders
+        // the main clinic bound above.
+        boolean offered = false;
+        if (RxSatelliteClinicAddress.clinicPart(req.getParameter("scAddress")) != null) {
             LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(req);
             String user = loggedInInfo == null ? null : loggedInInfo.getLoggedInProviderNo();
             String tel = SafeEncode.forHtml(LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgTel"));
             String fax = SafeEncode.forHtml(LocaleUtils.getMessage(req.getLocale(), "RxPreview.msgFax"));
-            boolean offered = requested != null && RxSatelliteClinicAddress.blocksFor(user, tel, fax).stream()
-                    .map(RxSatelliteClinicAddress::clinicPart)
-                    .anyMatch(requested::equals);
+            offered = RxSatelliteClinicAddress.offers(RxSatelliteClinicAddress.blocksFor(user, tel, fax), req.getParameter("scAddress"));
             if (!offered) {
                 logger.warn("Fax for prescription {} named a satellite clinic block this provider is not offered; using the main clinic header",
                         LogSafe.sanitize(String.valueOf(prescription.getId())));
-                bound.put("useSC", "false");
-                bound.put("scAddress", "");
             }
+        }
+        bound.put("useSC", offered ? "true" : "false");
+        if (!offered) {
+            bound.put("scAddress", "");
         }
 
         // Reprint annotation. The preview decides "is this a reprint" from the session flag the
         // reprint action sets, and prints the first drug's stored print date and count.
-        boolean reprinting = session != null && "true".equalsIgnoreCase(String.valueOf(session.getAttribute("rePrint")));
+        // RxRePrescribe2Action stores the literal "true"; an exact compare needs no case fold.
+        boolean reprinting = session != null && "true".equals(session.getAttribute("rePrint"));
         RxPrescriptionData.Prescription first = recordDrugs.isEmpty() ? null : recordDrugs.get(0);
         if (reprinting && first != null && first.getPrintDate() != null) {
             bound.put("rxReprint", "true");
@@ -981,6 +993,30 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             bound.put("origPrintDate", "");
             bound.put("numPrints", "");
         }
+    }
+
+    /**
+     * The digits of {@code requested} when they name a configured fax line ({@code fax_config.faxNumber},
+     * the same match the dispatch loop in {@link #service} applies), otherwise {@code ""}.
+     */
+    private String configuredFaxLine(String requested) {
+        if (requested == null) {
+            return "";
+        }
+        String digits = requested.trim().replaceAll("\\D", "");
+        if (digits.isEmpty()) {
+            return "";
+        }
+        List<FaxConfig> lines = faxConfigDao.findAll(null, null);
+        if (lines == null) {
+            return "";
+        }
+        for (FaxConfig line : lines) {
+            if (digits.equals(line.getFaxNumber())) {
+                return digits;
+            }
+        }
+        return "";
     }
 
     private static String nz(String value) {
@@ -1216,14 +1252,16 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             return securityInfoManager.hasPrivilege(loggedInInfo, "_rx", SecurityInfoManager.READ, patient)
                     && (!securityInfoManager.hasPrivilege(loggedInInfo, "_rx", SecurityInfoManager.WRITE, patient)
                         || !securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", SecurityInfoManager.READ, patient));
-        } catch (RuntimeException e) {
+        } catch (PatientDirectiveException e) {
             // hasPrivilege rethrows PatientDirectiveException (SecurityInfoManagerImpl); unguarded it
             // would crash the servlet instead of refusing the fax. Answer "not denied HERE" so the
             // request falls through to resolveSignatureImage, whose own guard withholds the signature
             // and produces the generic "not signed" reply. Nothing is authorized by this answer — it
             // only declines to emit the specific permission wording, which is right under a directive:
-            // that wording would confirm the script exists.
-            logger.warn("Privilege check failed for the fax permission gate; deferring to the signature gate", e);
+            // that wording would confirm the script exists. ONLY the directive is absorbed: a database
+            // or wiring failure in the privilege lookup must abort the request, not let it proceed to
+            // the later gates as if the caller had simply lacked a privilege.
+            logger.warn("A directive refused the fax permission check; deferring to the signature gate", e);
             return false;
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -911,8 +911,19 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         // rx/Preview2.jsp reaches the same row through RxPatientData, which is a pass-through over
         // DemographicManager; going straight to the manager keeps the consent and audit behaviour
         // of the preview without RxPatientData's static bean plumbing.
-        Demographic demographic = demographicManager.getDemographic(LoggedInInfo.getLoggedInInfoFromSession(req),
-                demographicId);
+        Demographic demographic;
+        try {
+            demographic = demographicManager.getDemographic(LoggedInInfo.getLoggedInInfoFromSession(req), demographicId);
+        } catch (RuntimeException e) {
+            // The manager's own privilege check rethrows PatientDirectiveException. resolveSignatureImage
+            // has already authorized this caller for this patient, so a refusal here is a consent
+            // directive on the demographic read, not an authorization failure; unguarded it would turn
+            // an otherwise valid fax into a 500 after the signature gate passed. The heading stays
+            // blank -- the same outcome as a missing row, and never the request's values.
+            logger.warn("Faxing prescription for demographic {} with a blank patient heading: the demographic could not be read",
+                    LogSafe.sanitize(String.valueOf(demographicId)), e);
+            return;
+        }
         if (demographic == null) {
             logger.warn("Faxing prescription for demographic {} with a blank patient heading: its demographic row is missing",
                     LogSafe.sanitize(String.valueOf(demographicId)));

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddress.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddress.java
@@ -88,26 +88,29 @@ public final class RxSatelliteClinicAddress {
     }
 
     /**
-     * Whether {@code requestedBlock} is one of {@code offeredBlocks}, judged on the clinic part with
-     * HTML entities decoded on both sides. The page unescapes the chosen block before it puts it on
-     * the wire ({@code StringEscapeUtils.unescapeHtml4} in {@code ViewScript2.jsp}), so a clinic
-     * named "Smith &amp; Jones" arrives with a bare ampersand while the composed block still carries
-     * {@code &amp;amp;}; comparing the encoded text would reject every legitimately chosen clinic
-     * whose name or address needed encoding.
+     * The offered block that {@code requestedBlock} names, in the form the page puts on the wire, or
+     * {@code null} when it names none. Blocks are matched on the clinic part with HTML entities
+     * decoded on both sides: the page unescapes the chosen block before it puts it on the wire
+     * ({@code StringEscapeUtils.unescapeHtml4} in {@code ViewScript2.jsp}), so a clinic named
+     * "Smith &amp; Jones" arrives with a bare ampersand while the composed block still carries
+     * {@code &amp;amp;}, and comparing the encoded text would reject every legitimately chosen clinic
+     * whose name or address needed encoding. The caller must then render the RETURNED block, never
+     * the requested one: decoded matching accepts {@code &amp;#38;} for {@code &amp;}, and the request's
+     * spelling would otherwise reach the parser and print as entity text.
      */
-    public static boolean offers(List<String> offeredBlocks, String requestedBlock) {
+    public static String offeredBlock(List<String> offeredBlocks, String requestedBlock) {
         String requested = clinicPart(requestedBlock);
         if (requested == null || offeredBlocks == null) {
-            return false;
+            return null;
         }
         String wanted = StringEscapeUtils.unescapeHtml4(requested);
         for (String block : offeredBlocks) {
             String part = clinicPart(block);
             if (part != null && StringEscapeUtils.unescapeHtml4(part).equals(wanted)) {
-                return true;
+                return StringEscapeUtils.unescapeHtml4(block);
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddress.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddress.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.prescript.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.commn.IsPropertiesOn;
+import io.github.carlos_emr.carlos.commn.dao.SiteDao;
+import io.github.carlos_emr.carlos.commn.model.Site;
+import io.github.carlos_emr.carlos.utility.SafeEncode;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+
+/**
+ * The satellite-clinic address block a prescriber can put at the head of a printed or faxed
+ * prescription, in the one wire shape both ends of that exchange agree on.
+ *
+ * <p>{@code rx/ViewScript2.jsp} lists the prescriber's satellite clinics and, when one is chosen,
+ * sends its block to {@code FrmCustomedPDFServlet} as the {@code scAddress} parameter, which the
+ * servlet parses back into clinic name, address, telephone and fax for the page header. The block
+ * is therefore a wire format, not presentation: the page must compose it exactly as the servlet
+ * splits it (bold prescriber name, then {@code <br>}-separated lines), and the servlet must be able
+ * to recompute the set of blocks the page could legitimately have sent, because {@code scAddress}
+ * is a request parameter and an outbound fax must not carry a clinic header the caller typed.
+ * Keeping the composition and the candidate list here, used by both, is what stops the two from
+ * drifting apart.</p>
+ *
+ * @since 2026-09-05
+ */
+public final class RxSatelliteClinicAddress {
+
+    private RxSatelliteClinicAddress() {
+    }
+
+    /**
+     * Composes one satellite clinic block: {@code <b>prescriber</b><br>name<br>address<br>city,
+     * province postal<br>Tel: phone<br>Fax: fax}. Every clinic value is HTML-encoded here; the
+     * prescriber name and the two labels arrive already encoded because the page localizes and
+     * encodes them once for all of its blocks.
+     */
+    public static String html(String encodedDoctorName, String name, String address, String city, String province,
+                              String postal, String phone, String fax, String encodedTelLabel, String encodedFaxLabel) {
+        return "<b>" + nz(encodedDoctorName) + "</b><br>"
+                + SafeEncode.forHtml(nz(name)) + "<br>"
+                + SafeEncode.forHtml(nz(address)) + "<br>"
+                + SafeEncode.forHtml(nz(city)) + ", "
+                + SafeEncode.forHtml(nz(province)) + " "
+                + SafeEncode.forHtml(nz(postal)) + "<br>"
+                + nz(encodedTelLabel) + ": "
+                + SafeEncode.forHtml(nz(phone)) + "<br>"
+                + nz(encodedFaxLabel) + ": "
+                + SafeEncode.forHtml(nz(fax));
+    }
+
+    /**
+     * The clinic part of a block — everything after the bold prescriber name — which is all the
+     * servlet's parser reads and therefore all that identifies a satellite clinic. {@code null} when
+     * the value is not a block at all.
+     */
+    public static String clinicPart(String block) {
+        if (block == null) {
+            return null;
+        }
+        int end = block.indexOf("</b>");
+        return end < 0 ? null : block.substring(end + "</b>".length());
+    }
+
+    /**
+     * The blocks {@code rx/ViewScript2.jsp} offers the given provider, from the same two sources and
+     * in the same order it reads them: the provider's active {@link Site}s when multisites is on,
+     * otherwise the {@code clinicSatellite*} properties. Empty when neither is configured, in which
+     * case the page shows no satellite selector and no {@code scAddress} is legitimate.
+     *
+     * @param providerNo the logged-in provider the page lists satellite clinics for
+     * @param encodedTelLabel the localized, HTML-encoded telephone label the page used
+     * @param encodedFaxLabel the localized, HTML-encoded fax label the page used
+     */
+    public static List<String> blocksFor(String providerNo, String encodedTelLabel, String encodedFaxLabel) {
+        List<String> blocks = new ArrayList<>();
+        if (IsPropertiesOn.isMultisitesEnable()) {
+            SiteDao siteDao = SpringUtils.getBean(SiteDao.class);
+            List<Site> sites = siteDao == null || providerNo == null ? List.of() : siteDao.getActiveSitesByProviderNo(providerNo);
+            for (Site s : sites) {
+                blocks.add(html("", s.getName(), s.getAddress(), s.getCity(), s.getProvince(), s.getPostal(),
+                        s.getPhone(), s.getFax(), encodedTelLabel, encodedFaxLabel));
+            }
+            return blocks;
+        }
+        CarlosProperties props = CarlosProperties.getInstance();
+        if (props.getProperty("clinicSatelliteName") == null) {
+            return blocks;
+        }
+        String[] names = split(props, "clinicSatelliteName");
+        String[] addresses = split(props, "clinicSatelliteAddress");
+        String[] cities = split(props, "clinicSatelliteCity");
+        String[] provinces = split(props, "clinicSatelliteProvince");
+        String[] postals = split(props, "clinicSatellitePostal");
+        String[] phones = split(props, "clinicSatellitePhone");
+        String[] faxes = split(props, "clinicSatelliteFax");
+        for (int i = 0; i < names.length; i++) {
+            blocks.add(html("", names[i], at(addresses, i), at(cities, i), at(provinces, i), at(postals, i),
+                    at(phones, i), at(faxes, i), encodedTelLabel, encodedFaxLabel));
+        }
+        return blocks;
+    }
+
+    private static String[] split(CarlosProperties props, String key) {
+        String value = props.getProperty(key);
+        return (value == null ? "" : value).split("\\|");
+    }
+
+    /** The page indexes every property list by the name list's index; a shorter list reads as blank. */
+    private static String at(String[] values, int i) {
+        return i < values.length ? values[i] : "";
+    }
+
+    private static String nz(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddress.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddress.java
@@ -24,6 +24,8 @@ package io.github.carlos_emr.carlos.prescript.data;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.IsPropertiesOn;
 import io.github.carlos_emr.carlos.commn.dao.SiteDao;
@@ -86,6 +88,29 @@ public final class RxSatelliteClinicAddress {
     }
 
     /**
+     * Whether {@code requestedBlock} is one of {@code offeredBlocks}, judged on the clinic part with
+     * HTML entities decoded on both sides. The page unescapes the chosen block before it puts it on
+     * the wire ({@code StringEscapeUtils.unescapeHtml4} in {@code ViewScript2.jsp}), so a clinic
+     * named "Smith &amp; Jones" arrives with a bare ampersand while the composed block still carries
+     * {@code &amp;amp;}; comparing the encoded text would reject every legitimately chosen clinic
+     * whose name or address needed encoding.
+     */
+    public static boolean offers(List<String> offeredBlocks, String requestedBlock) {
+        String requested = clinicPart(requestedBlock);
+        if (requested == null || offeredBlocks == null) {
+            return false;
+        }
+        String wanted = StringEscapeUtils.unescapeHtml4(requested);
+        for (String block : offeredBlocks) {
+            String part = clinicPart(block);
+            if (part != null && StringEscapeUtils.unescapeHtml4(part).equals(wanted)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * The blocks {@code rx/ViewScript2.jsp} offers the given provider, from the same two sources and
      * in the same order it reads them: the provider's active {@link Site}s when multisites is on,
      * otherwise the {@code clinicSatellite*} properties. Empty when neither is configured, in which
@@ -129,9 +154,14 @@ public final class RxSatelliteClinicAddress {
         return (value == null ? "" : value).split("\\|");
     }
 
-    /** The page indexes every property list by the name list's index; a shorter list reads as blank. */
-    private static String at(String[] values, int i) {
-        return i < values.length ? values[i] : "";
+    /**
+     * The {@code i}-th entry of one split {@code clinicSatellite*} property, or {@code ""} when that
+     * list is shorter than the name list it is indexed by. The page and {@link #blocksFor} both index
+     * every property list by the name list's index, so a list with fewer entries must read as blank
+     * rather than throw and take the prescription page down with it.
+     */
+    public static String at(String[] values, int i) {
+        return values != null && i < values.length ? values[i] : "";
     }
 
     private static String nz(String value) {

--- a/src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp
@@ -373,8 +373,15 @@
 
                                             request.setAttribute("phone", finalPhone);
                                         %>
+                                        <%-- clinicTitle joins its lines with <br>; the PDF wants real line breaks. This is a
+                                             tag ATTRIBUTE, and the JSP spec unescapes "\\" to "\" inside attribute values, so the
+                                             former replaceAll("(<br>)", "\\\n") reached Java as "\\n": a replacement string of
+                                             backslash + n, which regex replacement reads as an escaped literal 'n'. Every <br>
+                                             became the letter n and the faxed clinic header rendered as one glued line
+                                             ("ClinicnAddressnCity"). A literal replace with a plain "\n" has no escaping layer
+                                             to fall through. --%>
                                         <input type="hidden" name="clinicName"
-                                               value="<carlos:encode value='<%= clinicTitle.replaceAll("(<br>)","\\\n") %>' context="htmlAttribute"/>"/>
+                                               value="<carlos:encode value='<%= clinicTitle.replace("<br>", "\n") %>' context="htmlAttribute"/>"/>
                                         <input type="hidden" name="clinicPhone"
                                                value="<carlos:encode value='<%= finalPhone %>' context="htmlAttribute"/>"/>
                                         <input type="hidden" id="finalFax" name="clinicFax" value=""/>

--- a/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
@@ -39,6 +39,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.DigitalSignatureUtils" %>
+<%@ page import="io.github.carlos_emr.carlos.prescript.data.RxSatelliteClinicAddress" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.ui.servlet.ImageRenderingServlet" %>
 <%! boolean bMultisites = IsPropertiesOn.isMultisitesEnable(); %>
@@ -205,16 +206,11 @@
                 for (int i = 0; i < sites.size(); i++) {
                     Site s = sites.get(i);
                     vecAddressName.add(s.getName());
-                    String addressHtml = "<b>" + encodedDoctorName + "</b><br>"
-                            + SafeEncode.forHtml(s.getName()) + "<br>"
-                            + SafeEncode.forHtml(s.getAddress()) + "<br>"
-                            + SafeEncode.forHtml(s.getCity()) + ", "
-                            + SafeEncode.forHtml(s.getProvince()) + " "
-                            + SafeEncode.forHtml(s.getPostal()) + "<br>"
-                            + encodedTelLabel + ": "
-                            + SafeEncode.forHtml(s.getPhone()) + "<br>"
-                            + encodedFaxLabel + ": "
-                            + SafeEncode.forHtml(s.getFax());
+                    // One composer for this block on both ends: FrmCustomedPDFServlet parses the
+                    // chosen block back out of scAddress AND recomputes the blocks this provider was
+                    // offered, so a fax cannot carry a clinic header the request made up.
+                    String addressHtml = RxSatelliteClinicAddress.html(encodedDoctorName, s.getName(), s.getAddress(),
+                            s.getCity(), s.getProvince(), s.getPostal(), s.getPhone(), s.getFax(), encodedTelLabel, encodedFaxLabel);
                     vecAddress.add(addressHtml);
                     if (s.getName().equals(location))
                         session.setAttribute("RX_ADDR", String.valueOf(i));
@@ -252,16 +248,8 @@
 
                 for (int i = 0; i < temp0.length; i++) {
                     vecAddressName.add(temp0[i]);
-                    String addressHtml = "<b>" + encodedDoctorName + "</b><br>"
-                            + SafeEncode.forHtml(temp0[i]) + "<br>"
-                            + SafeEncode.forHtml(temp1[i]) + "<br>"
-                            + SafeEncode.forHtml(temp2[i]) + ", "
-                            + SafeEncode.forHtml(temp3[i]) + " "
-                            + SafeEncode.forHtml(temp4[i]) + "<br>"
-                            + encodedTelLabel + ": "
-                            + SafeEncode.forHtml(temp5[i]) + "<br>"
-                            + encodedFaxLabel + ": "
-                            + SafeEncode.forHtml(temp6[i]);
+                    String addressHtml = RxSatelliteClinicAddress.html(encodedDoctorName, temp0[i], temp1[i], temp2[i],
+                            temp3[i], temp4[i], temp5[i], temp6[i], encodedTelLabel, encodedFaxLabel);
                     vecAddress.add(addressHtml);
                 }
             }
@@ -373,20 +361,24 @@
                 <%}
             }%>
                 let action = "<%= request.getContextPath() %>/form/createcustomedpdf?__title=Rx&__method=" + method + "&useSC=" + useSC + "&scAddress=" + scAddress + "&rxPageSize=" + rxPageSize + "&scriptId=" + scriptId;
-                document.getElementById("preview").contentWindow.document.getElementById("preview2Form").action = action;
-                if (method !== "oscarRxFax") {
-                    document.getElementById("preview").contentWindow.document.getElementById("preview2Form").target = "_blank";
-                }
                 var previewForm = document.getElementById("preview").contentWindow.document.getElementById("preview2Form");
+                previewForm.action = action;
                 if (method === "oscarRxFax") {
                     // Only the fax waits. A print renders additNotes from the request, which
                     // addNotes() already updated synchronously, so there is nothing to wait for --
                     // and deferring a target="_blank" submit out of the click's user-gesture context
                     // would hand it to the popup blocker.
                     pendingNotesSave.then(function () {
+                        // Set the target at submit time, not click time: a print in the same modal
+                        // leaves target="_blank" on this shared form, and the fax must post back into
+                        // the modal, never open a tab. Doing it here also covers a print that lands
+                        // while this fax is still waiting on the notes save.
+                        previewForm.target = "";
+                        previewForm.action = action;
                         previewForm.submit();
                     });
                 } else {
+                    previewForm.target = "_blank";
                     previewForm.submit();
                 }
 

--- a/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
@@ -248,8 +248,12 @@
 
                 for (int i = 0; i < temp0.length; i++) {
                     vecAddressName.add(temp0[i]);
-                    String addressHtml = RxSatelliteClinicAddress.html(encodedDoctorName, temp0[i], temp1[i], temp2[i],
-                            temp3[i], temp4[i], temp5[i], temp6[i], encodedTelLabel, encodedFaxLabel);
+                    // Every list is indexed by the name list; a shorter one reads as blank (RxSatelliteClinicAddress.at).
+                    String addressHtml = RxSatelliteClinicAddress.html(encodedDoctorName, temp0[i],
+                            RxSatelliteClinicAddress.at(temp1, i), RxSatelliteClinicAddress.at(temp2, i),
+                            RxSatelliteClinicAddress.at(temp3, i), RxSatelliteClinicAddress.at(temp4, i),
+                            RxSatelliteClinicAddress.at(temp5, i), RxSatelliteClinicAddress.at(temp6, i),
+                            encodedTelLabel, encodedFaxLabel);
                     vecAddress.add(addressHtml);
                 }
             }

--- a/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
@@ -347,6 +347,17 @@
             }
 
 
+            /*
+             * The most recent Additional Notes save, so a fax can wait for it. A fax renders
+             * additNotes from the STORED prescription row (FrmCustomedPDFServlet.bindFaxContentToRecord
+             * replaces the posted value, deliberately, so a caller cannot print arbitrary text above
+             * another prescriber's signature). addNotes() saves that row with a fire-and-forget
+             * fetch, and the textarea's own onchange fires as focus leaves it for the Fax button --
+             * so without this the fax POST races the save, and a note the clinician just typed, and
+             * can still see in the preview, is silently absent from the outgoing fax.
+             */
+            var pendingNotesSave = Promise.resolve();
+
             function onPrint2(method, scriptId) {
                 var useSC = false;
                 var scAddress = "";
@@ -366,7 +377,18 @@
                 if (method !== "oscarRxFax") {
                     document.getElementById("preview").contentWindow.document.getElementById("preview2Form").target = "_blank";
                 }
-                document.getElementById("preview").contentWindow.document.getElementById("preview2Form").submit();
+                var previewForm = document.getElementById("preview").contentWindow.document.getElementById("preview2Form");
+                if (method === "oscarRxFax") {
+                    // Only the fax waits. A print renders additNotes from the request, which
+                    // addNotes() already updated synchronously, so there is nothing to wait for --
+                    // and deferring a target="_blank" submit out of the click's user-gesture context
+                    // would hand it to the popup blocker.
+                    pendingNotesSave.then(function () {
+                        previewForm.submit();
+                    });
+                } else {
+                    previewForm.submit();
+                }
 
                 return true;
             }
@@ -397,11 +419,17 @@
                 var ran_number = Math.round(Math.random() * 1000000);
                 var comment = encodeURIComponent(document.getElementById('additionalNotes').value);
                 var params = "scriptNo=<%=request.getAttribute("scriptId")%>&comment=" + comment + "&rand=" + ran_number;  //]
-                fetch(url, {
+                // Keep the promise so onPrint2 can await it before faxing. The catch keeps a failed
+                // save from leaving a permanently rejected promise that would block every later fax;
+                // a fax that then goes out carries the previously stored note, which is the same
+                // outcome as before this call was made awaitable.
+                pendingNotesSave = fetch(url, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest', 'CSRF-TOKEN': getCsrfToken()},
                     credentials: 'same-origin',
                     body: params
+                }).catch(function (e) {
+                    console.warn('Additional notes save failed; faxing the stored note', e);
                 });
                 var additNotesEl = frames['preview'].document.getElementById('additNotes');
                 additNotesEl.style.whiteSpace = 'pre-wrap';

--- a/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
@@ -419,15 +419,29 @@
                 var ran_number = Math.round(Math.random() * 1000000);
                 var comment = encodeURIComponent(document.getElementById('additionalNotes').value);
                 var params = "scriptNo=<%=request.getAttribute("scriptId")%>&comment=" + comment + "&rand=" + ran_number;  //]
-                // Keep the promise so onPrint2 can await it before faxing. The catch keeps a failed
-                // save from leaving a permanently rejected promise that would block every later fax;
-                // a fax that then goes out carries the previously stored note, which is the same
-                // outcome as before this call was made awaitable.
-                pendingNotesSave = fetch(url, {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest', 'CSRF-TOKEN': getCsrfToken()},
-                    credentials: 'same-origin',
-                    body: params
+                // CHAIN onto the previous save, never replace it. Two edits in quick succession
+                // (type, blur, type, blur) would otherwise leave pendingNotesSave holding only the
+                // second request: if that one resolved first the fax would submit while the first
+                // was still in flight, and the first committing afterwards would overwrite the row
+                // with the older note -- the same stale-note fax this is meant to prevent, just
+                // harder to see. Chaining serializes the writes AND makes the fax await all of them.
+                //
+                // A non-2xx is a failed save: fetch() only rejects on network errors, so a CSRF
+                // rejection or a 500 would otherwise resolve and let the fax race ahead silently.
+                // The trailing catch keeps the chain usable -- an unrecovered rejection would block
+                // every later fax on this page -- and a fax that proceeds after one carries the
+                // previously stored note, the same outcome as before this was made awaitable.
+                pendingNotesSave = pendingNotesSave.then(function () {
+                    return fetch(url, {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest', 'CSRF-TOKEN': getCsrfToken()},
+                        credentials: 'same-origin',
+                        body: params
+                    }).then(function (response) {
+                        if (!response.ok) {
+                            throw new Error('ViewAddRxComment returned HTTP ' + response.status);
+                        }
+                    });
                 }).catch(function (e) {
                     console.warn('Additional notes save failed; faxing the stored note', e);
                 });

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -70,7 +70,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -247,7 +246,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
 
             assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             assertThat(response.getContentAsString()).contains("Unable to generate fax");
-            verify(faxJobDao, never()).persist(any()); // binding reads fax lines; dispatch never ran
+            verify(faxConfigDao, never()).findAll(any(), any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
         }
@@ -285,7 +284,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(documentDir.resolve("prescription_rx-123.pdf")).exists();
             assertThat(faxDir.resolve("prescription_rx-123.pdf")).exists();
             assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
-            verify(faxConfigDao, atLeastOnce()).findAll(any(), any());
+            verify(faxConfigDao).findAll(any(), any());
             verify(faxJobDao, never()).persist(any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
@@ -327,7 +326,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(existingPdf).hasContent("existing pdf");
             assertThat(faxDir.resolve("prescription_rx-123.pdf")).hasContent("existing pdf");
             assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
-            verify(faxConfigDao, atLeastOnce()).findAll(any(), any());
+            verify(faxConfigDao).findAll(any(), any());
             verify(faxJobDao, never()).persist(any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
@@ -366,7 +365,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             assertThat(response.getContentAsString()).contains("Unable to generate fax");
             assertThat(faxDir.resolve("prescription_rx-123.txt")).isDirectory();
-            verify(faxJobDao, never()).persist(any()); // binding reads fax lines; dispatch never ran
+            verify(faxConfigDao, never()).findAll(any(), any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
             restoreProperty("fax_file_location", previousFaxFileLocation);
@@ -1333,18 +1332,21 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should print the sending fax line only when it is a configured fax_config line")
-    void shouldBindClinicFax_toConfiguredLineOnly() throws Exception {
-        MockHttpServletRequest request = createFaxRequest(); // clinicFax 4165553434
+    @DisplayName("should print the clinic's official fax, never the outgoing line the request names")
+    void shouldBindClinicFax_toClinicOfficialFax() throws Exception {
+        MockHttpServletRequest request = createFaxRequest(); // clinicFax 4165553434 = the sending line
         stubStoredSignature();
-        FaxConfig line = new FaxConfig();
-        line.setFaxNumber("4165553434");
-        when(faxConfigDao.findAll(any(), any())).thenReturn(List.of(line));
+        stubPrescriberClinic(); // clinic row fax 9055550009
 
-        assertThat(new FrmCustomedPDFServlet().bindFaxContentToRecord(request).getParameter("clinicFax")).isEqualTo("4165553434");
+        assertThat(new FrmCustomedPDFServlet().bindFaxContentToRecord(request).getParameter("clinicFax")).isEqualTo("9055550009");
 
-        request.setParameter("clinicFax", "(416) 555-9999");
-        assertThat(new FrmCustomedPDFServlet().bindFaxContentToRecord(request).getParameter("clinicFax")).isEmpty();
+        // The prescriber's own faxnumber preference wins over the clinic row, as on the preview.
+        UserProperty faxPreference = new UserProperty();
+        faxPreference.setProviderNo("999998");
+        faxPreference.setName("faxnumber");
+        faxPreference.setValue("9055551234");
+        when(userPropertyDao.getProp("999998", "faxnumber")).thenReturn(faxPreference);
+        assertThat(new FrmCustomedPDFServlet().bindFaxContentToRecord(request).getParameter("clinicFax")).isEqualTo("9055551234");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -1304,7 +1304,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should keep a satellite clinic block the provider was offered")
     void shouldKeepSatelliteClinic_whenBlockIsOffered() throws Exception {
-        String previousMultisites = CarlosProperties.getInstance().getProperty("multisites");
+        String previousMultisites = (String) CarlosProperties.getInstance().get("multisites");
         MockHttpServletRequest request = createFaxRequest();
         stubStoredSignature();
         stubPrescriberClinic();
@@ -1333,7 +1333,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should fall back to the main clinic when the satellite block was never offered")
     void shouldDropSatelliteClinic_whenBlockIsNotOffered() throws Exception {
-        String previousMultisites = CarlosProperties.getInstance().getProperty("multisites");
+        String previousMultisites = (String) CarlosProperties.getInstance().get("multisites");
         MockHttpServletRequest request = createFaxRequest();
         stubStoredSignature();
         stubPrescriberClinic();

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -1325,7 +1325,10 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
 
             assertThat(bound.getParameter("useSC")).isEqualTo("true");
-            assertThat(bound.getParameter("scAddress")).isEqualTo(offered);
+            // The bound block is the OFFERED one (the prescriber-name prefix is not part of the match
+            // and not rendered); its clinic part is what parseSCAddress reads.
+            assertThat(RxSatelliteClinicAddress.clinicPart(bound.getParameter("scAddress")))
+                    .isEqualTo(RxSatelliteClinicAddress.clinicPart(offered));
         } finally {
             restoreProperty("multisites", previousMultisites);
         }
@@ -1375,7 +1378,42 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
 
             assertThat(bound.getParameter("useSC")).isEqualTo("true");
-            assertThat(bound.getParameter("scAddress")).isEqualTo(posted);
+            assertThat(RxSatelliteClinicAddress.clinicPart(bound.getParameter("scAddress")))
+                    .isEqualTo(RxSatelliteClinicAddress.clinicPart(posted));
+        } finally {
+            restoreProperty("multisites", previousMultisites);
+        }
+    }
+
+    @Test
+    @DisplayName("should render the offered block, not the request's entity-spelled copy of it")
+    void shouldRenderOfferedBlock_whenRequestSpellsItWithEntities() throws Exception {
+        String previousMultisites = (String) CarlosProperties.getInstance().get("multisites");
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        stubPrescriberClinic();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        Site site = northSite();
+        site.setName("Smith & Jones");
+        String wire = org.apache.commons.text.StringEscapeUtils.unescapeHtml4(RxSatelliteClinicAddress.html("Dr A",
+                "Smith & Jones", "2 North Ave", "Barrie", "ON", "L4M 1A1", "7055551111", "7055552222", telLabel(request), faxLabel(request)));
+        // Same clinic, but the ampersand spelled as a numeric entity: it matches after decoding, yet
+        // this spelling must never reach the parser and print as "&#38;".
+        request.setParameter("useSC", "true");
+        request.setParameter("scAddress", wire.replace("Smith & Jones", "Smith &#38; Jones"));
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            CarlosProperties.getInstance().setProperty("multisites", "true");
+            when(siteDao.getActiveSitesByProviderNo("999998")).thenReturn(List.of(site));
+
+            HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+            assertThat(bound.getParameter("useSC")).isEqualTo("true");
+            assertThat(RxSatelliteClinicAddress.clinicPart(bound.getParameter("scAddress")))
+                    .isEqualTo(RxSatelliteClinicAddress.clinicPart(wire)).contains("Smith & Jones").doesNotContain("&#38;");
         } finally {
             restoreProperty("multisites", previousMultisites);
         }

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.utility.LocaleUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -565,7 +566,10 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         assertThat(bound.getParameter("patientHIN")).isEqualTo("1234567890");
         assertThat(bound.getParameter("patientAddress")).isEqualTo("1 Record Lane");
         assertThat(bound.getParameter("patientCityPostal")).isEqualTo("Hamilton, ON L8S 4L8");
-        assertThat(bound.getParameter("patientPhone")).endsWith("9055550101").doesNotContain("4165559999");
+        // The label is whatever RxPreview.msgTel resolves to on this classpath (the key itself when the
+        // bundle is absent); resolving it the way production does keeps the assertion exact either way.
+        assertThat(bound.getParameter("patientPhone"))
+                .isEqualTo(LocaleUtils.getMessage(request.getLocale(), "RxPreview.msgTel") + ": 9055550101");
         // Never populated by the Rx preview, so the only thing it could carry is chosen text.
         assertThat(bound.getParameter("patientChartNo")).isEmpty();
     }
@@ -587,6 +591,23 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         assertThat(bound.getParameter("patientHIN")).isEmpty();
         assertThat(bound.getParameter("patientAddress")).isEmpty();
         assertThat(bound.getParameter("patientCityPostal")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should blank the patient heading, not fail the fax, when the demographic read is refused")
+    void shouldBlankPatientIdentity_whenDemographicReadThrows() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        request.setParameter("patientName", "Someone Else");
+        stubStoredSignature();
+        // DemographicManager rethrows PatientDirectiveException from its own privilege check; after the
+        // signature gate has passed, that must not surface as a 500 -- and must not fall back to the request.
+        when(demographicManager.getDemographic(any(), eq(DEMOGRAPHIC_NO))).thenThrow(new RuntimeException("directive"));
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound).isNotNull();
+        assertThat(bound.getParameter("patientName")).isEmpty();
+        assertThat(bound.getParameter("rx")).contains("Amoxicillin 500 mg capsule");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -16,14 +16,17 @@ import io.github.carlos_emr.carlos.commn.dao.PrescriptionDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderExtDao;
 import io.github.carlos_emr.carlos.casemgmt.model.ProviderExt;
 import io.github.carlos_emr.carlos.commn.model.Drug;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.commn.exception.PatientDirectiveException;
 import io.github.carlos_emr.carlos.commn.model.Prescription;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.DigitalSignatureManager;
 import io.github.carlos_emr.carlos.managers.FaxManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LocaleUtils;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import io.github.carlos_emr.carlos.web.PrescriptionQrCodeUIBean;
@@ -37,9 +40,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
-import io.github.carlos_emr.carlos.commn.model.Demographic;
-import io.github.carlos_emr.carlos.managers.DemographicManager;
-import io.github.carlos_emr.carlos.utility.LocaleUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -57,6 +57,7 @@ import java.util.GregorianCalendar;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -594,20 +595,33 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should blank the patient heading, not fail the fax, when the demographic read is refused")
-    void shouldBlankPatientIdentity_whenDemographicReadThrows() throws Exception {
+    @DisplayName("should blank the patient heading, not fail the fax, when a directive refuses the demographic read")
+    void shouldBlankPatientIdentity_whenDirectiveRefusesDemographicRead() throws Exception {
         MockHttpServletRequest request = createFaxRequest();
         request.setParameter("patientName", "Someone Else");
         stubStoredSignature();
-        // DemographicManager rethrows PatientDirectiveException from its own privilege check; after the
-        // signature gate has passed, that must not surface as a 500 -- and must not fall back to the request.
-        when(demographicManager.getDemographic(any(), eq(DEMOGRAPHIC_NO))).thenThrow(new RuntimeException("directive"));
+        // getDemographic declares PatientDirectiveException from its own privilege check. After the
+        // signature gate has passed that must not surface as a 500 -- and must not fall back to the request.
+        when(demographicManager.getDemographic(any(), eq(DEMOGRAPHIC_NO))).thenThrow(new PatientDirectiveException("directive"));
 
         HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
 
         assertThat(bound).isNotNull();
         assertThat(bound.getParameter("patientName")).isEmpty();
         assertThat(bound.getParameter("rx")).contains("Amoxicillin 500 mg capsule");
+    }
+
+    @Test
+    @DisplayName("should abort the fax, not send a blank heading, when the demographic read fails for any other reason")
+    void shouldPropagateFailure_whenDemographicReadFailsUnexpectedly() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        // A database or wiring failure is not a directive. Absorbing it would fax a prescription with no
+        // patient on it while masking an outage; it must propagate and stop the fax.
+        when(demographicManager.getDemographic(any(), eq(DEMOGRAPHIC_NO))).thenThrow(new IllegalStateException("datasource down"));
+
+        assertThatThrownBy(() -> new FrmCustomedPDFServlet().bindFaxContentToRecord(request))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -50,6 +52,7 @@ import javax.imageio.ImageIO;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.GregorianCalendar;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,6 +84,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     private SecurityInfoManager securityInfoManager;
     private DrugDao drugDao;
     private ProviderExtDao providerExtDao;
+    private DemographicManager demographicManager;
 
     @BeforeEach
     void setUp() {
@@ -97,6 +101,8 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         registerMock(ClinicDAO.class, mock(ClinicDAO.class));
         registerMock(ProviderDao.class, mock(ProviderDao.class));
         registerMock(DemographicDao.class, mock(DemographicDao.class));
+        demographicManager = mock(DemographicManager.class);
+        registerMock(DemographicManager.class, demographicManager);
         registerMock(PrescriptionDao.class, prescriptionDao);
         drugDao = mock(DrugDao.class);
         registerMock(DrugDao.class, drugDao);
@@ -512,6 +518,113 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         assertThat(blocks.get(0)).contains("Amoxicillin 500 mg").contains(nl + "1" + nl).contains("cap PO TID");
         assertThat(blocks.get(1)).contains("Ibuprofen 400 mg").doesNotContain("1 tab PRN");
         assertThat(blocks.get(2)).contains("1 tab PRN");
+    }
+
+    /**
+     * The demographic row of patient {@value #DEMOGRAPHIC_NO}, as the record holds it. Every value
+     * here is deliberately different from what {@link #createFaxRequest()} posts, so an assertion
+     * that finds the record's value proves the binding rather than a coincidence.
+     */
+    private void stubRecordDemographic() {
+        Demographic demographic = new Demographic();
+        demographic.setDemographicNo(DEMOGRAPHIC_NO);
+        demographic.setFirstName("Real");
+        demographic.setLastName("Patient");
+        demographic.setAddress("1 Record Lane");
+        demographic.setCity("Hamilton");
+        demographic.setProvince("ON");
+        demographic.setPostal("L8S 4L8");
+        demographic.setPhone("9055550101");
+        demographic.setHin("1234567890");
+        demographic.setBirthDay(new GregorianCalendar(1980, 2, 4));
+        when(demographicManager.getDemographic(any(), eq(DEMOGRAPHIC_NO))).thenReturn(demographic);
+    }
+
+    @Test
+    @DisplayName("should fax the patient identity of the prescription record, not the request")
+    void shouldBindPatientIdentity_toPrescriptionDemographic() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        // A caller who legitimately holds _rx write on this patient posts someone else's identity
+        // alongside the signed script's id. The verified drugs and stored signature must never go
+        // out under it.
+        request.setParameter("patientName", "Someone Else");
+        request.setParameter("patientDOB", "Jan 1, 1900");
+        request.setParameter("patientHIN", "9999999999");
+        request.setParameter("patientAddress", "999 Attacker Ave");
+        request.setParameter("patientCityPostal", "Nowhere ZZ");
+        request.setParameter("patientPhone", "Tel: 4165559999");
+        request.setParameter("patientChartNo", "INJECTED");
+        stubStoredSignature();
+        stubRecordDemographic();
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound).isNotNull();
+        assertThat(bound.getParameter("patientName")).isEqualTo("Real Patient");
+        assertThat(bound.getParameter("patientDOB")).isEqualTo("Mar 4, 1980");
+        assertThat(bound.getParameter("patientHIN")).isEqualTo("1234567890");
+        assertThat(bound.getParameter("patientAddress")).isEqualTo("1 Record Lane");
+        assertThat(bound.getParameter("patientCityPostal")).isEqualTo("Hamilton, ON L8S 4L8");
+        assertThat(bound.getParameter("patientPhone")).endsWith("9055550101").doesNotContain("4165559999");
+        // Never populated by the Rx preview, so the only thing it could carry is chosen text.
+        assertThat(bound.getParameter("patientChartNo")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should blank the patient heading when the prescription's demographic row is missing")
+    void shouldBlankPatientIdentity_whenDemographicRowMissing() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        request.setParameter("patientName", "Someone Else");
+        request.setParameter("patientHIN", "9999999999");
+        stubStoredSignature();
+        when(demographicManager.getDemographic(any(), eq(DEMOGRAPHIC_NO))).thenReturn(null);
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound).isNotNull();
+        // Absent data prints as absent. Falling back to the request would be the very bypass.
+        assertThat(bound.getParameter("patientName")).isEmpty();
+        assertThat(bound.getParameter("patientHIN")).isEmpty();
+        assertThat(bound.getParameter("patientAddress")).isEmpty();
+        assertThat(bound.getParameter("patientCityPostal")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should compose the city line the way the Rx preview does, by which parts are present")
+    void shouldComposeCityPostal_byWhichPartsArePresent() {
+        assertThat(FrmCustomedPDFServlet.formatCityPostal("Hamilton", "ON", "L8S 4L8")).isEqualTo("Hamilton, ON L8S 4L8");
+        assertThat(FrmCustomedPDFServlet.formatCityPostal("", "ON", "L8S 4L8")).isEqualTo("ON L8S 4L8");
+        assertThat(FrmCustomedPDFServlet.formatCityPostal("Hamilton", "", "L8S 4L8")).isEqualTo("Hamilton  L8S 4L8");
+    }
+
+    @Test
+    @DisplayName("should keep a one-character prescription line in the rendered fax body")
+    void shouldKeepOneCharacterLine_whenSplittingRenderedBlocks() {
+        String nl = System.lineSeparator();
+        // The record-bound fax body is written server-side with plain platform newlines, so a
+        // standalone dose line is a real line, not the CRLF remnant the separator test looks for.
+        String body = "Amoxicillin 500 mg" + nl + "1" + nl + "cap PO TID" + nl + nl + "Ibuprofen 400 mg" + nl + nl;
+
+        List<String> blocks = FrmCustomedPDFServlet.splitRenderedRxBlocks(body, nl);
+
+        assertThat(blocks).hasSize(2);
+        assertThat(blocks.get(0)).contains("Amoxicillin 500 mg").contains("1").contains("cap PO TID");
+        assertThat(blocks.get(1)).contains("Ibuprofen 400 mg");
+    }
+
+    @Test
+    @DisplayName("should still break blocks on the lone carriage return left by a browser-submitted body")
+    void shouldSplitRenderedBlocks_onLoneCarriageReturn() {
+        String nl = "\n";
+        // A CRLF body split on "\n": every line keeps a trailing "\r", and a blank line is "\r"
+        // alone. That remnant is the only one-character separator, and it must keep working.
+        String body = "Amoxicillin 500 mg\r" + nl + "\r" + nl + "Ibuprofen 400 mg\r" + nl;
+
+        List<String> blocks = FrmCustomedPDFServlet.splitRenderedRxBlocks(body, nl);
+
+        assertThat(blocks).hasSize(2);
+        assertThat(blocks.get(0)).contains("Amoxicillin 500 mg").doesNotContain("Ibuprofen");
+        assertThat(blocks.get(1)).contains("Ibuprofen 400 mg");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -14,13 +14,20 @@ import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.DrugDao;
 import io.github.carlos_emr.carlos.commn.dao.PrescriptionDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderExtDao;
+import io.github.carlos_emr.carlos.commn.dao.SiteDao;
+import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
 import io.github.carlos_emr.carlos.casemgmt.model.ProviderExt;
+import io.github.carlos_emr.carlos.commn.model.Clinic;
 import io.github.carlos_emr.carlos.commn.model.Drug;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.commn.exception.PatientDirectiveException;
 import io.github.carlos_emr.carlos.commn.model.Prescription;
+import io.github.carlos_emr.carlos.commn.model.Site;
+import io.github.carlos_emr.carlos.commn.model.UserProperty;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
+import io.github.carlos_emr.carlos.prescript.data.RxSatelliteClinicAddress;
+import io.github.carlos_emr.carlos.prescript.util.RxUtil;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.DigitalSignatureManager;
 import io.github.carlos_emr.carlos.managers.FaxManager;
@@ -29,6 +36,7 @@ import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LocaleUtils;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
+import io.github.carlos_emr.carlos.utility.SafeEncode;
 import io.github.carlos_emr.carlos.web.PrescriptionQrCodeUIBean;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,6 +61,7 @@ import javax.imageio.ImageIO;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
@@ -87,6 +96,10 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     private DrugDao drugDao;
     private ProviderExtDao providerExtDao;
     private DemographicManager demographicManager;
+    private ProviderDao providerDao;
+    private ClinicDAO clinicDao;
+    private UserPropertyDAO userPropertyDao;
+    private SiteDao siteDao;
 
     @BeforeEach
     void setUp() {
@@ -100,8 +113,14 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         registerMock(DigitalSignatureManager.class, digitalSignatureManager);
         registerMock(SecurityInfoManager.class, securityInfoManager);
         registerMock(FaxManager.class, mock(FaxManager.class));
-        registerMock(ClinicDAO.class, mock(ClinicDAO.class));
-        registerMock(ProviderDao.class, mock(ProviderDao.class));
+        clinicDao = mock(ClinicDAO.class);
+        registerMock(ClinicDAO.class, clinicDao);
+        providerDao = mock(ProviderDao.class);
+        registerMock(ProviderDao.class, providerDao);
+        userPropertyDao = mock(UserPropertyDAO.class);
+        registerMock(UserPropertyDAO.class, userPropertyDao);
+        siteDao = mock(SiteDao.class);
+        registerMock(SiteDao.class, siteDao);
         registerMock(DemographicDao.class, mock(DemographicDao.class));
         demographicManager = mock(DemographicManager.class);
         registerMock(DemographicManager.class, demographicManager);
@@ -170,6 +189,9 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
 
         // Grant both READ and WRITE for the patient; the fax path requires WRITE, a preview READ.
         when(securityInfoManager.hasPrivilege(any(), eq("_rx"), anyString(), eq(String.valueOf(DEMOGRAPHIC_NO))))
+                .thenReturn(true);
+        // The fax also heads the page with the demographic record, so faxing needs _demographic READ.
+        when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(SecurityInfoManager.READ), eq(String.valueOf(DEMOGRAPHIC_NO))))
                 .thenReturn(true);
     }
 
@@ -719,6 +741,8 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         when(prescriptionDao.find(SCRIPT_ID)).thenReturn(unsigned);
         when(securityInfoManager.hasPrivilege(any(), eq("_rx"), anyString(), eq(String.valueOf(DEMOGRAPHIC_NO))))
                 .thenReturn(true);
+        when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(SecurityInfoManager.READ), eq(String.valueOf(DEMOGRAPHIC_NO))))
+                .thenReturn(true);
 
         try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
             loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
@@ -1166,6 +1190,253 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
     }
 
     /** The same request as {@link #createFaxRequest()} but a print/preview: no {@code __method}. */
+    @Test
+    @DisplayName("should refuse to fax on anything but POST before touching the prescription")
+    void shouldRejectFax_whenRequestMethodIsNotPost() throws Exception {
+        // CSRFGuard protects POST only, and this servlet answers every method through service():
+        // a GET that faxed would be a cross-site-triggerable fax of a real prescription to a
+        // caller-chosen number.
+        MockHttpServletRequest request = createFaxRequest();
+        request.setMethod("GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        stubStoredSignature();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            FrmCustomedPDFServlet servlet = new FrmCustomedPDFServlet();
+            servlet.init(new MockServletConfig(new MockServletContext()));
+
+            servlet.service(request, response);
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            assertThat(response.getHeader("Allow")).isEqualTo("POST");
+            verify(prescriptionDao, never()).find(anyInt());
+            verify(digitalSignatureManager, never()).getDigitalSignature(anyInt());
+            verify(faxJobDao, never()).persist(any());
+        }
+    }
+
+    @Test
+    @DisplayName("should refuse to fax when the caller may not read the patient's demographic")
+    void shouldRefuseFax_whenCallerLacksDemographicRead() throws Exception {
+        // The fax heads the page with the demographic record, so _demographic READ is part of the
+        // permission to fax; refused here deliberately instead of surfacing as DemographicManager's
+        // RuntimeException half-way through.
+        MockHttpServletRequest request = createFaxRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        stubStoredSignature();
+        when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(SecurityInfoManager.READ), eq(String.valueOf(DEMOGRAPHIC_NO))))
+                .thenReturn(false);
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            FrmCustomedPDFServlet servlet = new FrmCustomedPDFServlet();
+            servlet.init(new MockServletConfig(new MockServletContext()));
+
+            servlet.service(request, response);
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(response.getContentAsString()).contains("fax-failure").contains("permission").doesNotContain("not signed");
+            verify(demographicManager, never()).getDemographic(any(), anyInt());
+            verify(faxJobDao, never()).persist(any());
+        }
+    }
+
+    @Test
+    @DisplayName("should fax the latest drug date of the record, not the request's rxDate")
+    void shouldBindRxDate_toLatestRecordDrugDate() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        request.setParameter("rxDate", "January 1, 1900");
+        stubStoredSignature();
+        Prescription prescription = prescriptionDao.find(SCRIPT_ID);
+        Drug older = drugRow(5, RECORD_DRUG_LINE);
+        older.setRxDate(new GregorianCalendar(2026, 2, 4).getTime());
+        Drug newer = drugRow(6, SECOND_DRUG_LINE);
+        Date latest = new GregorianCalendar(2026, 4, 6).getTime();
+        newer.setRxDate(latest);
+        stubRecordDrugs(prescription, older, newer);
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound.getParameter("rxDate")).isEqualTo(RxUtil.DateToString(latest, "MMMM d, yyyy")).doesNotContain("1900");
+    }
+
+    @Test
+    @DisplayName("should fax the prescriber's clinic header, not the request's")
+    void shouldBindClinicHeader_toPrescriberClinic() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        request.setParameter("clinicName", "Forged Clinic\n1 Forged Way");
+        request.setParameter("clinicPhone", "4165550001");
+        stubStoredSignature();
+        stubPrescriberClinic();
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        // The page strips the "(nnnnnn)" clinic number and joins name, address, "city   postal".
+        assertThat(bound.getParameter("clinicName")).isEqualTo("Record Clinic \n10 Record Rd\nHamilton   L8S 4L8");
+        assertThat(bound.getParameter("clinicPhone")).isEqualTo("9055550000");
+        assertThat(bound.getParameter("useSC")).isNull();
+    }
+
+    @Test
+    @DisplayName("should let the prescriber's rxPhone preference win over the clinic telephone")
+    void shouldBindClinicPhone_toPrescriberPreference() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        stubPrescriberClinic();
+        UserProperty rxPhone = new UserProperty();
+        rxPhone.setProviderNo("999998");
+        rxPhone.setName("rxPhone");
+        rxPhone.setValue("4161112222");
+        when(userPropertyDao.getProp("999998", "rxPhone")).thenReturn(rxPhone);
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound.getParameter("clinicPhone")).isEqualTo("4161112222");
+    }
+
+    @Test
+    @DisplayName("should keep a satellite clinic block the provider was offered")
+    void shouldKeepSatelliteClinic_whenBlockIsOffered() throws Exception {
+        String previousMultisites = CarlosProperties.getInstance().getProperty("multisites");
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        stubPrescriberClinic();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        String offered = RxSatelliteClinicAddress.html("Dr A", "North Site", "2 North Ave", "Barrie", "ON", "L4M 1A1",
+                "7055551111", "7055552222", telLabel(request), faxLabel(request));
+        request.setParameter("useSC", "true");
+        request.setParameter("scAddress", offered);
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            CarlosProperties.getInstance().setProperty("multisites", "true");
+            when(siteDao.getActiveSitesByProviderNo("999998")).thenReturn(List.of(northSite()));
+
+            HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+            assertThat(bound.getParameter("useSC")).isEqualTo("true");
+            assertThat(bound.getParameter("scAddress")).isEqualTo(offered);
+        } finally {
+            restoreProperty("multisites", previousMultisites);
+        }
+    }
+
+    @Test
+    @DisplayName("should fall back to the main clinic when the satellite block was never offered")
+    void shouldDropSatelliteClinic_whenBlockIsNotOffered() throws Exception {
+        String previousMultisites = CarlosProperties.getInstance().getProperty("multisites");
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        stubPrescriberClinic();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        // A well-formed block for a clinic this provider has no site for.
+        String forged = RxSatelliteClinicAddress.html("Dr A", "Forged Site", "2 Forged Rd", "Forgedville", "ZZ", "Z0Z 0Z0",
+                "4165550002", "4165550003", telLabel(request), faxLabel(request));
+        request.setParameter("useSC", "true");
+        request.setParameter("scAddress", forged);
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            CarlosProperties.getInstance().setProperty("multisites", "true");
+            when(siteDao.getActiveSitesByProviderNo("999998")).thenReturn(List.of(northSite()));
+
+            HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+            assertThat(bound.getParameter("useSC")).isEqualTo("false");
+            assertThat(bound.getParameter("scAddress")).isEmpty();
+            assertThat(bound.getParameter("clinicName")).startsWith("Record Clinic");
+        } finally {
+            restoreProperty("multisites", previousMultisites);
+        }
+    }
+
+    @Test
+    @DisplayName("should fax the record's print history as the reprint annotation when reprinting")
+    void shouldBindReprintAnnotation_fromRecordPrintHistory() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        request.setParameter("rxReprint", "true");
+        request.setParameter("origPrintDate", "FORGED DATE");
+        request.setParameter("numPrints", "77");
+        request.getSession().setAttribute("rePrint", "true");
+        stubStoredSignature();
+        Prescription prescription = prescriptionDao.find(SCRIPT_ID);
+        Date firstPrinted = new GregorianCalendar(2026, 0, 2).getTime();
+        prescription.setDatePrinted(firstPrinted);
+        prescription.setDatesReprinted("2026-02-03"); // reprinted once: printed twice in all
+        stubRecordDrugs(prescription, drugRow(5, RECORD_DRUG_LINE));
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound.getParameter("rxReprint")).isEqualTo("true");
+        assertThat(bound.getParameter("origPrintDate")).isEqualTo(String.valueOf(firstPrinted));
+        assertThat(bound.getParameter("numPrints")).isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("should blank the reprint annotation when this session is not reprinting")
+    void shouldBlankReprintAnnotation_whenNotReprinting() throws Exception {
+        MockHttpServletRequest request = createFaxRequest();
+        request.setParameter("rxReprint", "true");
+        request.setParameter("origPrintDate", "FORGED DATE");
+        request.setParameter("numPrints", "77");
+        stubStoredSignature();
+
+        HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+        assertThat(bound.getParameter("rxReprint")).isEqualTo("false");
+        assertThat(bound.getParameter("origPrintDate")).isEmpty();
+        assertThat(bound.getParameter("numPrints")).isEmpty();
+    }
+
+    /** The prescriber 999998 and the clinic row RxProviderData composes the clinic header from. */
+    private void stubPrescriberClinic() {
+        Clinic clinic = new Clinic();
+        clinic.setClinicName("Record Clinic (123456)");
+        clinic.setClinicAddress("10 Record Rd");
+        clinic.setClinicCity("Hamilton");
+        clinic.setClinicProvince("ON");
+        clinic.setClinicPostal("L8S 4L8");
+        clinic.setClinicPhone("9055550000");
+        clinic.setClinicFax("9055550009");
+        when(clinicDao.getClinic()).thenReturn(clinic);
+        io.github.carlos_emr.carlos.commn.model.Provider prescriber = new io.github.carlos_emr.carlos.commn.model.Provider();
+        prescriber.setProviderNo("999998");
+        prescriber.setFirstName("Ann");
+        prescriber.setLastName("Prescriber");
+        when(providerDao.getProvider("999998")).thenReturn(prescriber);
+    }
+
+    private static Site northSite() {
+        Site site = new Site();
+        site.setName("North Site");
+        site.setAddress("2 North Ave");
+        site.setCity("Barrie");
+        site.setProvince("ON");
+        site.setPostal("L4M 1A1");
+        site.setPhone("7055551111");
+        site.setFax("7055552222");
+        return site;
+    }
+
+    private static String telLabel(HttpServletRequest request) {
+        return SafeEncode.forHtml(LocaleUtils.getMessage(request.getLocale(), "RxPreview.msgTel"));
+    }
+
+    private static String faxLabel(HttpServletRequest request) {
+        return SafeEncode.forHtml(LocaleUtils.getMessage(request.getLocale(), "RxPreview.msgFax"));
+    }
+
     private MockHttpServletRequest createPreviewRequest() {
         MockHttpServletRequest request = createFaxRequest();
         request.removeParameter("__method");

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -19,6 +19,7 @@ import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
 import io.github.carlos_emr.carlos.casemgmt.model.ProviderExt;
 import io.github.carlos_emr.carlos.commn.model.Clinic;
 import io.github.carlos_emr.carlos.commn.model.Drug;
+import io.github.carlos_emr.carlos.commn.model.FaxConfig;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.commn.exception.PatientDirectiveException;
@@ -69,6 +70,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -245,7 +247,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
 
             assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             assertThat(response.getContentAsString()).contains("Unable to generate fax");
-            verify(faxConfigDao, never()).findAll(any(), any());
+            verify(faxJobDao, never()).persist(any()); // binding reads fax lines; dispatch never ran
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
         }
@@ -283,7 +285,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(documentDir.resolve("prescription_rx-123.pdf")).exists();
             assertThat(faxDir.resolve("prescription_rx-123.pdf")).exists();
             assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
-            verify(faxConfigDao).findAll(any(), any());
+            verify(faxConfigDao, atLeastOnce()).findAll(any(), any());
             verify(faxJobDao, never()).persist(any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
@@ -325,7 +327,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(existingPdf).hasContent("existing pdf");
             assertThat(faxDir.resolve("prescription_rx-123.pdf")).hasContent("existing pdf");
             assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
-            verify(faxConfigDao).findAll(any(), any());
+            verify(faxConfigDao, atLeastOnce()).findAll(any(), any());
             verify(faxJobDao, never()).persist(any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
@@ -364,7 +366,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             assertThat(response.getContentAsString()).contains("Unable to generate fax");
             assertThat(faxDir.resolve("prescription_rx-123.txt")).isDirectory();
-            verify(faxConfigDao, never()).findAll(any(), any());
+            verify(faxJobDao, never()).persist(any()); // binding reads fax lines; dispatch never ran
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
             restoreProperty("fax_file_location", previousFaxFileLocation);
@@ -1281,7 +1283,7 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         // The page strips the "(nnnnnn)" clinic number and joins name, address, "city   postal".
         assertThat(bound.getParameter("clinicName")).isEqualTo("Record Clinic \n10 Record Rd\nHamilton   L8S 4L8");
         assertThat(bound.getParameter("clinicPhone")).isEqualTo("9055550000");
-        assertThat(bound.getParameter("useSC")).isNull();
+        assertThat(bound.getParameter("useSC")).isEqualTo("false"); // always rebound from the block, never read
     }
 
     @Test
@@ -1325,6 +1327,109 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
 
             assertThat(bound.getParameter("useSC")).isEqualTo("true");
             assertThat(bound.getParameter("scAddress")).isEqualTo(offered);
+        } finally {
+            restoreProperty("multisites", previousMultisites);
+        }
+    }
+
+    @Test
+    @DisplayName("should print the sending fax line only when it is a configured fax_config line")
+    void shouldBindClinicFax_toConfiguredLineOnly() throws Exception {
+        MockHttpServletRequest request = createFaxRequest(); // clinicFax 4165553434
+        stubStoredSignature();
+        FaxConfig line = new FaxConfig();
+        line.setFaxNumber("4165553434");
+        when(faxConfigDao.findAll(any(), any())).thenReturn(List.of(line));
+
+        assertThat(new FrmCustomedPDFServlet().bindFaxContentToRecord(request).getParameter("clinicFax")).isEqualTo("4165553434");
+
+        request.setParameter("clinicFax", "(416) 555-9999");
+        assertThat(new FrmCustomedPDFServlet().bindFaxContentToRecord(request).getParameter("clinicFax")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should keep a satellite block whose clinic text needed HTML encoding")
+    void shouldKeepSatelliteClinic_whenBlockTextWasHtmlEncoded() throws Exception {
+        String previousMultisites = (String) CarlosProperties.getInstance().get("multisites");
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        stubPrescriberClinic();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        Site site = northSite();
+        site.setName("Smith & Jones");
+        // The page unescapes the block before it goes on the wire, so the request carries "&", not "&amp;".
+        String posted = org.apache.commons.text.StringEscapeUtils.unescapeHtml4(RxSatelliteClinicAddress.html("Dr A",
+                "Smith & Jones", "2 North Ave", "Barrie", "ON", "L4M 1A1", "7055551111", "7055552222", telLabel(request), faxLabel(request)));
+        request.setParameter("useSC", "true");
+        request.setParameter("scAddress", posted);
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            CarlosProperties.getInstance().setProperty("multisites", "true");
+            when(siteDao.getActiveSitesByProviderNo("999998")).thenReturn(List.of(site));
+
+            HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+            assertThat(bound.getParameter("useSC")).isEqualTo("true");
+            assertThat(bound.getParameter("scAddress")).isEqualTo(posted);
+        } finally {
+            restoreProperty("multisites", previousMultisites);
+        }
+    }
+
+    @Test
+    @DisplayName("should strip whichever localized label precedes the satellite telephone and fax")
+    void shouldStripLocalizedLabels_whenParsingSatelliteBlock() {
+        String block = RxSatelliteClinicAddress.html("Dr A", "Site Nord", "2 rue Nord", "Gatineau", "QC", "J8X 1A1",
+                "8195551111", "8195552222", "T&eacute;l", "T&eacute;l&eacute;copieur");
+
+        java.util.HashMap<String, String> parsed = FrmCustomedPDFServlet.parseSCAddress(block);
+
+        assertThat(parsed.get("clinicTel")).isEqualTo("8195551111");
+        assertThat(parsed.get("clinicFax")).isEqualTo("8195552222");
+        assertThat(parsed.get("clinicName")).isEqualTo("Site Nord\n2 rue Nord\nGatineau, QC J8X 1A1");
+    }
+
+    @Test
+    @DisplayName("should let an unexpected privilege-lookup failure abort the fax instead of deferring it")
+    void shouldPropagateFailure_whenPrivilegeLookupFailsUnexpectedly() throws Exception {
+        stubStoredSignature();
+        Prescription prescription = prescriptionDao.find(SCRIPT_ID);
+        when(securityInfoManager.hasPrivilege(any(), eq("_rx"), eq(SecurityInfoManager.READ), eq(String.valueOf(DEMOGRAPHIC_NO))))
+                .thenThrow(new IllegalStateException("datasource down"));
+
+        assertThatThrownBy(() -> new FrmCustomedPDFServlet().isFaxDeniedByPrivilege(prescription, mock(LoggedInInfo.class)))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("should decide the satellite flag from the block alone, whatever case the request spelled it in")
+    void shouldRebindSatelliteFlag_fromOfferedBlockNotRequestCase() throws Exception {
+        String previousMultisites = (String) CarlosProperties.getInstance().get("multisites");
+        MockHttpServletRequest request = createFaxRequest();
+        stubStoredSignature();
+        stubPrescriberClinic();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        // generatePDFDocumentBytes reads useSC case-insensitively, so "TrUe" with a forged block would
+        // reach parseSCAddress if the flag were only rewritten when spelled "true".
+        String forged = RxSatelliteClinicAddress.html("Dr A", "Forged Site", "2 Forged Rd", "Forgedville", "ZZ", "Z0Z 0Z0",
+                "4165550002", "4165550003", telLabel(request), faxLabel(request));
+        request.setParameter("useSC", "TrUe");
+        request.setParameter("scAddress", forged);
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            CarlosProperties.getInstance().setProperty("multisites", "true");
+            when(siteDao.getActiveSitesByProviderNo("999998")).thenReturn(List.of(northSite()));
+
+            HttpServletRequest bound = new FrmCustomedPDFServlet().bindFaxContentToRecord(request);
+
+            assertThat(bound.getParameter("useSC")).isEqualTo("false");
+            assertThat(bound.getParameter("scAddress")).isEmpty();
         } finally {
             restoreProperty("multisites", previousMultisites);
         }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxPreviewClinicHeaderAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxPreviewClinicHeaderAssetRegressionTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 CARLOS EMR Contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.carlos_emr.carlos.prescript;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins how {@code rx/Preview2.jsp} turns the clinic header's {@code <br>} joins into the line
+ * breaks the PDF servlet renders.
+ *
+ * <p>The header is composed as {@code name<br>address<br>city   postal} and handed to the servlet
+ * through the hidden {@code clinicName} input. That input's value is a tag ATTRIBUTE, and the JSP
+ * specification unescapes {@code \\} to {@code \} inside attribute values before the scriptlet is
+ * compiled — so the former {@code replaceAll("(<br>)", "\\\n")} reached Java as {@code "\\n"}, a
+ * replacement string of backslash + n, which regex replacement reads as an escaped literal
+ * {@code n}. Every faxed prescription rendered its clinic header as one glued line
+ * ({@code ClinicnAddressnCity}). A literal {@link String#replace(CharSequence, CharSequence)} with
+ * a plain {@code "\n"} has no second escaping layer to fall through.</p>
+ *
+ * <p>The browser check {@code scripts/rx-fax-record-binding-playwright-checks.js} asserts the
+ * rendered result on a packaged install; this test keeps the source from regressing between runs.</p>
+ *
+ * @since 2026-09-05
+ */
+@DisplayName("Rx preview clinic header asset regressions")
+@Tag("unit")
+@Tag("prescription")
+class RxPreviewClinicHeaderAssetRegressionTest {
+
+    private static final Path PREVIEW2_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "rx", "Preview2.jsp");
+
+    private static String read(Path path) throws IOException {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    /** The page without its JSP comments, so a fix explained in a comment cannot satisfy or fail an assertion. */
+    private static String executableJsp(String page) {
+        return page.replaceAll("(?s)<%--.*?--%>", "");
+    }
+
+    @Test
+    @DisplayName("should convert the clinic header's <br> joins with a literal newline, not a regex replacement")
+    void shouldConvertHeaderBreaks_withLiteralNewline() throws IOException {
+        String page = executableJsp(read(PREVIEW2_JSP));
+
+        assertThat(page)
+                .as("clinicName is fed to the PDF servlet with real line breaks")
+                .contains("clinicTitle.replace(\"<br>\", \"\\n\")");
+        // Whitespace-insensitive: the regex form must not come back in any layout. Inside a JSP
+        // attribute, \\\n compiles to a replacement of backslash + n, i.e. the letter n.
+        assertThat(page.replaceAll("\\s+", ""))
+                .doesNotContain("clinicTitle.replaceAll(\"(<br>)\"");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxPreviewClinicHeaderAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxPreviewClinicHeaderAssetRegressionTest.java
@@ -1,18 +1,23 @@
 /**
- * Copyright (c) 2026 CARLOS EMR Contributors.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.prescript;
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.prescript.data;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.commn.dao.SiteDao;
+import io.github.carlos_emr.carlos.commn.model.Site;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("RxSatelliteClinicAddress wire format")
+@Tag("unit")
+@Tag("prescription")
+class RxSatelliteClinicAddressUnitTest extends CarlosUnitTestBase {
+
+    private static final String[] KEYS = {"multisites", "clinicSatelliteName", "clinicSatelliteAddress",
+            "clinicSatelliteCity", "clinicSatelliteProvince", "clinicSatellitePostal", "clinicSatellitePhone",
+            "clinicSatelliteFax"};
+    private final String[] previous = new String[KEYS.length];
+    private SiteDao siteDao;
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 0; i < KEYS.length; i++) {
+            previous[i] = CarlosProperties.getInstance().getProperty(KEYS[i]);
+            CarlosProperties.getInstance().remove(KEYS[i]);
+        }
+        siteDao = mock(SiteDao.class);
+        registerMock(SiteDao.class, siteDao);
+    }
+
+    @AfterEach
+    void restoreProperties() {
+        for (int i = 0; i < KEYS.length; i++) {
+            if (previous[i] == null) {
+                CarlosProperties.getInstance().remove(KEYS[i]);
+            } else {
+                CarlosProperties.getInstance().setProperty(KEYS[i], previous[i]);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("should compose the block the servlet parses, encoding the clinic values")
+    void shouldComposeBlock_inServletWireShape() {
+        String block = RxSatelliteClinicAddress.html("Dr A", "North &amp; Co", "2 North Ave", "Barrie", "ON", "L4M 1A1",
+                "7055551111", "7055552222", "Tel", "Fax");
+
+        assertThat(block).isEqualTo("<b>Dr A</b><br>North &amp;amp; Co<br>2 North Ave<br>Barrie, ON L4M 1A1<br>Tel: 7055551111<br>Fax: 7055552222");
+        assertThat(RxSatelliteClinicAddress.clinicPart(block)).isEqualTo("<br>North &amp;amp; Co<br>2 North Ave<br>Barrie, ON L4M 1A1<br>Tel: 7055551111<br>Fax: 7055552222");
+    }
+
+    @Test
+    @DisplayName("should return null for a value that is not a block")
+    void shouldReturnNull_forTextWithoutPrescriberName() {
+        assertThat(RxSatelliteClinicAddress.clinicPart(null)).isNull();
+        assertThat(RxSatelliteClinicAddress.clinicPart("Just a clinic name")).isNull();
+    }
+
+    @Test
+    @DisplayName("should list the provider's active sites when multisites is on")
+    void shouldListActiveSites_whenMultisitesEnabled() {
+        CarlosProperties.getInstance().setProperty("multisites", "true");
+        Site site = new Site();
+        site.setName("North Site");
+        site.setAddress("2 North Ave");
+        site.setCity("Barrie");
+        site.setProvince("ON");
+        site.setPostal("L4M 1A1");
+        site.setPhone("7055551111");
+        site.setFax("7055552222");
+        when(siteDao.getActiveSitesByProviderNo("999998")).thenReturn(List.of(site));
+
+        List<String> blocks = RxSatelliteClinicAddress.blocksFor("999998", "Tel", "Fax");
+
+        assertThat(blocks).containsExactly(RxSatelliteClinicAddress.html("", "North Site", "2 North Ave", "Barrie", "ON",
+                "L4M 1A1", "7055551111", "7055552222", "Tel", "Fax"));
+    }
+
+    @Test
+    @DisplayName("should list the clinicSatellite* properties when multisites is off")
+    void shouldListPropertySatellites_whenMultisitesDisabled() {
+        CarlosProperties.getInstance().setProperty("clinicSatelliteName", "East|West");
+        CarlosProperties.getInstance().setProperty("clinicSatelliteAddress", "1 East St|2 West St");
+        CarlosProperties.getInstance().setProperty("clinicSatelliteCity", "Ajax|Milton");
+        CarlosProperties.getInstance().setProperty("clinicSatelliteProvince", "ON|ON");
+        CarlosProperties.getInstance().setProperty("clinicSatellitePostal", "L1S 1A1|L9T 1A1");
+        CarlosProperties.getInstance().setProperty("clinicSatellitePhone", "9055550001|9055550002");
+        // A shorter list reads as blank instead of failing the whole page.
+        CarlosProperties.getInstance().setProperty("clinicSatelliteFax", "9055550003");
+
+        List<String> blocks = RxSatelliteClinicAddress.blocksFor("999998", "Tel", "Fax");
+
+        assertThat(blocks).containsExactly(
+                RxSatelliteClinicAddress.html("", "East", "1 East St", "Ajax", "ON", "L1S 1A1", "9055550001", "9055550003", "Tel", "Fax"),
+                RxSatelliteClinicAddress.html("", "West", "2 West St", "Milton", "ON", "L9T 1A1", "9055550002", "", "Tel", "Fax"));
+    }
+
+    @Test
+    @DisplayName("should offer no blocks when neither sites nor satellite properties are configured")
+    void shouldOfferNothing_whenNoSatelliteSourceConfigured() {
+        assertThat(RxSatelliteClinicAddress.blocksFor("999998", "Tel", "Fax")).isEmpty();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
@@ -89,10 +89,12 @@ class RxSatelliteClinicAddressUnitTest extends CarlosUnitTestBase {
                 "7055551111", "7055552222", "Tel", "Fax");
         String posted = org.apache.commons.text.StringEscapeUtils.unescapeHtml4(offered);
 
-        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), posted)).isTrue();
-        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), posted.replace("Barrie", "Elsewhere"))).isFalse();
-        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), null)).isFalse();
-        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), "no bold name")).isFalse();
+        // The match answers with the offered block in wire form, so callers render that, never the request.
+        assertThat(RxSatelliteClinicAddress.offeredBlock(List.of(offered), posted)).isEqualTo(posted);
+        assertThat(RxSatelliteClinicAddress.offeredBlock(List.of(offered), posted.replace("Smith & Jones", "Smith &#38; Jones"))).isEqualTo(posted);
+        assertThat(RxSatelliteClinicAddress.offeredBlock(List.of(offered), posted.replace("Barrie", "Elsewhere"))).isNull();
+        assertThat(RxSatelliteClinicAddress.offeredBlock(List.of(offered), null)).isNull();
+        assertThat(RxSatelliteClinicAddress.offeredBlock(List.of(offered), "no bold name")).isNull();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
@@ -83,6 +83,19 @@ class RxSatelliteClinicAddressUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should recognise an offered block after the page has unescaped its HTML entities")
+    void shouldRecogniseOfferedBlock_afterPageUnescapedIt() {
+        String offered = RxSatelliteClinicAddress.html("Dr A", "Smith & Jones", "2 North Ave", "Barrie", "ON", "L4M 1A1",
+                "7055551111", "7055552222", "Tel", "Fax");
+        String posted = org.apache.commons.text.StringEscapeUtils.unescapeHtml4(offered);
+
+        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), posted)).isTrue();
+        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), posted.replace("Barrie", "Elsewhere"))).isFalse();
+        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), null)).isFalse();
+        assertThat(RxSatelliteClinicAddress.offers(List.of(offered), "no bold name")).isFalse();
+    }
+
+    @Test
     @DisplayName("should return null for a value that is not a block")
     void shouldReturnNull_forTextWithoutPrescriberName() {
         assertThat(RxSatelliteClinicAddress.clinicPart(null)).isNull();

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxSatelliteClinicAddressUnitTest.java
@@ -52,7 +52,9 @@ class RxSatelliteClinicAddressUnitTest extends CarlosUnitTestBase {
     @BeforeEach
     void setUp() {
         for (int i = 0; i < KEYS.length; i++) {
-            previous[i] = CarlosProperties.getInstance().getProperty(KEYS[i]);
+            // Raw stored value: getProperty() warns and substitutes a default for a missing key,
+            // and this only snapshots state to restore it.
+            previous[i] = (String) CarlosProperties.getInstance().get(KEYS[i]);
             CarlosProperties.getInstance().remove(KEYS[i]);
         }
         siteDao = mock(SiteDao.class);


### PR DESCRIPTION
## Description

Seven defects in the stamp-signed Rx fax, each confirmed against the code and then **reproduced and re-verified in a real browser** against a packaged Ubuntu 26.04 install (see *How Was This Tested?*). Defects 1–3 arrived with #3575 and were surfaced by automated review on the alpha11 promotion PR (#3603); 4–7 are older and were found by the multi-agent slice/crosscut review of the promotion and by the PDFs the new browser check produces.

### 1. Patient identity was still caller-controlled (security)

`resolveSignatureImage` verifies that the caller holds `_rx` **write** for the prescription's patient and that `demographic_no` names that same patient. `bindFaxContentToRecord` then takes the drugs, signing name, notes and prescriber numbers from the record — its own comment says *"EVERY field the fax renders must come from the record"*.

But six fields did not: `patientName`, `patientDOB`, `patientHIN`, `patientAddress`, `patientCityPostal` and `patientPhone` were read straight from request parameters and printed in the page heading. A stale preview, or a tampered post from a caller who legitimately holds `_rx` write on the patient, could send the **verified drugs under the prescriber's stored signature** while heading the page with a different person's name, date of birth and health number — a correctly signed prescription for the wrong patient, faxed to a pharmacy.

Fixed by binding all of them to the prescription's own demographic via `DemographicManager` (the same row `rx/Preview2.jsp` reaches through `RxPatientData`, so consent and audit behaviour is unchanged). Every slot is overridden even when empty — an unbound field is a field the request still controls; `patientChartNo` binds to empty because the Rx preview never populates it; `showPatientDOB` stays a display preference. Formats reproduce what `Preview2.jsp` posts, so a legitimate fax renders byte-identically.

### 2. A one-character prescription line was silently dropped

`splitRenderedRxBlocks` treated **any** line of length 1 as a block separator. The sentinel it means is the lone `\r` left when a browser-submitted CRLF body is split on `\n` — which a bare one-character line can never be. The record-bound fax body uses plain newlines, so a standalone dose line such as `1` **vanished from the faxed script**. Now matches `\r` exactly; the unreachable `s.equals(newline)` branch is gone.

### 3. A note typed just before faxing could be omitted

`addNotes()` saved with a fire-and-forget `fetch()`; the textarea's `onchange` fires as focus leaves it for the Fax button, so the fax POST raced the save, and because the fax (correctly) renders `additNotes` from the stored row, losing the race dropped an instruction still visible in the preview. The save's promise is now **chained** (saves serialize) and awaited **on the fax path only**. A non-2xx from `ViewAddRxComment` is a failed save and is logged. The shared preview form's `target` is set at submit time on both paths, so a print in the same modal can no longer leave `_blank` on the fax.

### 4. The clinic header rendered glued, with the letter `n` for every line break *(pre-existing)*

Every faxed prescription's clinic header rendered as `McMaster HospitalnHamiltonnHamilton`. `Preview2.jsp` composes it as `name<br>address<br>city   postal` and converted the `<br>` joins for the hidden `clinicName` input with `replaceAll("(<br>)", "\\\n")`. That sits inside a tag **attribute**, and the JSP spec unescapes `\\`→`\` in attribute values before the scriptlet compiles, so Java received `"\\n"` — a replacement of backslash + `n`, which regex replacement reads as an escaped literal `n`. Replaced with a literal `replace("<br>", "\n")`.

### 5. Date, clinic block, reprint annotation and satellite clinic were still caller-controlled *(pre-existing)*

With 1–4 in place, the remaining header values were still read straight from the request and printed on the signed document: `rxDate` (back- or post-dates a controlled-substance script), `clinicName`/`clinicPhone`/`clinicFax` (routes the pharmacy's call-back to a phone or fax the caller chose), `rxReprint`/`origPrintDate`/`numPrints` (arbitrary text as *"Orig printed: …; times printed: …"* above the signature), and `useSC`/`scAddress` (a whole clinic block the servlet parses and prints verbatim). Each has the record source `Preview2.jsp` itself renders from, and each is now bound the same way: the latest `drugs.rx_date` in the page's `"MMMM d, yyyy"` shape; the prescriber's clinic as `RxProviderData` resolves it (clinic row + the prescriber's rxAddress/rxPhone/faxnumber preferences), composed exactly as the preview composes `clinicName`, with the **clinic's official fax** as the printed `Fax:` — the request's `clinicFax` is the *outgoing* line and only selects the sending line in `service()`; the record's print history only when this session is reprinting; and a satellite block only when it is one the page could have offered this provider (matched after HTML-unescaping, since the page unescapes the block before posting it). The satellite flag itself is never read from the request: it is rebound from whether the block is offered. That last check needs page and servlet to agree on the block's wire shape, so the composition moves into a new `RxSatelliteClinicAddress` and `ViewScript2.jsp` calls it for both of its satellite sources. Two pre-existing satellite bugs found on the way are fixed with it: `parseSCAddress` stripped only English `Tel:`/`Fax:` labels (French installs faxed `Tél: Tél: …`), and short `clinicSatellite*` property lists threw on the prescription page.

### 6. The fax was reachable by GET *(pre-existing, security)*

`FrmCustomedPDFServlet` answers every method through `service()`, and CSRFGuard protects `POST,PUT,DELETE,PATCH` only. `GET …/form/createcustomedpdf?__method=oscarRxFax&scriptId=N&pharmaFax=<attacker>&…` therefore wrote the PDF, persisted a `FaxJob` and handed a real, signed prescription to the fax provider at a caller-chosen number — token-free and cross-site-triggerable from any page a prescriber has open. The fax path now answers **405** to anything but POST before touching the record; the page's Fax button already submits a POST form.

### 7. `_rx` write without `_demographic` read was a 500 mid-fax

The fax heads the page with the demographic record, so a caller holding `_rx` WRITE but not `_demographic` READ reached `DemographicManager`'s bare `RuntimeException` half-way through. The permission gate (`isFaxDeniedByPrivilege`) now also requires `_demographic` READ on the patient and answers with the same deliberate refusal before any side effect; it absorbs only `PatientDirectiveException`, so an unexpected failure of the privilege lookup aborts the request.

## Related Issues

Found via review on #3603. Related to #3575, which introduced defects 1–3. Sibling verb/authorization defects in the Rx slice: #3585, #3611. Dead program-address branch in `Preview2.jsp`: #3612.

## Target Branch

`release/2026.08`. Defects 1–3 exist only on this maintenance line (they arrived with #3575 and are not yet on `main`) and it is queued to publish as `2026.08.0-alpha11`, so the fix belongs on the line that carries them; 4–7 ride along and forward-merge.

## How Was This Tested?

### Unit

- `FrmCustomedPDFServletUnitTest` **69/69**, `RxSatelliteClinicAddressUnitTest` 6/6, `RxPreviewClinicHeaderAssetRegressionTest` — including: identity bound / blank on missing row / blank on directive / propagate on unexpected failure; one-character line kept; **405 on GET before the prescription is read**; **permission refusal without `_demographic` READ** (no `getDemographic`, no `FaxJob`); unexpected privilege-lookup failure propagates; rxDate = latest record date; clinic header from the prescriber's clinic, rxPhone preference wins; **clinic fax = clinic's official fax / `faxnumber` preference, never the outgoing line**; satellite block kept when offered (also when its text needed HTML encoding), dropped when not, flag rebound whatever case the request spelled it in; localized labels stripped; reprint annotation from the record's print history, blank when not reprinting.
- JSPs compile under the `jspc` profile (`ViewScript2.jsp`, `Preview2.jsp`). Encoder null-safety lint passes (new code uses `SafeEncode`). No `IMPROPER_UNICODE` sites: method token, session flag and satellite flag are exact compares.

### Browser — new `scripts/rx-fax-record-binding-playwright-checks.js`

Drives the real UI on a packaged install (Ubuntu 26.04 deb, through nginx + ModSecurity): writes and stamp-signs a prescription, faxes it with the real Fax button, then posts a forged fax for the same signed script from inside the page with a genuine CSRFGuard token — forging identity **and** `rxDate`, `clinicName`/`clinicPhone`, `rxReprint`/`origPrintDate`/`numPrints`, `useSC`/`scAddress` — and **reads the PDFs the servlet wrote to `DOCUMENT_DIR`**, asserting on the rendered text runs: no forged marker renders, the staged outgoing fax line never renders, and the record's date (read back from the drugs row) and the clinic line the page itself posted do. The notes race is made deterministic by holding the `ViewAddRxComment` save with route interception. Nothing from a PDF is printed.

**A/B on the same install:**

| install | result |
| --- | --- |
| alpha11 WAR, unpatched | **FAIL — 11 findings**: one-character line dropped; note omitted; all seven forged identity fields rendered; record name and HIN absent |
| + servlet classes and `ViewScript2.jsp` through 19aa0046 | **FAIL — 1 finding**: clinic header glued |
| + `Preview2.jsp` fix | **PASS** on the pre-5–7 assertions |
| servlet through 19aa0046 against the **new** header assertions | **FAIL — exactly 5 header findings**: forged `rxDate`, `origPrintDate`, `scAddress` rendered; record date and clinic line absent |
| 571c763b … 9bc38a22 (this head) | **PASS — 0 findings** on every run after each round |

Also in the check itself: both fax round-trip promises are awaited together (awaited in sequence, a click that produced no request left the second rejection unhandled, crashed the process and skipped fixture cleanup — the leftover `555…` pharmacy fax numbers); it waits for the preview iframe's form before clicking Fax (the click handler dereferences it, which a cold Tomcat compiling the Rx JSPs on first hit made observable); `RX_FAX_ROUND_TRIP_TIMEOUT_MS` (validated, 1–600 s) covers that cold start and the runbook gives the check a 900 s wrapper. The same rejection pattern is fixed in `rx-fax-signature-stamp`; three sibling checks fill `#pin` only when the login page renders it; the notes check quotes its mysql option-file password and refuses one with a line break; the stamp check logs the fax request path without its query.

Registered as `npm run test:rx-fax-record-binding-playwright` and in `docs/ui-tests/deb-install-validation.md` §6 (`RX_FAX_DOCUMENT_DIR` is required).

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

---

### Bearing on the alpha11 promotion

The affected code ships in alpha11. When this lands, `release/2026.08` is merged into #3603's branch (a real merge, no recut) so the alpha carries the fix; that moves #3603's head and its pinned DCO confirmation phrase must be re-posted against the new head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhEotcrscmDa2ztS3kzKs3

## Summary by Sourcery

Secure and correct stamp-signed prescription faxing by making the stored prescription record authoritative for all rendered content and validating the complete fax workflow end to end.

Bug Fixes:
- Bind faxed prescription identity, dates, clinic details, satellite clinic information, notes, and reprint metadata to the stored prescription record instead of caller-controlled request values.
- Prevent signed prescription faxes from being triggered by non-POST requests and reject faxing when the caller lacks demographic read access.
- Preserve one-character prescription directions, localized satellite clinic labels, and correctly separated clinic header lines.
- Ensure notes saved immediately before faxing are persisted before the fax is submitted.

Enhancements:
- Centralize satellite clinic address generation and validation so the prescription page and fax servlet use the same wire format.
- Improve browser-check reliability, cleanup, credential handling, and operation across installations with optional legacy PIN login fields.

Documentation:
- Document the packaged-install browser validation for record-bound Rx faxes, including PDF output access and cold-server timeout configuration.

Tests:
- Add unit coverage for record binding, authorization, HTTP method restrictions, prescription line splitting, clinic and satellite headers, reprint metadata, and failure handling.
- Add a browser-driven regression check that verifies rendered fax PDFs against forged identity and header data, notes races, one-character directions, and clinic formatting.