### PR TITLE
fix(encounter): render the eChart notes panel once instead of twice

### DIFF
--- a/scripts/echart-new-patient-notes-playwright-checks.js
+++ b/scripts/echart-new-patient-notes-playwright-checks.js
@@ -356,14 +356,30 @@ async function assertNotesPaginationSettles(echart) {
     assert(!throbber.visible && throbber.display === 'none',
       `notes loading throbber stayed visible after pagination stopped: ${JSON.stringify(throbber)}`);
 
-    // An empty chart needs the initial load only. The encounter layout renders
-    // ChartNotes.jsp twice, so two are expected; anything beyond that means a
-    // poll walked the offset forward, or a second poll is still armed.
+    // An empty chart needs the initial load only. ChartNotes.jsp is rendered exactly
+    // once, into #notCPP, so exactly one fetch is expected; a second offset-0 fetch
+    // means the layout rendered the notes panel twice again, and anything at a higher
+    // offset means a poll walked the offset forward or a second poll is still armed.
     const paginationRequests = notesRequests.filter((r) => r.offset > 0);
     assert(paginationRequests.length === 0,
       `a chart with no notes paged for more: ${JSON.stringify(notesRequests)}`);
-    assert(notesRequests.length <= 2,
+    assert(notesRequests.length === 1,
       `unexpected number of notes fetches on an empty chart: ${JSON.stringify(notesRequests)}`);
+
+    // The notes panel must exist exactly once and live inside #notCPP, where the
+    // filter/save reloads replace it. Two Template Search fieldsets, two entry forms
+    // or two throbbers is the duplicate-render bug an alpha tester reported on an
+    // empty demo chart.
+    const panelCounts = await echart.evaluate(() => ({
+      templateSearch: document.querySelectorAll('#enTemplate').length,
+      entryForms: document.querySelectorAll('form[name="caseManagementEntryForm"]').length,
+      viewForms: document.querySelectorAll('form[name="caseManagementViewForm"]').length,
+      throbbers: document.querySelectorAll('#notesLoading').length,
+      noteContainers: document.querySelectorAll('#encMainDiv').length,
+      insideNotCpp: document.querySelectorAll('#notCPP #encMainDiv').length,
+    }));
+    assert(Object.values(panelCounts).every((count) => count === 1),
+      `the eChart must render the notes panel exactly once, inside #notCPP: ${JSON.stringify(panelCounts)}`);
     await screenshot(echart, config.screenshotDir, 'echart-new-patient-settled');
 
     const fatalConsole = recorder.consoleIssues.filter((issue) => /is not defined|SyntaxError|ReferenceError|Cannot read/i.test(issue.text || ''));

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp
@@ -31,9 +31,12 @@
 <%--
     ChartNotes.jsp — Renders the clinical notes panel inside the encounter page.
 
-    Loaded either as the standalone CaseManagementView AJAX result or as part of
-    newEncounterLayout.jsp. Displays filtered and sorted clinical notes for a
-    patient, with inline editing, issue assignment, and template insertion.
+    Rendered as the CaseManagementView "ajaxView" result into the encounter
+    layout's #notCPP container: on chart open through viewFullChart(false), and
+    again on every filter or save reload. newEncounterLayout.jsp must never also
+    include it server-side; that produced two note panels per chart. Displays
+    filtered and sorted clinical notes for a patient, with inline editing, issue
+    assignment, and template insertion.
 
     The 1 MB buffer (page directive + response.setBufferSize) prevents Tomcat 11
     from truncating large AJAX forward responses. Without it, the
@@ -160,11 +163,11 @@
         if (request.getParameter("caseManagementEntryForm") == null) {
             request.setAttribute("caseManagementEntryForm", cform);
         }
-        boolean layoutIncludesDependencies = Boolean.parseBoolean(
-                String.valueOf(request.getAttribute("eChartLayoutIncludesDependencies")));
 %>
 
-<% if (!layoutIncludesDependencies) { %>
+<%-- Shared libraries for the standalone route (casemgmt/ViewChartNotes). When this fragment is
+     inserted into #notCPP by CarlosAjax/update(), external <script src> tags are stripped and
+     not re-loaded (Prototype evalScripts semantics); only the inline scripts below run. --%>
 <script type="text/javascript" src="${carlos:forHtmlAttribute(ctx)}/library/jquery/jquery-3.7.1.min.js"></script>
 <script type="text/javascript" src="${carlos:forHtmlAttribute(ctx)}/library/jquery/jquery-ui-1.14.2.min.js"></script>
 <script type="text/javascript">jQuery.noConflict();</script>
@@ -176,7 +179,6 @@
 <!-- vanilla JS autocomplete select box (replaces Scriptaculous Autocompleter.SelectBox) -->
 <script src="${carlos:forHtmlAttribute(ctx)}/share/javascript/select.js" type="text/javascript"></script>
 <script type="text/javascript" src="${carlos:forHtmlAttribute(ctx)}/js/newCaseManagementView.js.jsp?v=<%= System.currentTimeMillis() %>"></script>
-<% } %>
 <script type="text/javascript">
     ctx = "${carlos:forJavaScript(ctx)}";
     imgPrintgreen.src = ctx + "/encounter/graphics/printerGreen.png"; //preload green print image so firefox will update properly
@@ -210,9 +212,9 @@
 
     jQuery(document).ready(function () {
         notesLoader(0, notesIncrement, demographicNo);
-        // The encounter layout renders this page twice on open, and both copies run this
-        // handler in the same window. Without the stop, the first interval handle is
-        // overwritten here and its timer polls on, unstoppable, for the life of the chart.
+        // Filter and save reloads re-render this fragment into #notCPP and run this handler
+        // again in the same window. Without the stop, the earlier interval handle would be
+        // overwritten here and its timer would poll on, unstoppable, for the life of the chart.
         stopNotesScrollCheck();
         notesScrollCheckInterval = setInterval('notesIncrementAndLoadMore()', 1000);
     });

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterLayout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterLayout.jsp
@@ -609,10 +609,19 @@
         </div>
 
         <div id="content">
+            <%--
+                newCaseManagementView.jsp supplies the CPP summary boxes and the empty #notCPP
+                container. The clinical notes panel (ChartNotes.jsp) is deliberately NOT included
+                here: the window load handler above calls viewFullChart(false), which POSTs to
+                CaseManagementEntry (method=edit, chain=list) and renders ChartNotes.jsp into
+                #notCPP with the state only that path prepares (entry form bean, restored draft,
+                note lock, filter lists). Filter and save reloads replace #notCPP the same way.
+                A second, server-side include of ChartNotes.jsp outside #notCPP once lived here;
+                it rendered a duplicate Template Search / note editor panel on every chart open and
+                a second "Loading Notes..." throbber that shared an id with the first, so only one
+                of the two could ever be hidden.
+            --%>
             <jsp:include page="/WEB-INF/jsp/casemgmt/newCaseManagementView.jsp"/>
-            <%-- Clinical notes are part of the first eChart render; CPP AJAX fragments only fill the summary boxes above. --%>
-            <c:set var="eChartLayoutIncludesDependencies" value="true" scope="request"/>
-            <jsp:include page="/WEB-INF/jsp/casemgmt/ChartNotes.jsp"/>
         </div>
     </div>
     <!-- hovering divs -->

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -495,12 +495,13 @@
     var notesCurrentTop = null;       // ID of topmost note element before pagination insert
     var notesScrollCheckInterval = null;
     /*
-     * Fetches still in flight, and the id of the most recent one. Both are needed because
-     * the encounter layout renders ChartNotes.jsp twice, so two offset-0 loads overlap on
-     * every chart open. The count holds off the scroll poll until BOTH have landed — a
-     * pagination fetch racing a pending initial load inserts its notes out of order. The
-     * id makes the older, superseded load a no-op at completion, so a first request that
-     * fails or gets redirected cannot stop the poll the second render just armed.
+     * Fetches still in flight, and the id of the most recent one. Loads can overlap: a
+     * filter or save reload re-renders ChartNotes.jsp into #notCPP and starts a fresh
+     * offset-0 load while a pagination fetch may still be pending. The count holds off the
+     * scroll poll until every pending load has landed — a pagination fetch racing a pending
+     * initial load inserts its notes out of order. The id makes the older, superseded load a
+     * no-op at completion, so a request that fails or gets redirected cannot stop the poll
+     * the latest render just armed.
      */
     var notesLoadsInFlight = 0;
     var notesLoadSequence = 0;
@@ -581,10 +582,10 @@
      * ends up looking at the notes that just arrived. (notesCurrentTop records the previous
      * top note for a scroll restore that was never written; nothing reads it today.)
      *
-     * Callers are never turned away: the encounter layout renders ChartNotes.jsp twice on
-     * open (the second render replaces #encMainDiv), so both initial loads must run or the
-     * surviving container is left empty. The in-flight count only holds off the scroll
-     * poll, which would otherwise stack requests behind a pending batch.
+     * Callers are never turned away: a filter or save reload replaces #encMainDiv and issues
+     * a new initial load while an earlier one may still be pending, and the newest load must
+     * run or the surviving container is left empty. The in-flight count only holds off the
+     * scroll poll, which would otherwise stack requests behind a pending batch.
      *
      * @param {number} offset - Zero-based offset into the patient's note list (0 = newest batch)
      * @param {number} numToReturn - Maximum number of notes to fetch in this batch

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/EChartLayoutRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/EChartLayoutRegressionTest.java
@@ -8,36 +8,54 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
  * Regression tests for the eChart JSP composition.
+ *
+ * <p>The clinical notes panel ({@code ChartNotes.jsp}) is rendered exactly once per chart,
+ * into the {@code #notCPP} container, by the {@code viewFullChart(false)} AJAX call the
+ * layout issues on window load (and again by filter/save reloads). The layout once also
+ * included the panel server-side, outside {@code #notCPP}; every chart then opened with two
+ * Template Search / note editor panels and a duplicate {@code #notesLoading} throbber that
+ * could never be hidden. These tests pin the single-render composition.
  */
+@Tag("unit")
 @DisplayName("eChart layout regression")
 class EChartLayoutRegressionTest {
 
     private static final Path NEW_ENCOUNTER_LAYOUT =
             Path.of("src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterLayout.jsp");
+    private static final Path NEW_CASE_MANAGEMENT_VIEW =
+            Path.of("src/main/webapp/WEB-INF/jsp/casemgmt/newCaseManagementView.jsp");
     private static final Path CHART_NOTES =
             Path.of("src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp");
 
     @Test
-    @DisplayName("should include clinical notes panel when rendering new encounter layout")
-    void shouldIncludeClinicalNotesPanel_whenRenderingNewEncounterLayout() throws IOException {
-        String jsp = Files.readString(NEW_ENCOUNTER_LAYOUT, StandardCharsets.UTF_8);
+    @DisplayName("should render notes panel once via AJAX when rendering new encounter layout")
+    void shouldRenderNotesPanelOnceViaAjax_whenRenderingNewEncounterLayout() throws IOException {
+        String layout = Files.readString(NEW_ENCOUNTER_LAYOUT, StandardCharsets.UTF_8);
+        String view = Files.readString(NEW_CASE_MANAGEMENT_VIEW, StandardCharsets.UTF_8);
 
-        assertThat(jsp).contains("<jsp:include page=\"/WEB-INF/jsp/casemgmt/newCaseManagementView.jsp\"/>");
-        assertThat(jsp).contains("<jsp:include page=\"/WEB-INF/jsp/casemgmt/ChartNotes.jsp\"/>");
+        assertThat(layout).contains("<jsp:include page=\"/WEB-INF/jsp/casemgmt/newCaseManagementView.jsp\"/>");
+        // The window-load AJAX render is the only render of the notes panel.
+        assertThat(layout).contains("viewFullChart(false);");
+        assertThat(layout).doesNotContain("<jsp:include page=\"/WEB-INF/jsp/casemgmt/ChartNotes.jsp\"");
+        assertThat(layout).doesNotContain("eChartLayoutIncludesDependencies");
+        // viewFullChart() and the filter/save reloads all replace this container.
+        assertThat(view).contains("<div id=\"notCPP\">");
     }
 
     @Test
-    @DisplayName("should suppress duplicate shared scripts when notes are layout-included")
-    void shouldSuppressDuplicateSharedScripts_whenNotesAreLayoutIncluded() throws IOException {
+    @DisplayName("should load shared scripts unconditionally for the notes fragment")
+    void shouldLoadSharedScriptsUnconditionally_forNotesFragment() throws IOException {
         String jsp = Files.readString(CHART_NOTES, StandardCharsets.UTF_8);
 
-        assertThat(jsp).contains("eChartLayoutIncludesDependencies");
-        assertThat(jsp).contains("if (!layoutIncludesDependencies)");
+        assertThat(jsp).doesNotContain("layoutIncludesDependencies");
         assertThat(jsp).contains("newCaseManagementView.js.jsp");
+        // Each render arms its own scroll poll; the previous one must be stopped first.
+        assertThat(jsp).contains("stopNotesScrollCheck();");
     }
 
     @Test


### PR DESCRIPTION
## Description

An alpha tester opened the eChart for the demo patient FAKE-Brent Zemlak (an empty chart) and saw two Template Search fieldsets and two encounter/note panels stacked in the notes pane. They also reported a "Loading Notes..." spinner that never clears on some charts.

Both symptoms have one cause: **`newEncounterLayout.jsp` rendered `ChartNotes.jsp` twice on every chart open.**

1. The layout included `ChartNotes.jsp` server-side, directly under `#content` (outside `#notCPP`).
2. On window load, the layout's `viewFullChart(false)` POSTs to `CaseManagementEntry` (`method=edit`, `chain=list` → `CaseManagementView` `ajaxView`) and inserts a second `ChartNotes.jsp` into `#notCPP`.

Every chart therefore opened with two entry forms, two view forms, two Template Search fieldsets, two `#encMainDiv` containers and two `#notesLoading` throbbers. It is only *obvious* on an empty chart, where nothing else fills the pane, which is why it looked patient-specific. (#3589's message already noted "the encounter layout renders ChartNotes.jsp twice on open" and worked around the double load rather than removing it.)

The "never-ending spinner" is the duplicate throbber: both spans carry `id="notesLoading"`, so `notesLoader()` can only ever hide the first one in DOM order. Which copy stayed visible depended on whether the AJAX render landed before or after the static copy's first load completed, hence "at times".

### Which copy to keep

Only the AJAX render carries the state the panel needs: `edit()` builds the entry form bean, restores a draft, takes the note lock; `view()` supplies the filter lists (providers, roles, issues) and runs the program-domain check. The server-side include ran none of that (the chart opens via `method=setUpMainEncounter`, which only looks up the client image), and it also survived every filter/save reload, since those replace `#notCPP` only. So the server-side include is removed and the layout now carries a comment explaining why it must not return.

### Changes

- `newEncounterLayout.jsp`: drop the server-side `ChartNotes.jsp` include and the `eChartLayoutIncludesDependencies` flag; `viewFullChart(false)` on window load is the single render.
- `ChartNotes.jsp`: remove the `layoutIncludesDependencies` switch that existed only for the duplicate. The shared `<script src>` tags are unconditional again (they are stripped, not re-loaded, when the fragment is inserted by `update()`, and are needed by the standalone `casemgmt/ViewChartNotes` route). Header and ready-handler comments updated.
- `newCaseManagementView.js.jsp`: comments only. The per-request in-flight/sequence bookkeeping from #3589 stays, because filter and save reloads still start a fresh offset-0 load while a pagination fetch can be pending.
- `EChartLayoutRegressionTest`: it pinned the server-side include; it now pins the single AJAX render (no `ChartNotes.jsp` include or layout flag in the layout, `#notCPP` present, `viewFullChart(false)` on load, `stopNotesScrollCheck()` before arming the poll).
- `scripts/echart-new-patient-notes-playwright-checks.js`: expects exactly one initial notes fetch (was `<= 2`) and asserts `#enTemplate`, both forms, `#notesLoading` and `#encMainDiv` exist exactly once and inside `#notCPP`.

Side effect worth knowing: the server-side copy rendered the notes panel even when `view()` would have returned `domain-error` for the patient. With one render, that access check is now the only thing shown for such patients, as designed.

## Related Issues

Related to #3589

## Target Branch

Supported-release fix for the 2026.08 line: topic branch from `release/2026.08` → `release/2026.08`. Maintainers forward-merge.

## How Was This Tested?

**Packaged install, Ubuntu 26.04, built from this branch.** `dpkg-buildpackage` in an `ubuntu:26.04` container using the WAR built from this branch (`CARLOS_WAR=`, DrugRef and the eForm renderer skipped), installed with the runbook preseed (Ontario, self-signed TLS, demo data, seeded `carlosdoc` kept) into a systemd-booted `ubuntu:26.04` container, provisioned with `carlos-ctl db-apply-settings && db-users && db-migrate && demo-data`. Every check below went through nginx + ModSecurity on `:443`.

Before/after on the same install, same patient the tester reported (demographic 1976, FAKE-Brent FAKE-Zemlak, empty chart), counting DOM elements after the chart settled:

| | pre-fix JSPs (release/2026.08) | this branch |
|---|---|---|
| `#enTemplate` (Template Search) | 2 | 1 |
| `form[name=caseManagementEntryForm]` | 2 | 1 |
| `#encMainDiv` | 2 (one outside `#notCPP`) | 1 (inside `#notCPP`) |
| `#notesLoading` throbbers | 2, one stuck `display:block` | 1, hidden |
| initial `viewNotesOpt` fetches | 2 | 1 |

The pre-fix screenshot matches the tester's photo (second Template Search and note panel below the toolbar, "Loading Notes..." stuck). The same single-panel result holds on the two note-heaviest demo charts (demographic 1 with 289 notes, demographic 12 with 40).

- `npm run test:echart-new-patient-playwright` — **PASS** on the packaged install with the tightened assertions (1 fetch, one panel inside `#notCPP`, throbber hidden).
- `npm run test:echart-playwright` — **PASS** (notes rendered, pagination stopped at end of chart, CPP save/archive, Unresolved Issues refresh).
- `mvn test -Dtest=EChartLayoutRegressionTest` — 3/3 pass.
- `scripts/lint/check-encoder-null-safety.sh` — PASS; `scripts/lint/check-bdd-test-naming.sh` — PASS (270 files); `node --check` on the Playwright script.

Two container-only workarounds were needed that are unrelated to this change: the seeded account's `forcePasswordReset` flag was cleared so the checks could log in, and the Docker image's `policy-rc.d` was removed so postinst could start MariaDB.

## Screenshots

Before (tester's photo, reproduced identically on the pre-fix build): two Template Search fieldsets and two note panels, "Loading Notes..." stuck. After: one panel, throbber hidden.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`) — **not signed off**: the commit was pushed without a `Signed-off-by` trailer and this environment may not amend or force-push. A maintainer can satisfy the check with the documented comment `Confirming DCO sign off for all commits at f368d4ddb42e3a00bbb7e1d0e21e0eb13637baf7`.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGEZkWvyohWDyzKEQbiESR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGEZkWvyohWDyzKEQbiESR)_

## Summary by Sourcery

Ensure the eChart notes panel is rendered exactly once inside #notCPP to fix duplicated panels and stuck loading indicators.

Bug Fixes:
- Render the eChart notes panel only once through its AJAX path, eliminating duplicate note forms, Template Search fields, containers, and loading indicators.
- Prevent the notes loading spinner from remaining visible because of duplicate elements sharing the same identifier.

Enhancements:
- Keep notes reload and polling safeguards for overlapping filter, save, and pagination requests while simplifying fragment rendering behavior.

Tests:
- Update JSP regression coverage to enforce single AJAX rendering into #notCPP and unconditional notes-fragment dependencies.
- Tighten Playwright checks to require one initial notes fetch and exactly one instance of each notes-panel element.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the eChart notes panel rendering twice on every chart open, showing two Template Search fieldsets and two note editors, plus a "Loading Notes..." spinner that never cleared because both throbbers shared `id="notesLoading"`. The panel now renders exactly once, via the `viewFullChart(false)` AJAX call that supplies the entry form, restored draft, note lock, and filter lists.

- `newEncounterLayout.jsp` drops the server-side `ChartNotes.jsp` include and the `eChartLayoutIncludesDependencies` flag.
- `ChartNotes.jsp` loads its shared script tags unconditionally again; they're stripped rather than re-loaded when the fragment is inserted, so the standalone `casemgmt/ViewChartNotes` route is unaffected.
- The in-flight/sequence bookkeeping from #3589 stays, since filter and save reloads still start a fresh offset-0 load while a pagination fetch may be pending.
- The regression test and new-patient Playwright check now assert exactly one notes panel inside `#notCPP`.

Side effect: patients whose `view()` returns `domain-error` now see only that access check, as designed.

Related to #3589.

<sup>Written for commit f368d4ddb42e3a00bbb7e1d0e21e0eb13637baf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

