### PR TITLE
fix(consultation): stop site/team privacy from blanking the consult inbox outside multisite

### DIFF
--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -7,8 +7,10 @@ the real front door (nginx + ModSecurity/CRS on `:443`), not the devcontainer's
 bare Tomcat.
 
 It is the procedure that first surfaced the WAF false positives on note-saving
-and eForm saves, the add-patient validation regression, and the nullable-column
-500s on the consultation surfaces. Last validated end-to-end 2026-08-31 with
+and eForm saves, the add-patient validation regression, the nullable-column
+500s on the consultation surfaces, and the empty Consultations inbox on the demo
+dataset (the seeded `_site_access_privacy` grant was applied without multisite mode;
+`consultation-nullable-fields-playwright-checks.js` now asserts the list has rows). Last validated end-to-end 2026-08-31 with
 **41/41 scripts passing** on 2026.09.0~snapshot18.
 
 That 37/37 is also the cautionary tale for this document. A tester found six

--- a/scripts/consultation-nullable-fields-playwright-checks.js
+++ b/scripts/consultation-nullable-fields-playwright-checks.js
@@ -118,6 +118,12 @@ function sqlValue(value) {
     await listPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
     await assertNotErrorPage(listPage, 'consultation list');
     await screenshot(listPage, config.screenshotDir, 'consultation-nullable-list');
+    // The demo dataset ships hundreds of consults, so an empty first page is a
+    // regression, not a filter: the packaged install once rendered zero rows
+    // because the seeded _site_access_privacy grant was applied without
+    // multisite mode. The per-request fallback below must not mask that.
+    const listRows = await listPage.locator('table.consult-table tbody tr').count();
+    assert(listRows > 0, 'consultation list rendered no rows for the demo dataset');
 
     // Open the staged request from the list the way a user would; the list
     // links carry requestId=<id>. Fall back to direct navigation only if the

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtil.java
@@ -139,9 +139,13 @@ public class EctViewConsultationRequestsUtil {
                  }
               }
 
-              providerId = demo.getProviderNo();
-              if ( providerId != null && !providerId.equals("")) {
-                  prov = providerDao.getProvider(demo.getProviderNo());
+              // Same contract as estConsultationVecByDemographic below: the whole loop
+              // shares one catch, so a consult whose demographic or most-responsible
+              // provider row is gone must degrade to "N/A" rather than NPE and blank the
+              // entire inbox list.
+              providerId = (demo != null) ? demo.getProviderNo() : null;
+              prov = (providerId != null && !providerId.isEmpty()) ? providerDao.getProvider(providerId) : null;
+              if ( prov != null ) {
                   providerName = prov.getFormattedName();
                   providerNo.add(prov.getProviderNo());
               }
@@ -164,10 +168,11 @@ public class EctViewConsultationRequestsUtil {
               boolean isEReferral = extraMap.containsKey(ConsultationRequestExtKey.EREFERRAL_REF.getKey());
 
               demographicNo.add(consult.getDemographicId().toString());
-              date.add(DateFormatUtils.ISO_DATE_FORMAT.format(consult.getReferralDate()));
+              Date referralDate = consult.getReferralDate();
+              date.add(referralDate != null ? DateFormatUtils.ISO_DATE_FORMAT.format(referralDate) : "");
               ids.add(consult.getId().toString());
               status.add(consult.getStatus());
-              patient.add(demo.getFormattedName());
+              patient.add(demo != null ? demo.getFormattedName() : "");
               provider.add(providerName);
               service.add(serviceDescription);
               vSpecialist.add(specialistName);
@@ -199,7 +204,8 @@ public class EctViewConsultationRequestsUtil {
                 followUpDate.add(DateFormatUtils.ISO_DATE_FORMAT.format(date1));
               }
               
-              Provider cProv = providerDao.getProvider(consult.getProviderNo());
+              String cProvNo = consult.getProviderNo();
+              Provider cProv = (cProvNo != null && !cProvNo.isEmpty()) ? providerDao.getProvider(cProvNo) : null;
               consultProvider.add(cProv);
           }
       } catch (Exception e) {            

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -128,21 +128,25 @@
     List<ProviderData> pdList = null;
     HashMap<String, String> providerMap = new HashMap<String, String>();
 
-    // Site/team access privacy is a MULTISITE feature and is only applied when
-    // multisite mode is on, mirroring the schedule (appointmentprovideradminday.jsp).
-    // The Flyway seed grants the admin role _site_access_privacy on every install,
-    // but without multisite there are no site assignments to restrict by and
-    // mgrSite below stays empty, so applying the filters here would silently
-    // drop EVERY consult from the list (seen on the packaged demo install).
-    boolean restrictToSiteOrTeam = bMultisites && (isSiteAccessPrivacy || isTeamAccessPrivacy);
+    // Site access privacy is a MULTISITE feature: providersite rows only exist
+    // when multisite mode is on, so it is applied only then, mirroring the
+    // schedule (appointmentprovideradminday.jsp). The Flyway seed grants the
+    // admin role _site_access_privacy on every install, and without multisite
+    // there are no site assignments to restrict by and mgrSite below stays
+    // empty, so applying it would silently drop EVERY consult from the list
+    // (seen on the packaged demo install). Team access privacy filters on the
+    // plain provider.team column and stays enforced without multisite.
+    boolean restrictToSite = bMultisites && isSiteAccessPrivacy;
+    boolean restrictToTeam = isTeamAccessPrivacy;
+    boolean restrictToSiteOrTeam = restrictToSite || restrictToTeam;
 
 //multisites function
     if (restrictToSiteOrTeam) {
 
-        if (isSiteAccessPrivacy)
+        if (restrictToSite)
             pdList = providerDataDao.findByProviderSite(curProvider_no);
 
-        if (isTeamAccessPrivacy)
+        if (restrictToTeam)
             pdList = providerDataDao.findByProviderTeam(curProvider_no);
 
         for (ProviderData providerData : pdList) {
@@ -218,11 +222,12 @@
         EctConsultationFormRequestUtil consultUtil;
         consultUtil = new EctConsultationFormRequestUtil();
 
-        // Same multisite gate as the row filters below: outside multisite mode the
-        // team dropdown lists every team rather than the (non-existent) site's.
-        if (restrictToSiteOrTeam && isTeamAccessPrivacy) {
+        // Same gates as the row filters below: outside multisite mode the site
+        // restriction is off, so the dropdown lists every team unless team
+        // privacy narrows it.
+        if (restrictToTeam) {
             consultUtil.estTeamsByTeam(curProvider_no);
-        } else if (restrictToSiteOrTeam && isSiteAccessPrivacy) {
+        } else if (restrictToSite) {
             consultUtil.estTeamsBySite(curProvider_no);
         } else {
             consultUtil.estTeams();
@@ -565,7 +570,9 @@
                                 }
 
                                 //multisites. skip record if not belong to same site
-                                if (restrictToSiteOrTeam) {
+                                // (mgrSite is only populated under multisite; without it
+                                // this check would drop every row).
+                                if (bMultisites && restrictToSiteOrTeam) {
                                     if (!mgrSite.contains(siteName)) continue;
                                 }
                                 overdue = false;

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -128,8 +128,16 @@
     List<ProviderData> pdList = null;
     HashMap<String, String> providerMap = new HashMap<String, String>();
 
+    // Site/team access privacy is a MULTISITE feature and is only applied when
+    // multisite mode is on, mirroring the schedule (appointmentprovideradminday.jsp).
+    // The Flyway seed grants the admin role _site_access_privacy on every install,
+    // but without multisite there are no site assignments to restrict by and
+    // mgrSite below stays empty, so applying the filters here would silently
+    // drop EVERY consult from the list (seen on the packaged demo install).
+    boolean restrictToSiteOrTeam = bMultisites && (isSiteAccessPrivacy || isTeamAccessPrivacy);
+
 //multisites function
-    if (isSiteAccessPrivacy || isTeamAccessPrivacy) {
+    if (restrictToSiteOrTeam) {
 
         if (isSiteAccessPrivacy)
             pdList = providerDataDao.findByProviderSite(curProvider_no);
@@ -210,9 +218,11 @@
         EctConsultationFormRequestUtil consultUtil;
         consultUtil = new EctConsultationFormRequestUtil();
 
-        if (isTeamAccessPrivacy) {
+        // Same multisite gate as the row filters below: outside multisite mode the
+        // team dropdown lists every team rather than the (non-existent) site's.
+        if (restrictToSiteOrTeam && isTeamAccessPrivacy) {
             consultUtil.estTeamsByTeam(curProvider_no);
-        } else if (isSiteAccessPrivacy) {
+        } else if (restrictToSiteOrTeam && isSiteAccessPrivacy) {
             consultUtil.estTeamsBySite(curProvider_no);
         } else {
             consultUtil.estTeams();
@@ -527,7 +537,7 @@
 
                             for (int i = 0; i < theRequests.ids.size(); i++) {
                                 //multisites. skip record if not belong to same site/team
-                                if (isSiteAccessPrivacy || isTeamAccessPrivacy) {
+                                if (restrictToSiteOrTeam) {
                                     if (providerMap.get(theRequests.providerNo.get(i)) == null) continue;
                                 }
 
@@ -555,7 +565,7 @@
                                 }
 
                                 //multisites. skip record if not belong to same site
-                                if (isSiteAccessPrivacy || isTeamAccessPrivacy) {
+                                if (restrictToSiteOrTeam) {
                                     if (!mgrSite.contains(siteName)) continue;
                                 }
                                 overdue = false;

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtilUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequestsUtilUnitTest.java
@@ -25,11 +25,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
@@ -38,6 +40,7 @@ import io.github.carlos_emr.carlos.commn.dao.ConsultationServiceDao;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.ConsultationManager;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -71,6 +74,7 @@ class EctViewConsultationRequestsUtilUnitTest extends CarlosUnitTestBase {
     private ConsultationRequestExtDao consultationRequestExtDao;
     private ProviderDao providerDao;
     private DemographicManager demographicManager;
+    private ConsultationManager consultationManager;
 
     private LoggedInInfo loggedInInfo;
     private EctViewConsultationRequestsUtil util;
@@ -89,6 +93,10 @@ class EctViewConsultationRequestsUtilUnitTest extends CarlosUnitTestBase {
         registerMock(DemographicManager.class, demographicManager);
         // Resolved by the util even on the serviceId==0 path, so it must be registered.
         registerMock(ConsultationServiceDao.class, mock(ConsultationServiceDao.class));
+        // The inbox (by-team) path folds the extension rows through the manager.
+        consultationManager = mock(ConsultationManager.class);
+        when(consultationManager.getExtValuesAsMap(any())).thenReturn(Map.of());
+        registerMock(ConsultationManager.class, consultationManager);
 
         // serviceId 0 routes the description and specialist lookups through the extensions table,
         // keeping these tests off the ConsultationServices path they are not about.
@@ -185,5 +193,74 @@ class EctViewConsultationRequestsUtilUnitTest extends CarlosUnitTestBase {
 
         assertThat(verdict).isTrue();
         assertThat(util.provider).containsExactly("Lovelace, Ada");
+    }
+
+    /**
+     * The inbox (by-team) list shares the by-demographic contract: one imperfect row must
+     * degrade to "N/A"/blank, never take every consult on the page down with it. The
+     * unbounded-filter call is what ViewConsultationRequests.jsp issues for the default
+     * "Consultations" view.
+     */
+    private void stubInboxQuery(ConsultationRequest consult) {
+        when(consultationRequestDao.getConsults(isNull(), eq(false), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull()))
+                .thenReturn(List.of(consult));
+    }
+
+    @Test
+    @DisplayName("should list the inbox consult when the demographic's MRP no longer exists")
+    void shouldListInboxConsult_whenMrpProviderRowWasDeleted() throws Exception {
+        when(demographicManager.getDemographic(any(LoggedInInfo.class), eq(DEMO_ID)))
+                .thenReturn(demographicWithMrp("999"));
+        when(providerDao.getProvider("999")).thenReturn(null);
+        stubInboxQuery(consultWithNoOrderingProvider());
+
+        boolean verdict = util.estConsultationVecByTeam(loggedInInfo, null, false, null, null, null, null,
+                null, null, null);
+
+        assertThat(verdict).isTrue();
+        assertThat(util.ids).containsExactly("7");
+        assertThat(util.provider).containsExactly("N/A");
+        assertThat(util.providerNo).containsExactly("-1");
+        assertThat(util.patient).containsExactly("Doe, Jane");
+        // A null referral date renders blank instead of NPE-ing the whole page.
+        assertThat(util.date).containsExactly("");
+    }
+
+    @Test
+    @DisplayName("should list the inbox consult when the demographic itself cannot be resolved")
+    void shouldListInboxConsult_whenDemographicCannotBeResolved() throws Exception {
+        when(demographicManager.getDemographic(any(LoggedInInfo.class), eq(DEMO_ID)))
+                .thenReturn(null);
+        stubInboxQuery(consultWithNoOrderingProvider());
+
+        boolean verdict = util.estConsultationVecByTeam(loggedInInfo, null, false, null, null, null, null,
+                null, null, null);
+
+        assertThat(verdict).isTrue();
+        assertThat(util.ids).containsExactly("7");
+        assertThat(util.provider).containsExactly("N/A");
+        assertThat(util.patient).containsExactly("");
+        assertThat(util.demographicNo).containsExactly(DEMO_NO);
+    }
+
+    @Test
+    @DisplayName("should render the inbox MRP's formatted name when the provider record resolves")
+    void shouldRenderInboxFormattedName_whenMrpResolves() throws Exception {
+        when(demographicManager.getDemographic(any(LoggedInInfo.class), eq(DEMO_ID)))
+                .thenReturn(demographicWithMrp("101"));
+        Provider mrp = new Provider();
+        mrp.setProviderNo("101");
+        mrp.setFirstName("Ada");
+        mrp.setLastName("Lovelace");
+        when(providerDao.getProvider("101")).thenReturn(mrp);
+        stubInboxQuery(consultWithNoOrderingProvider());
+
+        boolean verdict = util.estConsultationVecByTeam(loggedInInfo, null, false, null, null, null, null,
+                null, null, null);
+
+        assertThat(verdict).isTrue();
+        assertThat(util.provider).containsExactly("Lovelace, Ada");
+        assertThat(util.providerNo).containsExactly("101");
     }
 }


### PR DESCRIPTION
## Description

On a packaged (deb) install the **Consultations** inbox rendered zero rows for `carlosdoc`, after a noticeable delay, even though the demo dataset ships 268 consultation requests.

The data is fine: all 268 rows survive the additive demo load with valid patients, providers, specialists and services. The list page was throwing every row away:

- The Ontario and BC Flyway data seeds grant the `admin` role `_site_access_privacy`.
- `ViewConsultationRequests.jsp` applied its site/team privacy filters whenever that grant was present, regardless of multisite mode. With multisite disabled there are no site names to match, `mgrSite` stays empty, and every consult was skipped **after** the query and all per-row lookups had already run (hence the delay followed by an empty table).
- The devcontainer never shows this because its snapshot has no such grant; the deb uses the Flyway seed.

Changes:

- `ViewConsultationRequests.jsp`: apply the `_site_access_privacy` row filter, the site-name check and the site-based team dropdown only when multisite mode is on, mirroring how the schedule page (`appointmentprovideradminday.jsp`) already gates them. `_team_access_privacy` filters on the plain `provider.team` column and stays enforced without multisite (split per the Codex review finding).
- `EctViewConsultationRequestsUtil.estConsultationVecByTeam`: same null hardening the by-demographic path already has (missing demographic, missing MRP provider, null referral date, empty ordering provider degrade to `N/A`/blank instead of NPE-ing the whole inbox out of the shared catch).
- `EctViewConsultationRequestsUtilUnitTest`: three new tests for the inbox path.
- `scripts/consultation-nullable-fields-playwright-checks.js`: assert the demo list actually renders rows. Previously it silently fell back to direct navigation, which is why the deb validation run stayed green with an empty list.
- `docs/ui-tests/deb-install-validation.md`: record the finding.

Not changed here, worth a follow-up: the seed itself grants `_site_access_privacy` to `admin` on every install, and other pages that honour that grant without a multisite gate (for example the day sheet report) may hide rows the same way.

## Related Issues

None filed; reported directly from a 2026.08 alpha deb install.

## Target Branch

Supported fix for the 2026.08 alpha train: topic branch cut from `release/2026.08` and targeting `release/2026.08`, per `docs/release-process.md`. Maintainers forward-merge into `develop`.

## How Was This Tested?

- Built the `carlos-emr` .deb from this tree inside an `ubuntu:26.04` container (`dpkg-buildpackage -us -uc -b`, DrugRef and eform-renderer skipped), installed it into a second `ubuntu:26.04` container with `carlos-emr/install-demo-data=true`, started the packaged Tomcat, and drove the Consultations link as `carlosdoc` with Playwright.

  | State | Rows on the Consultations list |
  |---|---|
  | Packaged install as shipped | 0 |
  | Same install, seeded `_site_access_privacy` grant removed | 100 (first page) |
  | Same install, grant kept, patched JSP deployed | 100 (first page) |
  | Patched JSP, `_team_access_privacy` granted, carlosdoc on a team | 96 (only consults whose MRP shares the team) |
  | Patched JSP, `_team_access_privacy` granted, carlosdoc with no team | 0 |

- Seeded a MariaDB 11.4 instance exactly the way `carlos-ctl demo-data` assembles the stream and confirmed all 268 consults load with no dangling demographic/provider/specialist/service references.
- `mvn -Dtest=EctViewConsultationRequestsUtilUnitTest test`: 6/6 pass.
- `scripts/lint/check-encoder-null-safety.sh`: PASS.
- `node --check` on the modified Playwright script.

## Screenshots

Before: empty table under "View Consultation Requests". After: the demo consults listed (first page of 100), same install and same seeded privileges.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn9d2QQhuBe6dUh2sv63H9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sn9d2QQhuBe6dUh2sv63H9)_

## Summary by Sourcery

Restore consultation inbox results outside multisite and make incomplete consultation records render safely.

Bug Fixes:
- Prevent the Consultations inbox from incorrectly showing no rows on packaged installs when multisite is disabled.
- Preserve consultation rows when demographic, provider, or referral-date data is missing by rendering safe fallback values instead of failing the inbox load.

Enhancements:
- Align consultation privacy filtering and team selection with multisite configuration while retaining team-based privacy enforcement.

Documentation:
- Document the packaged-install empty inbox finding and its validation coverage.

Tests:
- Add unit coverage for incomplete consultation data and successful provider-name rendering.
- Make the consultation Playwright check fail when the demo consultation list renders no rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Consultations inbox rendering an empty list on packaged installs outside multisite mode: site privacy now gates on multisite, team privacy stays enforced everywhere, and the by-team inbox path no longer blanks on rows with missing data.

- Site privacy row filters and the site-based team dropdown now apply only when multisite mode is on; team privacy still filters on the plain `provider.team` column outside multisite.
- `EctViewConsultationRequestsUtil.estConsultationVecByTeam` now degrades missing demographics, missing MRP providers, and null referral dates to `N/A`/blank instead of NPE-ing the entire inbox.
- Added three unit tests covering the inbox path.
- The consultation Playwright check now asserts the demo list renders rows instead of silently falling back to direct navigation.

**Follow-up**
- Other pages that honor `_site_access_privacy` without a multisite gate (for example the day sheet report) may hide rows the same way.

<sup>Written for commit 3aa97fb8825d1dbb53da49832bf62ff1a9a23266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>

<!-- End of auto-generated description by cubic. -->
