### PR TITLE
fix(consultation): make consultation faxing a true/false flag, enable it by default, and normalize it on deb upgrade

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -278,7 +278,7 @@ rx.drugofchoice.hide=false
 ## Requires the Indivica attachment enabled as well
 ## Feel free to set faxEnable=yes - just in case.
 faxEnable=yes
-consultation_fax_enabled=yes
+consultation_fax_enabled=true
 ### True if dynamic labelling is enabled in consultations and false otherwise.
 # This requires consultation_fax_enabled = true
 consultation_dynamic_labelling_enabled=true

--- a/debian/carlos-emr.postinst
+++ b/debian/carlos-emr.postinst
@@ -322,6 +322,54 @@ case "$1" in
             : > "${CONSULT_SIG_SENTINEL}"
         fi
 
+        # One-time migration (2026.08), the twin of the signature one above:
+        # earlier packages shipped consultation_fax_enabled=false, install_once
+        # copied it into the persistent /etc override, and that override is the
+        # LAST source carlos-emr-tomcat loads — so the new stock default of true
+        # in the WAR's own carlos.properties cannot reach an upgraded install.
+        # Same conservative shape as the signature migration: flip ONLY the
+        # byte-exact old stock line, ONLY on upgrade, ONLY once (sentinel), and
+        # write the sentinel on fresh installs too so a false the operator sets
+        # after this release is never flipped back. An operator who hand-edited
+        # the line (any spacing, any other value) is left alone by the exact
+        # whole-line match.
+        # Faxing only APPEARS in the UI here; sending still needs an active fax
+        # account (Administration > Faxes > Configure Fax) and the _fax object,
+        # so a site that never configured a provider sees no change.
+        CONSULT_FAX_SENTINEL="${STATE}/.consult-fax-default-migrated"
+        if [ ! -e "${CONSULT_FAX_SENTINEL}" ]; then
+            if [ -n "${2:-}" ] && [ -f "${PROPERTIES}" ] \
+                && grep -qx 'consultation_fax_enabled=false' "${PROPERTIES}"; then
+                sed -i 's/^consultation_fax_enabled=false$/consultation_fax_enabled=true/' "${PROPERTIES}"
+                echo "carlos-emr: enabled consultation faxing (migrated the old stock default off -> on)"
+            fi
+            mkdir -p "${STATE}"
+            : > "${CONSULT_FAX_SENTINEL}"
+        fi
+
+        # Normalise the legacy yes/no spellings of the same key to true/false.
+        # Until this release the two buttons that start a consultation fax were
+        # rendered by a tag that compared the raw string against the literal
+        # "yes", so operators who wanted faxing were told to write yes/no while
+        # every other reader of the key took true/yes/on. Both spellings still
+        # work (CarlosProperties accepts true/yes/on), so this rewrite cannot
+        # change behaviour in either direction — it only makes the file say what
+        # the property now is, a boolean.
+        # Deliberately NOT sentinel-guarded: it is idempotent and semantics-
+        # preserving, so it may run on every configure and pick up a legacy
+        # spelling written later by hand. It runs AFTER the flip above so that an
+        # operator's explicit "no" is normalised to false and never seen by the
+        # exact-match flip (which by then has also written its sentinel).
+        if [ -f "${PROPERTIES}" ] && grep -Eqi \
+            '^[[:space:]]*consultation_fax_enabled[[:space:]]*=[[:space:]]*(yes|no|on|off)[[:space:]]*$' \
+            "${PROPERTIES}"; then
+            sed -i -E \
+                -e 's/^([[:space:]]*consultation_fax_enabled[[:space:]]*=[[:space:]]*)(yes|on)[[:space:]]*$/\1true/I' \
+                -e 's/^([[:space:]]*consultation_fax_enabled[[:space:]]*=[[:space:]]*)(no|off)[[:space:]]*$/\1false/I' \
+                "${PROPERTIES}"
+            echo "carlos-emr: normalised consultation_fax_enabled to a true/false value"
+        fi
+
         # Fold the debconf answers into the operator-owned settings file.
         # db_get returns 10 for an unregistered item; under set -e that would
         # abort configure. All these keys are registered (templates + config),

--- a/debian/carlos-emr.postrm
+++ b/debian/carlos-emr.postrm
@@ -67,6 +67,7 @@ case "$1" in
         rm -rf /var/log/carlos-emr/backup-state
         rm -f "${STATE}/.first-configure-pending" \
               "${STATE}/.consult-signature-default-migrated" \
+              "${STATE}/.consult-fax-default-migrated" \
               "${STATE}/.db-name-default-migrated"
         # The OscarDocument -> CarlosDocument compat symlink is package
         # machinery, not data: the real document store it points at is KEPT.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+carlos-emr (2026.09.0~snapshot20) resolute; urgency=medium
+
+  * Consultation faxing is enabled by default and its flag is a real boolean.
+    The two buttons that start a consultation fax were rendered by a tag that
+    compared consultation_fax_enabled against the literal string "yes", while
+    every other reader of the key accepted true/yes/on -- so true enabled the
+    whole workflow except the buttons that launch it. The buttons now go
+    through the same boolean check as the rest of the page.
+  * The upgrade normalises the flag in /etc/carlos-emr/carlos.properties: the
+    old stock consultation_fax_enabled=false is flipped to true once (sentinel
+    guarded, upgrade only, byte-exact whole-line match, so an operator's own
+    edit is left alone), and the legacy yes/no/on/off spellings are rewritten
+    to true/false. That rewrite is semantics-preserving in both directions --
+    a site that had disabled faxing with "no" keeps it disabled as "false".
+    Faxing only becomes VISIBLE; sending still needs an active account under
+    Administration > Faxes > Configure Fax and the _fax security object.
+
+ -- CARLOS EMR Maintainers <michael@maplecreekmedical.ca>  Sat, 05 Sep 2026 00:00:00 +0000
+
 carlos-emr (2026.09.0~snapshot19) resolute; urgency=medium
 
   * The install wizard's billing-province question offers a third answer,

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -861,9 +861,10 @@ rx_signature_enabled=true
 # True if fax should be enabled in the prescript module and false otherwise.
 rx_fax_enabled=false
 
-# True if signatures should be enabled in the consultation module and false otherwise.
-# Requires faxEnable=yes
-consultation_fax_enabled=false
+# True if faxing should be enabled in the consultation module and false otherwise.
+# Enabled by default; sending still requires an active fax account configured under
+# Administration > Faxes > Configure Fax and the _fax security object on the provider's role.
+consultation_fax_enabled=true
 faxEnable=no
 printPDF_referring_prac=no
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2602,11 +2602,12 @@ if (userAgent != null) {
                                        value="<fmt:message key="global.btnPrint"/>"
                                        onclick="return checkForm('And Print Preview','EctConsultationFormRequest2Form');"/>
 
-                                <oscar:oscarPropertiesCheck value="yes" property="consultation_fax_enabled">
+                                <%-- Boolean check (true/false, also yes/on) via CarlosProperties; the raw tag compared the literal "yes" only. --%>
+                                <% if (props.isConsultationFaxEnabled()) { %>
                                     <input id="fax_button" name="updateAndFax" type="button" class="btn btn-primary btn-sm"
                                            value="<fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.btnUpdateAndFax"/>"
                                            onclick="return checkForm('Update And Fax','EctConsultationFormRequest2Form');"/>
-                                </oscar:oscarPropertiesCheck>
+                                <% } %>
 
                                 <% } else { %>
                                 <input name="submitSaveOnly" type="button" class="btn btn-primary btn-sm"
@@ -2616,11 +2617,12 @@ if (userAgent != null) {
                                        value="<fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.btnSubmitAndPrint"/>"
                                        onclick="return checkForm('Submit Consultation Request And Print Preview','EctConsultationFormRequest2Form'); "/>
 
-                                <oscar:oscarPropertiesCheck value="yes" property="consultation_fax_enabled">
+                                <%-- Boolean check (true/false, also yes/on) via CarlosProperties; the raw tag compared the literal "yes" only. --%>
+                                <% if (props.isConsultationFaxEnabled()) { %>
                                     <input id="fax_button" name="submitAndFax" type="button" class="btn btn-primary btn-sm"
                                            value="<fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.btnSubmitAndFax"/>"
                                            onclick="return checkForm('Submit And Fax','EctConsultationFormRequest2Form');"/>
-                                </oscar:oscarPropertiesCheck>
+                                <% } %>
 
                                 <% } %>
                                 </div>


### PR DESCRIPTION
## Description

Consultation faxing was gated on `consultation_fax_enabled`, but the two buttons that actually start the fax workflow ("Submit And Fax" / "Update And Fax" on the consultation request form) were rendered through `<oscar:oscarPropertiesCheck value="yes">`, which compares the raw property string against the literal `yes`. Every other consultation fax gate in the same page already uses `CarlosProperties.isConsultationFaxEnabled()`, which accepts `true`/`yes`/`on`. So `consultation_fax_enabled=true` enabled the fax workflow everywhere except the buttons that launch it, and the property could not be treated as a normal true/false boolean.

**Application**

- `ConsultationFormRequest.jsp`: render both fax buttons through `props.isConsultationFaxEnabled()` so `true`/`false` works end to end, consistent with the other ten gates in the same page.
- `src/main/resources/carlos.properties`: default `consultation_fax_enabled=true`. The old comment described "signatures" and claimed a `faxEnable=yes` prerequisite; nothing reads `faxEnable` (the Java getter reads a different key, `enableFax`), so the comment now states the real prerequisites.
- Devcontainer `carlos.properties`: `yes` to `true` for consistency.

**Packaging**

An upgraded install keeps its `/etc/carlos-emr/carlos.properties`, and `carlos-emr-tomcat` loads that file as the final override source, so a new stock default in the WAR cannot reach an existing deployment — the old stock `consultation_fax_enabled=false` would keep faxing hidden. `postinst` now, in this order:

1. **Flips** the byte-exact old stock `consultation_fax_enabled=false` to `true`. Same conservative shape as the `consultation_signature_enabled` migration it sits beside: upgrade-only, sentinel-guarded so it runs once, whole-line match so a hand-edited line (any spacing, any other value) is left alone. The sentinel is written on fresh installs too, so a `false` set after this release is never flipped back.
2. **Normalizes** the legacy `yes`/`no`/`on`/`off` spellings to `true`/`false` on every configure. `CarlosProperties` accepts `true`/`yes`/`on`, so this cannot change behavior in either direction — a site that disabled faxing with `no` keeps it disabled as `false`. It deliberately runs *after* the flip so an explicit `no` is never seen by the exact-match `false` to `true` rewrite.

`postrm` removes the new sentinel on purge so a later reinstall is genuinely fresh. Changelog entry added as `2026.09.0~snapshot20`, following the ladder rule in `debian/README.source` (never `~alpha`/`~beta`/`~rc` after a `~snapshot`).

Faxing only becomes *visible* here. Sending still requires an active fax account under Administration > Faxes > Configure Fax and the `_fax` security object, so a site that never configured a provider sees no change.

## Related Issues

None.

## Target Branch

Supported fix: topic branch created from `release/2026.08` and targeting `release/2026.08`. No Maven version or SCM metadata touched, and no Flyway migration added or edited. Maintainers can forward-merge into newer lines.

## How Was This Tested?

Packaging logic, executed under `dash` (the real `/bin/sh` for maintainer scripts) against the full value matrix, each case checked for both the resulting line and the operator's intent:

| starting line | context | result |
|---|---|---|
| `consultation_fax_enabled=false` | upgrade | `true` (the target population) |
| `consultation_fax_enabled=false` | fresh install, then a later upgrade | stays `false` — sentinel written on fresh install |
| `consultation_fax_enabled=yes` | upgrade | `true`, still enabled |
| `consultation_fax_enabled=no` | upgrade, then a second upgrade | `false` both times — an explicit disable survives |
| `consultation_fax_enabled=true` | upgrade | unchanged, no message |
| `consultation_fax_enabled = false` | upgrade | unchanged — hand-edited spacing reads as an explicit choice |
| `consultation_fax_enabled = YES` | upgrade | `true` |
| `#consultation_fax_enabled=yes` | upgrade | untouched |
| `consultation_fax_enabled=yes` | three consecutive configures | rewritten once, then no-ops |

Also: `dash -n` on both maintainer scripts, `dpkg-parsechangelog` on the new entry, and `dpkg --compare-versions '2026.09.0~snapshot19' lt '2026.09.0~snapshot20'`.

Application side: traced every reader of `consultation_fax_enabled`; the only non-boolean check was the two `oscarPropertiesCheck value="yes"` tags, now replaced with the scriptlet pattern already used elsewhere in the same file (`props` is declared at page scope). The JSP precompile (`mvn package -Pjspc`) was not run in this environment. A reviewer should open the consultation request form once with faxing enabled and confirm the Submit And Fax / Update And Fax buttons render.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dz3FftUTYwCX4vUfHZgwkA