### PR TITLE
fix(rx): make Administration &gt; Update Drugref report how the update ends

### DIFF
--- a/debian/carlos-emr-drugref.README.Debian
+++ b/debian/carlos-emr-drugref.README.Debian
@@ -47,6 +47,37 @@ Refresh or replace the dataset according to your own drug-data source and
 licensing. Commercial Medi-Span interaction monographs need a licence key in
 /etc/carlos-emr/drugref2.properties.
 
+Updating the dataset from Health Canada
+---------------------------------------
+Administration > Update Drugref (in CARLOS) asks DrugRef to rebuild its
+database from Health Canada's current Drug Product Database extract. The page
+follows the run and reports how it ended; a failed run keeps the previous
+dataset and says why it failed. The run takes 15 to 60 minutes, during which
+drug lookups when prescribing are limited, so start it outside clinic hours.
+
+What it needs from this host:
+
+  * Outbound HTTPS from the carlos-emr service to www.canada.ca. The download
+    is made by the Tomcat JVM itself (DrugRef runs inside it), so a host that
+    only allows browsers out through a proxy must pass the proxy to the JVM.
+    Set it in /etc/carlos-emr/carlos-emr.env and restart:
+
+        CARLOS_JAVA_OPTS="-Dhttps.proxyHost=proxy.example.ca -Dhttps.proxyPort=3128"
+
+    A proxy that intercepts TLS must also have its CA trusted by the JVM
+    (-Djavax.net.ssl.trustStore=... in the same variable, or import it into
+    the JDK's cacerts). Without either, the update fails during its download
+    step, harmlessly, and the page shows the reason.
+
+  * A mirror instead of the live site, if you stage the archives yourself:
+    set DPD_BASE_URL=https://mirror.example.ca/dpd in
+    /etc/carlos-emr/drugref2.properties (the file is read at Tomcat start).
+
+The run's log lines are prefixed "DrugRef database update" in
+journalctl -u carlos-emr. Every table the update rebuilds is kept as
+<table>_prev until the run succeeds; an interrupted run (a service restart
+mid-import) is rolled back automatically at the next start.
+
 Deployment fix baked into the webapp
 ------------------------------------
 The package installs WEB-INF/classes/hibernate.properties naming the dialect

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -3,9 +3,16 @@
 # release build: a branch name makes two builds weeks apart ship different
 # code under one package version.
 #
-# The current pin is the master merge commit of the pre-release security
-# hardening (carlos-emr/drugref2026#10). It must not be moved back below this
-# revision: earlier DrugRef builds ship the bundled `root` superuser credential
+# The current pin carries the database-update fix (carlos-emr/drugref2026
+# branch claude/drugref-db-update-trigger-8vxtn7, on top of the #10 merge):
+# download-before-drop, rollback to the previous dataset on failure, the
+# Hibernate 7 HQL fix without which every update died with the tables
+# already dropped, the column widths the 2026 extract needs, and the
+# getUpdateStatus() method Administration > Update Drugref polls. Advance it
+# to that branch's merge commit once it lands on master.
+#
+# It must not be moved back below the #10 merge (566a46eec559a0ba02f40afbc37ff14440bbc098):
+# earlier DrugRef builds ship the bundled `root` superuser credential
 # with a password published in that source tree, browser JSPs that run a
 # destructive database re-import on an unauthenticated GET and reflect a request
 # parameter unencoded, and JPQL built by string concatenation — including an
@@ -13,4 +20,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=566a46eec559a0ba02f40afbc37ff14440bbc098
+ref=a53deaaf7467ebab9a422de396e0726407199897

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -20,4 +20,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=a53deaaf7467ebab9a422de396e0726407199897
+ref=6955f3a5c86ea22b8d17e12c4b06d4b0e0f04c04

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -22,7 +22,10 @@
 # success and then dropped the *_prev tables, destroying the only copy of the
 # drug data. And the "refuse to start on an unresolvable swap" guard now
 # actually fires -- it was unreachable, because the undecidable-marker error
-# arrived through the same catch as "could not reach the database".
+# arrived through the same catch as "could not reach the database". And a
+# restore no longer guesses about an orphan table: the backup records what it
+# moved, so a table the import created is emptied and one the rename loop
+# never reached is left alone.
 #
 # This revision was verified on a packaged install (Ubuntu 26.04, MariaDB
 # 11.8.6): the four startup-repair cases, the empty-rebuild gate firing and
@@ -42,4 +45,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=97c5d64f462d80e3e59b425e9ef5cc4e11eef107
+ref=bcac158506571c329396dc9528019dc1608b62a7

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -8,8 +8,20 @@
 # download-before-drop, rollback to the previous dataset on failure, the
 # Hibernate 7 HQL fix without which every update died with the tables
 # already dropped, the column widths the 2026 extract needs, and the
-# getUpdateStatus() method Administration > Update Drugref polls. Advance it
-# to that branch's merge commit once it lands on master.
+# getUpdateStatus() method Administration > Update Drugref polls.
+#
+# It also carries the crash-safety fixes found in review of that branch: the
+# startup repair registers its JDBC driver explicitly (without which it did
+# nothing on every boot), the swap marker moves in one atomic statement and is
+# the commit point, the rollback reads that marker rather than a local flag
+# (so a commit that lands and then reports an error no longer restores the
+# previous dataset over the accepted one), and an empty marker left by a crash
+# between the marker's CREATE and INSERT is cleared rather than failing every
+# subsequent update.
+#
+# This is still a BRANCH HEAD. Advance it to that branch's merge commit once
+# carlos-emr/drugref2026#11 lands on master, before the CARLOS PR merges: a
+# release build must not fetch a ref that can move.
 #
 # It must not be moved back below the #10 merge (566a46eec559a0ba02f40afbc37ff14440bbc098):
 # earlier DrugRef builds ship the bundled `root` superuser credential

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -35,4 +35,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=98a1a819c843c160b59f237a1fe8cba5b9c3b814
+ref=e6cf209cdd918e23af0c331804dedcf1db512ebc

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -20,4 +20,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=7e64f6915c58ffdfc3b0149c504ff078ffcfedb3
+ref=29a238ebb4ee4ae203e47fe2cca838e0578d8baa

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -20,4 +20,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=6955f3a5c86ea22b8d17e12c4b06d4b0e0f04c04
+ref=7e64f6915c58ffdfc3b0149c504ff078ffcfedb3

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -20,7 +20,14 @@
 # subsequent update. It also refuses to commit a rebuild that produced no drug
 # rows: a swallowed read failure used to yield an empty import that reported
 # success and then dropped the *_prev tables, destroying the only copy of the
-# drug data.
+# drug data. And the "refuse to start on an unresolvable swap" guard now
+# actually fires -- it was unreachable, because the undecidable-marker error
+# arrived through the same catch as "could not reach the database".
+#
+# This revision was verified on a packaged install (Ubuntu 26.04, MariaDB
+# 11.8.6): the four startup-repair cases, the empty-rebuild gate firing and
+# restoring, and a full 31-minute rebuild to 39198 products / 80065 search
+# entries with drug search answering afterwards.
 #
 # This is still a BRANCH HEAD. Advance it to that branch's merge commit once
 # carlos-emr/drugref2026#11 lands on master, before the CARLOS PR merges: a
@@ -35,4 +42,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=e6cf209cdd918e23af0c331804dedcf1db512ebc
+ref=97c5d64f462d80e3e59b425e9ef5cc4e11eef107

--- a/debian/drugref.pin
+++ b/debian/drugref.pin
@@ -17,7 +17,10 @@
 # (so a commit that lands and then reports an error no longer restores the
 # previous dataset over the accepted one), and an empty marker left by a crash
 # between the marker's CREATE and INSERT is cleared rather than failing every
-# subsequent update.
+# subsequent update. It also refuses to commit a rebuild that produced no drug
+# rows: a swallowed read failure used to yield an empty import that reported
+# success and then dropped the *_prev tables, destroying the only copy of the
+# drug data.
 #
 # This is still a BRANCH HEAD. Advance it to that branch's merge commit once
 # carlos-emr/drugref2026#11 lands on master, before the CARLOS PR merges: a
@@ -32,4 +35,4 @@
 # surface. It also carries the earlier EntityManager-leak fix
 # (carlos-emr/drugref2026#8), without which drug searches exhaust the JDBC pool
 # after one or two calls and permanently return "None found".
-ref=29a238ebb4ee4ae203e47fe2cca838e0578d8baa
+ref=98a1a819c843c160b59f237a1fe8cba5b9c3b814

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -345,6 +345,7 @@ sudo carlos-ctl check
 | A specific page or action fails, but nothing in the application log | `sudo carlos-ctl waf tail` | The WAF blocked the request before it reached the application — the tail explains which rule and why |
 | eForm print/fax produces no PDF, application log silent | `sudo journalctl -u carlos-emr-chromedriver -n 50` | The render browser is its own service with its own journal; if it cannot start, eForm rendering fails by design |
 | Drug search returns nothing when prescribing | `sudo carlos-ctl check` (DrugRef probe) | `carlos-emr-drugref` not installed, or its service is down |
+| Administration > Update Drugref reports a failed update, or stays "updating" | The message on that page; `sudo journalctl -u carlos-emr \| grep 'DrugRef database update'` | The Tomcat JVM has no outbound HTTPS to `www.canada.ca` (proxy not passed via `CARLOS_JAVA_OPTS`, see `/usr/share/doc/carlos-emr-drugref/README.Debian`). A failed run keeps the previous drug data |
 | "no space left on device" anywhere | `df -h /var` | Database, document store and the local backup tier all live under `/var` — grow the disk or move backups offsite |
 
 ## The full operator reference

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -345,7 +345,7 @@ sudo carlos-ctl check
 | A specific page or action fails, but nothing in the application log | `sudo carlos-ctl waf tail` | The WAF blocked the request before it reached the application — the tail explains which rule and why |
 | eForm print/fax produces no PDF, application log silent | `sudo journalctl -u carlos-emr-chromedriver -n 50` | The render browser is its own service with its own journal; if it cannot start, eForm rendering fails by design |
 | Drug search returns nothing when prescribing | `sudo carlos-ctl check` (DrugRef probe) | `carlos-emr-drugref` not installed, or its service is down |
-| Administration > Update Drugref reports a failed update, or stays "updating" | The message on that page; `sudo journalctl -u carlos-emr \| grep 'DrugRef database update'` | The Tomcat JVM has no outbound HTTPS to `www.canada.ca` (proxy not passed via `CARLOS_JAVA_OPTS`, see `/usr/share/doc/carlos-emr-drugref/README.Debian`). A failed run keeps the previous drug data |
+| Administration > Update Drugref reports a failed update, or stays "updating" | The message on that page; `sudo journalctl -u carlos-emr \| grep -E 'DrugRef (database update\|updateDB failed)'` | The Tomcat JVM has no outbound HTTPS to `www.canada.ca` (proxy not passed via `CARLOS_JAVA_OPTS`, see `/usr/share/doc/carlos-emr-drugref/README.Debian`). A failed run keeps the previous drug data |
 | "no space left on device" anywhere | `df -h /var` | Database, document store and the local backup tier all live under `/var` — grow the disk or move backups offsite |
 
 ## The full operator reference

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -252,6 +252,9 @@ Environment contract (one block, exported before every script):
 ```bash
 cd /root/carlos
 export BASE_URL=https://127.0.0.1/carlos
+# Devcontainer seed values. On a FRESH DEB INSTALL the package randomises the password and the
+# PIN for carlosdoc -- read both from /etc/carlos-emr/initial-admin.txt and use those instead,
+# starting with the one-time forced-reset step further down.
 export TEST_USER=carlosdoc TEST_PASSWORD=carlos2026 TEST_PIN=2026
 # DB-backed checks: root over the MariaDB unix socket (the password value is
 # ignored by unix_socket auth but the scripts require it to be set).
@@ -349,13 +352,28 @@ export DRUGREF_UPDATE_TRIGGER=false DRUGREF_UPDATE_REQUIRE_STATUS=true
 # same invocation is still using the OLD TEST_PASSWORD and fails too. The reset is a one-time,
 # persistent change to the account, so it belongs outside the loop entirely.
 #
-# Run this ONCE, before exporting anything else, then use the new password for the whole suite:
+# The reset logs in with the CURRENT credential, so TEST_PASSWORD and TEST_PIN must be the
+# package-generated ones from /etc/carlos-emr/initial-admin.txt for this one command -- NOT the
+# carlos2026 / 2026 in the environment block above, which are the devcontainer seed values. The
+# package replaces both (the username stays carlosdoc; the password and the PIN are random per
+# install), so with the block's values the login fails on a wrong password before it ever
+# reaches /forcepasswordreset, and the reset silently does not happen. Set them inline so the
+# block's exports cannot shadow them:
 #
+#   sudo sed -n 's/^ *\(user\|password\|PIN\):/\1:/p' /etc/carlos-emr/initial-admin.txt
+#
+#   TEST_PASSWORD='<password from initial-admin.txt>' \
+#   TEST_PIN='<PIN from initial-admin.txt>' \
 #   RESET_PASSWORD='Carlos2026!Verify' \
 #     node scripts/drugref-update-playwright-checks.js      # completes the reset, then checks
-#   export TEST_PASSWORD='Carlos2026!Verify'                # for the loop below and every rerun
 #
-# Not needed on the devcontainer, whose carlosdoc is not flagged.
+# Then re-export both for the loop below and every rerun -- the PIN does not change during the
+# reset, so it keeps the generated value for the rest of the suite:
+#
+#   export TEST_PASSWORD='Carlos2026!Verify'
+#   export TEST_PIN='<PIN from initial-admin.txt>'
+#
+# Not needed on the devcontainer, whose carlosdoc is not flagged and does keep carlos2026/2026.
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -339,6 +339,16 @@ export RX_FAX_ROUND_TRIP_TIMEOUT_MS=180000
 #     DRUGREF_UPDATE_TIMEOUT_SEC=3600 \
 #     timeout 3900 node scripts/drugref-update-playwright-checks.js
 export DRUGREF_UPDATE_TRIGGER=false DRUGREF_UPDATE_REQUIRE_STATUS=true
+# On a FRESH install the packaged admin credential (/etc/carlos-emr/initial-admin.txt) is
+# flagged for a forced password reset, so TEST_PASSWORD alone cannot log in: the login lands on
+# /forcepasswordreset and every check fails there before testing anything. Set RESET_PASSWORD to
+# a new password meeting the policy and the first check completes the reset once.
+#
+# The reset is a ONE-TIME, PERSISTENT change to the account. After it, TEST_PASSWORD must be the
+# NEW password for every subsequent run -- so once the first check has passed, set
+#   export TEST_PASSWORD="$RESET_PASSWORD"
+# and drop RESET_PASSWORD. Neither is needed on the devcontainer, whose carlosdoc is not flagged.
+export RESET_PASSWORD='Carlos2026!Verify'
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -321,6 +321,15 @@ export RX_FAX_DOCUMENT_DIR=/var/lib/carlos-emr/CarlosDocument/carlos/document
 # click can take longer than the check's default 45 s round-trip allowance; raise it for a
 # cold server rather than reading the timeout as a fax failure.
 export RX_FAX_ROUND_TRIP_TIMEOUT_MS=180000
+# Administration > Update Drugref (drugref-update-playwright-checks.js). Read-only by default:
+# it opens the page from the Administration panel and asserts the status panel and the status
+# relay answer. DRUGREF_UPDATE_TRIGGER=true also clicks the button and follows the rebuild to
+# its end (SUCCEEDED, date moved forward, drug search still answers). That rebuilds the DrugRef
+# database from DPD_BASE_URL in /etc/carlos-emr/drugref2.properties -- Health Canada's site
+# unless you point it at a mirror -- and takes 15-60 minutes, so run it last and only on a
+# throwaway VM. DRUGREF_UPDATE_REQUIRE_STATUS=true rejects a DrugRef build without
+# getUpdateStatus (the packaged one must have it).
+export DRUGREF_UPDATE_TRIGGER=false DRUGREF_UPDATE_REQUIRE_STATUS=true
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -329,6 +329,15 @@ export RX_FAX_ROUND_TRIP_TIMEOUT_MS=180000
 # unless you point it at a mirror -- and takes 15-60 minutes, so run it last and only on a
 # throwaway VM. DRUGREF_UPDATE_REQUIRE_STATUS=true rejects a DrugRef build without
 # getUpdateStatus (the packaged one must have it).
+# TRIGGER stays false in this exported block: the suite loop below runs every script under
+# `timeout 300`, and a triggered rebuild takes 15-60 minutes, so the loop would SIGTERM it
+# mid-rebuild -- skipping the script's cleanup and leaving the remaining drug-dependent
+# checks running against a half-rebuilt database. Run the triggered mode on its own, after
+# the loop finishes, with a timeout longer than DRUGREF_UPDATE_TIMEOUT_SEC:
+#
+#   DRUGREF_UPDATE_TRIGGER=true DRUGREF_UPDATE_REQUIRE_STATUS=true \
+#     DRUGREF_UPDATE_TIMEOUT_SEC=3600 \
+#     timeout 3900 node scripts/drugref-update-playwright-checks.js
 export DRUGREF_UPDATE_TRIGGER=false DRUGREF_UPDATE_REQUIRE_STATUS=true
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do

--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -339,16 +339,23 @@ export RX_FAX_ROUND_TRIP_TIMEOUT_MS=180000
 #     DRUGREF_UPDATE_TIMEOUT_SEC=3600 \
 #     timeout 3900 node scripts/drugref-update-playwright-checks.js
 export DRUGREF_UPDATE_TRIGGER=false DRUGREF_UPDATE_REQUIRE_STATUS=true
-# On a FRESH install the packaged admin credential (/etc/carlos-emr/initial-admin.txt) is
-# flagged for a forced password reset, so TEST_PASSWORD alone cannot log in: the login lands on
-# /forcepasswordreset and every check fails there before testing anything. Set RESET_PASSWORD to
-# a new password meeting the policy and the first check completes the reset once.
+# FRESH INSTALL ONLY: clear the forced password reset BEFORE the loop below, not inside it.
 #
-# The reset is a ONE-TIME, PERSISTENT change to the account. After it, TEST_PASSWORD must be the
-# NEW password for every subsequent run -- so once the first check has passed, set
-#   export TEST_PASSWORD="$RESET_PASSWORD"
-# and drop RESET_PASSWORD. Neither is needed on the devcontainer, whose carlosdoc is not flagged.
-export RESET_PASSWORD='Carlos2026!Verify'
+# The packaged admin credential (/etc/carlos-emr/initial-admin.txt) is flagged for a forced
+# reset, so TEST_PASSWORD alone cannot log in -- every check lands on /forcepasswordreset and
+# fails there before testing anything. Doing it inside the loop does not work, in both
+# directions: the loop runs scripts in glob order, so several run before drugref-update and
+# abort on the reset; and once one of them has reset the credential, every later script in the
+# same invocation is still using the OLD TEST_PASSWORD and fails too. The reset is a one-time,
+# persistent change to the account, so it belongs outside the loop entirely.
+#
+# Run this ONCE, before exporting anything else, then use the new password for the whole suite:
+#
+#   RESET_PASSWORD='Carlos2026!Verify' \
+#     node scripts/drugref-update-playwright-checks.js      # completes the reset, then checks
+#   export TEST_PASSWORD='Carlos2026!Verify'                # for the loop below and every rerun
+#
+# Not needed on the devcontainer, whose carlosdoc is not flagged.
 
 for s in scripts/*-playwright-checks.js scripts/demographic-master-crud-smoke.js; do
   case "$s" in *eform-corpus-soak*) continue ;; esac   # needs a corpus dir; see below

--- a/scripts/drugref-update-playwright-checks.js
+++ b/scripts/drugref-update-playwright-checks.js
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for Administration > Update Drugref, driven the way
+ * an operator uses it: log in, open the Administration panel, click the
+ * "Update Drugref" link, read the status panel, and (optionally) click the
+ * button and follow the run to its end.
+ *
+ * Why this exists. A tester on 2026.08.0-alpha11 reported that "the feature to
+ * trigger drugref to update the db from CARLOS is not working". What actually
+ * happened: the click DID reach DrugRef, which dropped every drug table, then
+ * died on a Hibernate 7 HQL rejection with its in-progress flag still set. The
+ * page said "Update has started" and never looked again, the status probe said
+ * "updating" forever, and drug search answered "None found" until the seed was
+ * reloaded by hand. Nothing in the suite drove this page. This check pins:
+ *
+ *   1. The page reaches DrugRef: the verify probe answers a real date/version.
+ *   2. The status relay (method=status) answers JSON with a `state`, so the
+ *      page can tell "running" from "died". UNAVAILABLE is accepted only when
+ *      DRUGREF_UPDATE_REQUIRE_STATUS is not "true" (a DrugRef build older than
+ *      getUpdateStatus); the packaged deployment must answer a real state.
+ *   3. With DRUGREF_UPDATE_TRIGGER=true: the click gets "running" (or "already
+ *      running"), the page follows the run, the run ends SUCCEEDED, the date in
+ *      the panel moves forward, and a live drug search still answers. This
+ *      rebuilds the DrugRef database from DPD_BASE_URL and takes 15-60 minutes
+ *      against Health Canada; point DPD_BASE_URL at a local mirror in CI.
+ *
+ * Runs read-only by default (steps 1 and 2 only), so it is safe in the
+ * deb-install suite loop (docs/ui-tests/deb-install-validation.md §6).
+ *
+ * Requires the deb-install env contract: BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN.
+ * Optional: DRUGREF_UPDATE_TRIGGER (default false), DRUGREF_UPDATE_TIMEOUT_SEC
+ *   (default 3600), DRUGREF_UPDATE_REQUIRE_STATUS (default false), CHROME_PATH,
+ *   DRUGREF_UPDATE_SCREENSHOT_DIR (default /tmp), DRUG_SEARCH_TERM (default "amox").
+ */
+
+const { chromium } = require('playwright');
+const {
+  assert,
+  assertNoPageErrors,
+  assertNotErrorPage,
+  buildFailureDetails,
+  createRecorder,
+  getLaunchOptions,
+  gotoApp,
+  login,
+  screenshot,
+  validateBaseUrl,
+  wirePage,
+} = require('./eform-local-playwright-utils');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  screenshotDir: process.env.DRUGREF_UPDATE_SCREENSHOT_DIR || '/tmp',
+};
+const trigger = process.env.DRUGREF_UPDATE_TRIGGER === 'true';
+const requireStatus = process.env.DRUGREF_UPDATE_REQUIRE_STATUS === 'true';
+const timeoutSec = Number(process.env.DRUGREF_UPDATE_TIMEOUT_SEC || '3600');
+const searchTerm = process.env.DRUG_SEARCH_TERM || 'amox';
+assert(Number.isFinite(timeoutSec) && timeoutSec > 0, `DRUGREF_UPDATE_TIMEOUT_SEC must be a positive number, got ${process.env.DRUGREF_UPDATE_TIMEOUT_SEC}`);
+
+// Context-relative: BASE_URL carries the webapp context (/carlos), and the page's own
+// calls are made against it.
+const ENDPOINT = `${config.baseUrl.pathname.replace(/\/$/, '')}/rx/updateDrugrefDB`;
+
+function postedMethod(response) {
+  const body = response.request().postData() || '';
+  const match = /(?:^|&)method=([^&]*)/.exec(body);
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+async function callStatus(page) {
+  // Same call the page makes, through the page's own session and CSRF token.
+  return page.evaluate(async (endpoint) => {
+    const token = (document.querySelector('input[name="CSRF-TOKEN"]') || {}).value || '';
+    const body = new URLSearchParams();
+    body.append('method', 'status');
+    body.append('CSRF-TOKEN', token);
+    const r = await fetch(endpoint, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'CSRF-TOKEN': token,
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: body.toString(),
+    });
+    return { status: r.status, contentType: r.headers.get('content-type') || '', text: await r.text() };
+  }, ENDPOINT);
+}
+
+(async () => {
+  const recorder = createRecorder();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  try {
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 900 } });
+    const landing = await login(context, config, recorder);
+    await landing.close();
+
+    // Reach the page the way an operator does: the Administration panel's link
+    // opens it in a popup window.
+    const admin = await context.newPage();
+    wirePage(admin, 'admin-panel', recorder);
+    await gotoApp(admin, config.baseUrl, '/admin/ViewAdmin');
+    await admin.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(admin, 'administration panel');
+    const link = admin.locator('a', { hasText: /^\s*Update Drugref\s*$/i }).first();
+    await link.waitFor({ state: 'attached', timeout: 20000 });
+    const [popup] = await Promise.all([
+      context.waitForEvent('page', { timeout: 20000 }),
+      link.evaluate((a) => a.click()),
+    ]);
+    wirePage(popup, 'update-drugref', recorder);
+    await popup.waitForLoadState('domcontentloaded', { timeout: 30000 });
+    await assertNotErrorPage(popup, 'Update Drugref page');
+    assert(/\/admin\/ViewUpdateDrugref/.test(popup.url()), `popup opened ${popup.url()}, expected /admin/ViewUpdateDrugref`);
+
+    // Step 1: the verify probe answered and the panel shows a real dataset.
+    const verifyResponse = await popup.waitForResponse(
+      (r) => r.url().includes(ENDPOINT) && postedMethod(r) === 'verify',
+      { timeout: 30000 },
+    );
+    assert(verifyResponse.status() === 200, `verify probe answered HTTP ${verifyResponse.status()}`);
+    const verify = await verifyResponse.json();
+    assert(
+      verify && verify.lastUpdate && verify.lastUpdate !== 'updating',
+      `verify answered ${JSON.stringify(verify)}: DrugRef is unavailable, has no data, or an update is already running`,
+    );
+    await popup.locator('#statusDisplay').waitFor({ state: 'visible', timeout: 20000 });
+    const dateBefore = (await popup.locator('#dbDateTime').innerText()).trim();
+    assert(dateBefore === verify.lastUpdate, `panel shows "${dateBefore}" but verify said "${verify.lastUpdate}"`);
+    assert((await popup.locator('#drugDatabase').innerText()).trim().length > 0, 'panel shows no database name');
+    console.log(`STEP 1 verify: PASS (${verify.drugDatabase} ${verify.version}, last update ${dateBefore})`);
+
+    // Step 2: the status relay answers JSON with a state the page can act on.
+    const statusReply = await callStatus(popup);
+    assert(statusReply.status === 200, `status relay answered HTTP ${statusReply.status}`);
+    assert(/json/i.test(statusReply.contentType), `status relay answered "${statusReply.contentType}", not JSON`);
+    let status;
+    try {
+      status = JSON.parse(statusReply.text);
+    } catch (e) {
+      assert(false, `status relay body is not JSON: ${statusReply.text.slice(0, 200)}`);
+    }
+    assert(typeof status.state === 'string' && status.state.length > 0, `status has no state: ${statusReply.text}`);
+    if (status.state === 'UNAVAILABLE') {
+      assert(!requireStatus, 'status relay answered UNAVAILABLE: DrugRef is down or predates getUpdateStatus');
+      console.log('STEP 2 status: PASS with UNAVAILABLE (DrugRef build without getUpdateStatus; set DRUGREF_UPDATE_REQUIRE_STATUS=true to reject)');
+    } else {
+      assert(['IDLE', 'RUNNING', 'SUCCEEDED', 'FAILED'].includes(status.state), `unexpected state ${status.state}`);
+      assert(status.state !== 'RUNNING', 'an update is already running; rerun when it has finished');
+      console.log(`STEP 2 status: PASS (state ${status.state}${status.message ? ', ' + status.message : ''})`);
+    }
+    assert(await popup.locator('#updatedb').isVisible(), 'the Update Drugref button is not visible');
+
+    if (!trigger) {
+      await screenshot(popup, config.screenshotDir, 'drugref-update-page');
+      console.log('STEP 3 trigger: SKIPPED (set DRUGREF_UPDATE_TRIGGER=true to rebuild the DrugRef database)');
+    } else {
+      // Step 3: click, and follow the run to its end.
+      const [startResponse] = await Promise.all([
+        popup.waitForResponse((r) => r.url().includes(ENDPOINT) && postedMethod(r) === 'updateDB', { timeout: 60000 }),
+        popup.locator('#updatedb').click(),
+      ]);
+      assert(startResponse.status() === 200, `updateDB answered HTTP ${startResponse.status()}`);
+      const start = await startResponse.json();
+      assert(
+        start.result === 'running' || start.result === 'updating',
+        `updateDB answered ${JSON.stringify(start)}: the trigger did not reach DrugRef`,
+      );
+      await popup.locator('#updateResult').waitFor({ state: 'visible', timeout: 20000 });
+      const startText = (await popup.locator('#updateResult').innerText()).trim();
+      assert(/started|already running/i.test(startText), `page reported "${startText}" after the click`);
+      console.log(`STEP 3a trigger: PASS (${start.result}: "${startText.slice(0, 80)}")`);
+
+      const deadline = Date.now() + timeoutSec * 1000;
+      let last = null;
+      let sawRunning = false;
+      while (Date.now() < deadline) {
+        const reply = await callStatus(popup);
+        assert(reply.status === 200, `status relay answered HTTP ${reply.status} mid-run`);
+        last = JSON.parse(reply.text);
+        if (last.state === 'RUNNING') {
+          sawRunning = true;
+        } else if (last.state === 'UNAVAILABLE') {
+          // Older DrugRef: only the verify probe knows. Poll it instead.
+          const v = await popup.evaluate(async (endpoint) => {
+            const token = (document.querySelector('input[name="CSRF-TOKEN"]') || {}).value || '';
+            const body = new URLSearchParams();
+            body.append('method', 'verify');
+            body.append('CSRF-TOKEN', token);
+            const r = await fetch(endpoint, {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'CSRF-TOKEN': token, 'X-Requested-With': 'XMLHttpRequest' },
+              body: body.toString(),
+            });
+            return r.json();
+          }, ENDPOINT);
+          if (v.lastUpdate !== 'updating') {
+            break;
+          }
+          sawRunning = true;
+        } else {
+          break;
+        }
+        await popup.waitForTimeout(15000);
+      }
+      assert(last && last.state !== 'RUNNING', `update still running after ${timeoutSec}s: ${JSON.stringify(last)}`);
+      assert(last.state !== 'FAILED', `update FAILED: ${last.message}`);
+      console.log(`STEP 3b run: PASS (${sawRunning ? 'observed RUNNING, then ' : ''}${last.state}${last.message ? ': ' + last.message : ''})`);
+
+      // The page must have followed the run and now show the new date.
+      await popup.waitForFunction(
+        (before) => {
+          const el = document.getElementById('dbDateTime');
+          return el && el.textContent.trim() && el.textContent.trim() !== before;
+        },
+        dateBefore,
+        { timeout: 60000 },
+      );
+      const dateAfter = (await popup.locator('#dbDateTime').innerText()).trim();
+      assert(dateAfter > dateBefore, `last-update date did not move forward: "${dateBefore}" -> "${dateAfter}"`);
+      const resultText = (await popup.locator('#updateResult').innerText()).trim();
+      assert(/completed/i.test(resultText), `page reports "${resultText}" after the run ended`);
+      console.log(`STEP 3c page: PASS (panel now shows ${dateAfter}; "${resultText.slice(0, 100)}")`);
+
+      // And prescribing still finds drugs in the rebuilt dataset.
+      const rxPage = await context.newPage();
+      wirePage(rxPage, 'drug-search', recorder);
+      await gotoApp(rxPage, config.baseUrl, '/rx/choosePatient?demographicNo=1');
+      await rxPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+      const searchBox = rxPage.locator('#searchString');
+      await searchBox.waitFor({ state: 'visible', timeout: 20000 });
+      const [searchResponse] = await Promise.all([
+        rxPage.waitForResponse((r) => r.url().includes('/rx/searchDrug') && r.request().method() === 'POST', { timeout: 60000 }),
+        searchBox.pressSequentially(searchTerm, { delay: 120 }),
+      ]);
+      const payload = await searchResponse.json();
+      assert(Array.isArray(payload.results) && payload.results.length > 0, `drug search for "${searchTerm}" found nothing after the update`);
+      console.log(`STEP 3d search: PASS ("${searchTerm}" -> ${payload.results.length} result(s))`);
+      await rxPage.close();
+      await screenshot(popup, config.screenshotDir, 'drugref-update-done');
+    }
+
+    await popup.close();
+    await admin.close();
+    assertNoPageErrors(recorder);
+    await context.close();
+    console.log('PASS drugref update page');
+  } catch (error) {
+    console.error('FAIL drugref update Playwright check');
+    console.error(error.stack || error.message);
+    console.error(JSON.stringify(buildFailureDetails(recorder), null, 2));
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();

--- a/scripts/drugref-update-playwright-checks.js
+++ b/scripts/drugref-update-playwright-checks.js
@@ -70,6 +70,17 @@ const config = {
   screenshotDir: process.env.DRUGREF_UPDATE_SCREENSHOT_DIR || '/tmp',
 };
 const trigger = process.env.DRUGREF_UPDATE_TRIGGER === 'true';
+// The trigger REBUILDS the target's drug database, so it is refused against anything but a
+// loopback target. DRUGREF_UPDATE_TRIGGER=true alone is an easy thing to leave exported in
+// a shell that is later pointed at a real installation with ALLOW_NON_LOCAL_BASE_URL.
+if (trigger) {
+  const host = config.baseUrl.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  assert(
+    new Set(['localhost', '127.0.0.1', '::1', '0:0:0:0:0:0:0:1']).has(host),
+    `DRUGREF_UPDATE_TRIGGER=true rebuilds the DrugRef database and is refused against the `
+      + `non-loopback target ${host}. Run it against a disposable local install.`,
+  );
+}
 const requireStatus = process.env.DRUGREF_UPDATE_REQUIRE_STATUS === 'true';
 const timeoutSec = Number(process.env.DRUGREF_UPDATE_TIMEOUT_SEC || '3600');
 const searchTerm = process.env.DRUG_SEARCH_TERM || 'amox';
@@ -110,7 +121,13 @@ async function callStatus(page) {
   const recorder = createRecorder();
   const browser = await chromium.launch(getLaunchOptions(config.chromePath));
   try {
-    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 900 } });
+    // Certificate validation is bypassed for loopback only. BASE_URL can be pointed at a
+    // remote deployment with ALLOW_NON_LOCAL_BASE_URL=true, and this check logs in as an
+    // administrator and carries CSRF tokens, so an unvalidated certificate there would be
+    // a real exposure rather than the self-signed localhost cert the runbook expects.
+    const loopback = new Set(['localhost', '127.0.0.1', '::1', '0:0:0:0:0:0:0:1']);
+    const isLoopback = loopback.has(config.baseUrl.hostname.replace(/^\[|\]$/g, '').toLowerCase());
+    const context = await browser.newContext({ ignoreHTTPSErrors: isLoopback, viewport: { width: 1280, height: 900 } });
     const landing = await login(context, config, recorder);
     await landing.close();
 
@@ -123,6 +140,13 @@ async function callStatus(page) {
     await assertNotErrorPage(admin, 'administration panel');
     const link = admin.locator('a', { hasText: /^\s*Update Drugref\s*$/i }).first();
     await link.waitFor({ state: 'attached', timeout: 20000 });
+    // Registered BEFORE the click: the popup fetches its CSRF token and fires the verify
+    // probe from its own DOMContentLoaded, which can complete before a waiter attached to
+    // the popup afterwards exists — a 30s timeout on a page that worked.
+    const verifyResponsePromise = context.waitForEvent('response', {
+      predicate: (r) => r.url().includes(ENDPOINT) && postedMethod(r) === 'verify',
+      timeout: 30000,
+    });
     const [popup] = await Promise.all([
       context.waitForEvent('page', { timeout: 20000 }),
       link.evaluate((a) => a.click()),
@@ -133,10 +157,7 @@ async function callStatus(page) {
     assert(/\/admin\/ViewUpdateDrugref/.test(popup.url()), `popup opened ${popup.url()}, expected /admin/ViewUpdateDrugref`);
 
     // Step 1: the verify probe answered and the panel shows a real dataset.
-    const verifyResponse = await popup.waitForResponse(
-      (r) => r.url().includes(ENDPOINT) && postedMethod(r) === 'verify',
-      { timeout: 30000 },
-    );
+    const verifyResponse = await verifyResponsePromise;
     assert(verifyResponse.status() === 200, `verify probe answered HTTP ${verifyResponse.status()}`);
     const verify = await verifyResponse.json();
     assert(

--- a/scripts/drugref-update-playwright-checks.js
+++ b/scripts/drugref-update-playwright-checks.js
@@ -96,6 +96,30 @@ function postedMethod(response) {
   return match ? decodeURIComponent(match[1]) : '';
 }
 
+/**
+ * Searches for a drug through the prescribing UI, the way a clinician does, and returns the
+ * number of matches. Deliberately not an XML-RPC call: what matters is that a prescriber can
+ * find a drug, which exercises the search index, the Rx page and the relay together.
+ */
+async function searchDrugs(context, config, recorder, term, label) {
+  const rxPage = await context.newPage();
+  wirePage(rxPage, label, recorder);
+  try {
+    await gotoApp(rxPage, config.baseUrl, '/rx/choosePatient?demographicNo=1');
+    await rxPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    const searchBox = rxPage.locator('#searchString');
+    await searchBox.waitFor({ state: 'visible', timeout: 20000 });
+    const [searchResponse] = await Promise.all([
+      rxPage.waitForResponse((r) => r.url().includes('/rx/searchDrug') && r.request().method() === 'POST', { timeout: 60000 }),
+      searchBox.pressSequentially(term, { delay: 120 }),
+    ]);
+    const payload = await searchResponse.json();
+    return Array.isArray(payload.results) ? payload.results.length : 0;
+  } finally {
+    await rxPage.close();
+  }
+}
+
 async function callStatus(page) {
   // Same call the page makes, through the page's own session and CSRF token.
   return page.evaluate(async (endpoint) => {
@@ -169,6 +193,13 @@ async function callStatus(page) {
     assert(dateBefore === verify.lastUpdate, `panel shows "${dateBefore}" but verify said "${verify.lastUpdate}"`);
     assert((await popup.locator('#drugDatabase').innerText()).trim().length > 0, 'panel shows no database name');
     console.log(`STEP 1 verify: PASS (${verify.drugDatabase} ${verify.version}, last update ${dateBefore})`);
+
+    // Step 1b: drug search works BEFORE the update. Without this the post-update search below
+    // cannot distinguish "the rebuild broke prescribing" from "prescribing was already broken",
+    // which is the whole question an operator is asking when they press the button.
+    const foundBefore = await searchDrugs(context, config, recorder, searchTerm, 'drug-search-before');
+    assert(foundBefore > 0, `drug search for "${searchTerm}" found nothing BEFORE any update: the installed dataset is already unusable`);
+    console.log(`STEP 1b search (before): PASS ("${searchTerm}" -> ${foundBefore} result(s))`);
 
     // Step 2: the status relay answers JSON with a state the page can act on.
     const statusReply = await callStatus(popup);
@@ -266,21 +297,12 @@ async function callStatus(page) {
       assert(/completed/i.test(resultText), `page reports "${resultText}" after the run ended`);
       console.log(`STEP 3c page: PASS (panel now shows ${dateAfter}; "${resultText.slice(0, 100)}")`);
 
-      // And prescribing still finds drugs in the rebuilt dataset.
-      const rxPage = await context.newPage();
-      wirePage(rxPage, 'drug-search', recorder);
-      await gotoApp(rxPage, config.baseUrl, '/rx/choosePatient?demographicNo=1');
-      await rxPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
-      const searchBox = rxPage.locator('#searchString');
-      await searchBox.waitFor({ state: 'visible', timeout: 20000 });
-      const [searchResponse] = await Promise.all([
-        rxPage.waitForResponse((r) => r.url().includes('/rx/searchDrug') && r.request().method() === 'POST', { timeout: 60000 }),
-        searchBox.pressSequentially(searchTerm, { delay: 120 }),
-      ]);
-      const payload = await searchResponse.json();
-      assert(Array.isArray(payload.results) && payload.results.length > 0, `drug search for "${searchTerm}" found nothing after the update`);
-      console.log(`STEP 3d search: PASS ("${searchTerm}" -> ${payload.results.length} result(s))`);
-      await rxPage.close();
+      // And prescribing still finds drugs in the REBUILT dataset. This is the one that
+      // matters: the original defect left the drug tables empty, so search answered nothing
+      // and the page reported success anyway.
+      const foundAfter = await searchDrugs(context, config, recorder, searchTerm, 'drug-search-after');
+      assert(foundAfter > 0, `drug search for "${searchTerm}" found ${foundBefore} result(s) before the update and NOTHING after it: the rebuild destroyed the dataset`);
+      console.log(`STEP 3d search (after): PASS ("${searchTerm}" -> ${foundAfter} result(s), was ${foundBefore} before)`);
       await screenshot(popup, config.screenshotDir, 'drugref-update-done');
     }
 

--- a/scripts/drugref-update-playwright-checks.js
+++ b/scripts/drugref-update-playwright-checks.js
@@ -41,6 +41,9 @@
  * deb-install suite loop (docs/ui-tests/deb-install-validation.md §6).
  *
  * Requires the deb-install env contract: BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN.
+ * On a freshly installed deb the packaged admin credential is flagged for a forced password
+ * reset, so also set RESET_PASSWORD to a new password meeting the policy; the check completes
+ * that reset once and then logs in with it.
  * Optional: DRUGREF_UPDATE_TRIGGER (default false), DRUGREF_UPDATE_TIMEOUT_SEC
  *   (default 3600), DRUGREF_UPDATE_REQUIRE_STATUS (default false), CHROME_PATH,
  *   DRUGREF_UPDATE_SCREENSHOT_DIR (default /tmp), DRUG_SEARCH_TERM (default "amox").
@@ -67,6 +70,9 @@ const config = {
   testUser: process.env.TEST_USER || 'carlosdoc',
   testPassword: process.env.TEST_PASSWORD || 'carlos2026',
   testPin: process.env.TEST_PIN || '2026',
+  // Only needed against a freshly installed deb, whose generated admin credential is flagged
+  // for a forced password reset; login() completes the reset once and carries on.
+  resetPassword: process.env.RESET_PASSWORD || '',
   screenshotDir: process.env.DRUGREF_UPDATE_SCREENSHOT_DIR || '/tmp',
 };
 const trigger = process.env.DRUGREF_UPDATE_TRIGGER === 'true';

--- a/scripts/drugref-update-playwright-checks.js
+++ b/scripts/drugref-update-playwright-checks.js
@@ -189,6 +189,9 @@ async function callStatus(page) {
       assert(status.state !== 'RUNNING', 'an update is already running; rerun when it has finished');
       console.log(`STEP 2 status: PASS (state ${status.state}${status.message ? ', ' + status.message : ''})`);
     }
+    // Load-bearing: #updateButton now renders hidden and is only revealed once a probe
+    // reports a definite state, so this asserts the page positively enabled the trigger
+    // rather than merely never having hidden it.
     assert(await popup.locator('#updatedb').isVisible(), 'the Update Drugref button is not visible');
 
     if (!trigger) {

--- a/scripts/drugref-update-playwright-checks.js
+++ b/scripts/drugref-update-playwright-checks.js
@@ -203,6 +203,9 @@ async function callStatus(page) {
     // Step 1b: drug search works BEFORE the update. Without this the post-update search below
     // cannot distinguish "the rebuild broke prescribing" from "prescribing was already broken",
     // which is the whole question an operator is asking when they press the button.
+    // The Rx picker has minLength: 3 (SearchDrug3.jsp), so a shorter term emits no POST at all
+    // and searchDrugs would sit out its 60s timeout instead of saying why.
+    assert(searchTerm.length >= 3, `DRUG_SEARCH_TERM must be at least 3 characters, got "${searchTerm}"`);
     const foundBefore = await searchDrugs(context, config, recorder, searchTerm, 'drug-search-before');
     assert(foundBefore > 0, `drug search for "${searchTerm}" found nothing BEFORE any update: the installed dataset is already unusable`);
     console.log(`STEP 1b search (before): PASS ("${searchTerm}" -> ${foundBefore} result(s))`);

--- a/scripts/eform-local-playwright-utils.js
+++ b/scripts/eform-local-playwright-utils.js
@@ -186,9 +186,12 @@ async function login(context, config, recorder) {
   if (/forcepasswordreset/i.test(page.url())) {
     assert(
       config.resetPassword,
-      `${config.testUser} must change its password before it can be used. Set RESET_PASSWORD to a`
-      + ' new password meeting the policy and re-run; the check will complete the reset once and'
-      + ' then log in with it. (A fresh carlos-emr install flags its generated admin credential.)',
+      `${config.testUser} must change its password before it can be used: a fresh carlos-emr`
+      + ' install flags its generated admin credential for a forced reset. Complete it ONCE, in an'
+      + ' isolated run outside any suite loop, with RESET_PASSWORD set to a new password meeting'
+      + ' the policy, then export TEST_PASSWORD as that new password for every later run. Doing'
+      + ' it inside a loop leaves the scripts that ran before it unreset and the ones after it'
+      + ' authenticating with the old password.',
     );
     await page.locator('input[name="oldPassword"]').fill(config.testPassword);
     await page.locator('input[name="newPassword"]').fill(config.resetPassword);

--- a/scripts/eform-local-playwright-utils.js
+++ b/scripts/eform-local-playwright-utils.js
@@ -173,10 +173,32 @@ async function login(context, config, recorder) {
     await page.locator('#pin').fill(config.testPin);
   }
   await Promise.all([
-    page.waitForURL(/providercontrol|appointment/i, { timeout: 30000 }),
+    // forcepasswordreset is a legitimate destination, not a failure: the carlos-emr package
+    // generates its first-login credential already flagged for a reset, so on a freshly
+    // installed deb -- the case the deb-install runbook is written for -- this is where the
+    // login lands. Waiting only for the schedule made every check here fail before it tested
+    // anything, and the devcontainer defaults hid it because that account is not flagged.
+    page.waitForURL(/providercontrol|appointment|forcepasswordreset/i, { timeout: 30000 }),
     page.locator('input[type="submit"], button[type="submit"]').first().click(),
   ]);
   await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+  if (/forcepasswordreset/i.test(page.url())) {
+    assert(
+      config.resetPassword,
+      `${config.testUser} must change its password before it can be used. Set RESET_PASSWORD to a`
+      + ' new password meeting the policy and re-run; the check will complete the reset once and'
+      + ' then log in with it. (A fresh carlos-emr install flags its generated admin credential.)',
+    );
+    await page.locator('input[name="oldPassword"]').fill(config.testPassword);
+    await page.locator('input[name="newPassword"]').fill(config.resetPassword);
+    await page.locator('input[name="confirmPassword"]').fill(config.resetPassword);
+    await Promise.all([
+      page.waitForURL(/providercontrol|appointment/i, { timeout: 30000 }),
+      page.locator('input[type="submit"], button[type="submit"]').first().click(),
+    ]);
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  }
   return page;
 }
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/gate/ViewUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/gate/ViewUpdateDrugref2Action.java
@@ -15,6 +15,7 @@ package io.github.carlos_emr.carlos.admin.gate;
 import jakarta.servlet.http.HttpServletRequest;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.prescript.pageUtil.RxUpdateDrugref2Action;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
@@ -44,6 +45,14 @@ public final class ViewUpdateDrugref2Action extends ActionSupport {
         if (!authorized) {
             throw new SecurityException("missing required sec object (_admin or _admin.misc)");
         }
+
+        // Read opens the page; only write may start a rebuild. The two are deliberately
+        // different, so the page has to know which one it is looking at: rendering an Update
+        // button for a view-only administrator would produce a trigger that RxUpdateDrugref2Action
+        // then refuses with an HTML 500, which is exactly the broken state this page exists to
+        // report on. Server-side, and advisory only -- the refusal in the action is the control.
+        request.setAttribute("canTriggerUpdate",
+                RxUpdateDrugref2Action.canTriggerUpdate(securityInfoManager, loggedInInfo));
 
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -97,6 +97,24 @@ public class RxUpdateDrugref2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_rx)");
         }
 
+        // `status` additionally needs the same rights as the page that consumes it.
+        //
+        // The privilege split above reasons about mutation, which is the wrong axis for this
+        // one: `status` relays DrugRef's root-cause failure text, and that is operational
+        // detail -- a JDBC URL, a database host and user, a filesystem path, a driver or
+        // classpath message. `_rx` read is every prescriber in the clinic, while
+        // Administration > Update Drugref, the only caller, is gated on `_admin` /
+        // `_admin.misc` read by ViewUpdateDrugref2Action. Reporting is not automatically
+        // public just because it does not write.
+        //
+        // `verify` deliberately stays at `_rx` read: TopLinks2.jspf fires it on every Rx page
+        // load, and it carries only a date, a version and a database name.
+        if ("status".equals(method)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null)) {
+            throw new SecurityException("missing required sec object (_admin or _admin.misc)");
+        }
+
         if (mutating) {
             return updateDB();
         } else if ("verify".equals(method)) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -124,10 +124,15 @@ public class RxUpdateDrugref2Action extends ActionSupport {
      * a DrugRef build older than the method returns (an XML-RPC fault). The page then degrades
      * to the {@code verify} probe, whose {@code lastUpdate} still flips away from
      * {@code "updating"} when the run ends.</p>
+     *
+     * <p>The fallback comes from {@link RxDrugRef#unavailableStatus()} rather than being
+     * hand-assembled, so it carries every key a successful answer carries and the two shapes
+     * cannot drift apart. A client would otherwise see the documented keys on the success path
+     * and {@code undefined} for the same keys on the outage path — the one path where it is
+     * least able to cope with a surprise.</p>
      */
     private String status() throws IOException, ServletException {
-        Map<String, String> fallback = new HashMap<>();
-        fallback.put("state", "UNAVAILABLE");
+        Map<String, String> fallback = RxDrugRef.unavailableStatus();
         writeJson(runOrFallback("getUpdateStatus", () -> new RxDrugRef().getUpdateStatus(), fallback));
         return NONE;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -92,34 +92,32 @@ public class RxUpdateDrugref2Action extends ActionSupport {
             return NONE;
         }
 
-        String requiredPrivilege = mutating ? "w" : "r";
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_rx", requiredPrivilege, null)) {
-            throw new SecurityException("missing required sec object (_rx)");
-        }
 
-        // `updateDB` and `status` additionally need the same rights as the page that hosts
-        // them. The privilege split above reasons about mutation, which is the wrong axis for
-        // these two:
+        // The gate follows the AUDIENCE of each method, not whether it mutates.
         //
-        //  - `status` relays DrugRef's root-cause failure text, and that is operational
-        //    detail -- a JDBC URL, a database host and user, a filesystem path, a driver or
-        //    classpath message. Reporting is not automatically public because it does not write.
-        //  - `updateDB` rebuilds the clinic's drug database and degrades prescribing for the
-        //    thirty-odd minutes it takes. That is an administrative act, not a prescribing one,
-        //    and `_rx` write is every prescriber in the clinic. The rebuild and the report on it
-        //    belong to the same audience.
+        //  - `updateDB` and `status` belong to Administration > Update Drugref, which
+        //    ViewUpdateDrugref2Action gates on `_admin` / `_admin.misc` read. A rebuild degrades
+        //    prescribing for the thirty-odd minutes it takes, and `status` relays DrugRef's
+        //    root-cause failure text -- a JDBC URL, a database host and user, a filesystem path.
+        //    Both are administrative acts, so administration rights are what they require.
+        //  - `verify` and `getLastUpdate` belong to prescribing: TopLinks2.jspf fires verify on
+        //    every Rx page load. They carry only a date, a version and a database name.
         //
-        // Administration > Update Drugref, the only caller of either, is gated on `_admin` /
-        // `_admin.misc` read by ViewUpdateDrugref2Action, so nobody who can reach the page loses
-        // anything here; what closes is the direct POST from a prescriber-only account.
-        //
-        // `verify` and `getLastUpdate` deliberately stay at `_rx` read: TopLinks2.jspf fires
-        // verify on every Rx page load, and both carry only a date, a version and a database name.
+        // Requiring `_rx` on top of `_admin` for the first pair looked harmless and was not: an
+        // administrator who is not a prescriber could open the page and then every call from it
+        // failed with an HTML 500, which is the state this action exists to stop the page being
+        // in. The admin page also fires `verify`, so administration rights satisfy that too.
         boolean administrative = mutating || "status".equals(method);
-        if (administrative
-                && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
-                && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null)) {
-            throw new SecurityException("missing required sec object (_admin or _admin.misc)");
+        boolean hasAdministrationRights =
+                securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
+                || securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null);
+        if (administrative) {
+            if (!hasAdministrationRights) {
+                throw new SecurityException("missing required sec object (_admin or _admin.misc)");
+            }
+        } else if (!hasAdministrationRights
+                && !securityInfoManager.hasPrivilege(loggedInInfo, "_rx", "r", null)) {
+            throw new SecurityException("missing required sec object (_rx)");
         }
 
         if (mutating) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -101,15 +101,35 @@ public class RxUpdateDrugref2Action extends ActionSupport {
             return updateDB();
         } else if ("verify".equals(method)) {
             return verify();
+        } else if ("status".equals(method)) {
+            return status();
         }
         return getLastUpdate();
     }
 
     public String updateDB() throws IOException, ServletException {
         Map<String, Object> d = new HashMap<>();
+        // A null result means the call itself failed (DrugRef down, unreachable, or a fault):
+        // the page shows that as an error rather than the silent nothing it used to render.
         d.put("result", runOrFallback("updateDB", () -> new RxDrugRef().updateDB(), null));
         writeJson(d);
-        return null;
+        return NONE;
+    }
+
+    /**
+     * Relays DrugRef's {@code getUpdateStatus}: whether the last update attempt is running,
+     * succeeded or failed, and why. The admin page polls this after starting an update.
+     *
+     * <p>Falls back to {@code state=UNAVAILABLE} when DrugRef cannot answer, which is also what
+     * a DrugRef build older than the method returns (an XML-RPC fault). The page then degrades
+     * to the {@code verify} probe, whose {@code lastUpdate} still flips away from
+     * {@code "updating"} when the run ends.</p>
+     */
+    private String status() throws IOException, ServletException {
+        Map<String, String> fallback = new HashMap<>();
+        fallback.put("state", "UNAVAILABLE");
+        writeJson(runOrFallback("getUpdateStatus", () -> new RxDrugRef().getUpdateStatus(), fallback));
+        return NONE;
     }
 
     private String verify() throws IOException, ServletException {
@@ -122,14 +142,14 @@ public class RxUpdateDrugref2Action extends ActionSupport {
         fallback.put("drugDatabase", null);
         fallback.put("version", null);
         writeJson(runOrFallback("verify", () -> new RxDrugRef().verify(), fallback));
-        return null;
+        return NONE;
     }
 
     private String getLastUpdate() throws IOException, ServletException {
         Map<String, String> d = new HashMap<>();
         d.put("lastUpdate", runOrFallback("getLastUpdateTime", () -> new RxDrugRef().getLastUpdateTime(), null));
         writeJson(d);
-        return null;
+        return NONE;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -115,8 +115,17 @@ public class RxUpdateDrugref2Action extends ActionSupport {
         // page load to answer a question `_rx` alone settles. The `||` order carries the
         // authorization, not just the performance: it is the same predicate either way, so
         // this stays a pure short-circuit and never widens who is allowed through.
-        boolean administrative = mutating || "status".equals(method);
-        if (administrative) {
+        // Read is not enough to START one, though. updateDB rebuilds the drug database: it runs
+        // for half an hour, degrades drug lookups clinic-wide while it does, and can end with
+        // the dataset replaced. That is a mutation, and CARLOS gates mutating administration on
+        // WRITE -- ManageFlowsheets2Action, LookupListManager2Action and the admin gate actions
+        // all take "w" on _admin / _admin.misc. Accepting read here let a view-only
+        // administrator trigger the rebuild. `status` stays at read: it only reports.
+        if (mutating) {
+            if (!canTriggerUpdate(loggedInInfo)) {
+                throw new SecurityException("missing required sec object (_admin or _admin.misc)");
+            }
+        } else if ("status".equals(method)) {
             if (!hasAdministrationRights(loggedInInfo)) {
                 throw new SecurityException("missing required sec object (_admin or _admin.misc)");
             }
@@ -143,6 +152,23 @@ public class RxUpdateDrugref2Action extends ActionSupport {
     private boolean hasAdministrationRights(LoggedInInfo loggedInInfo) {
         return securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
                 || securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null);
+    }
+
+    /**
+     * @return whether the caller may START a database rebuild, which needs write on either
+     *         administration object. Kept public and static-free so
+     *         {@link io.github.carlos_emr.carlos.admin.gate.ViewUpdateDrugref2Action} can ask the
+     *         same question when deciding whether to render the trigger: a page that offers a
+     *         button this action then refuses is the failure this split exists to avoid.
+     */
+    public static boolean canTriggerUpdate(SecurityInfoManager securityInfoManager,
+            LoggedInInfo loggedInInfo) {
+        return securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "w", null)
+                || securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "w", null);
+    }
+
+    private boolean canTriggerUpdate(LoggedInInfo loggedInInfo) {
+        return canTriggerUpdate(securityInfoManager, loggedInInfo);
     }
 
     public String updateDB() throws IOException, ServletException {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -97,19 +97,26 @@ public class RxUpdateDrugref2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_rx)");
         }
 
-        // `status` additionally needs the same rights as the page that consumes it.
+        // `updateDB` and `status` additionally need the same rights as the page that hosts
+        // them. The privilege split above reasons about mutation, which is the wrong axis for
+        // these two:
         //
-        // The privilege split above reasons about mutation, which is the wrong axis for this
-        // one: `status` relays DrugRef's root-cause failure text, and that is operational
-        // detail -- a JDBC URL, a database host and user, a filesystem path, a driver or
-        // classpath message. `_rx` read is every prescriber in the clinic, while
-        // Administration > Update Drugref, the only caller, is gated on `_admin` /
-        // `_admin.misc` read by ViewUpdateDrugref2Action. Reporting is not automatically
-        // public just because it does not write.
+        //  - `status` relays DrugRef's root-cause failure text, and that is operational
+        //    detail -- a JDBC URL, a database host and user, a filesystem path, a driver or
+        //    classpath message. Reporting is not automatically public because it does not write.
+        //  - `updateDB` rebuilds the clinic's drug database and degrades prescribing for the
+        //    thirty-odd minutes it takes. That is an administrative act, not a prescribing one,
+        //    and `_rx` write is every prescriber in the clinic. The rebuild and the report on it
+        //    belong to the same audience.
         //
-        // `verify` deliberately stays at `_rx` read: TopLinks2.jspf fires it on every Rx page
-        // load, and it carries only a date, a version and a database name.
-        if ("status".equals(method)
+        // Administration > Update Drugref, the only caller of either, is gated on `_admin` /
+        // `_admin.misc` read by ViewUpdateDrugref2Action, so nobody who can reach the page loses
+        // anything here; what closes is the direct POST from a prescriber-only account.
+        //
+        // `verify` and `getLastUpdate` deliberately stay at `_rx` read: TopLinks2.jspf fires
+        // verify on every Rx page load, and both carry only a date, a version and a database name.
+        boolean administrative = mutating || "status".equals(method);
+        if (administrative
                 && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
                 && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null)) {
             throw new SecurityException("missing required sec object (_admin or _admin.misc)");

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -107,16 +107,21 @@ public class RxUpdateDrugref2Action extends ActionSupport {
         // administrator who is not a prescriber could open the page and then every call from it
         // failed with an HTML 500, which is the state this action exists to stop the page being
         // in. The admin page also fires `verify`, so administration rights satisfy that too.
+        //
+        // Evaluated lazily and cheapest-first, which matters here specifically: every
+        // hasPrivilege call re-runs secUserRoleDao.findActiveByProviderNo (there is no role
+        // cache), and TopLinks2.jspf fires `verify` on every Rx page load. Computing the
+        // administration rights up front cost ordinary prescribers two extra role queries per
+        // page load to answer a question `_rx` alone settles. The `||` order carries the
+        // authorization, not just the performance: it is the same predicate either way, so
+        // this stays a pure short-circuit and never widens who is allowed through.
         boolean administrative = mutating || "status".equals(method);
-        boolean hasAdministrationRights =
-                securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
-                || securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null);
         if (administrative) {
-            if (!hasAdministrationRights) {
+            if (!hasAdministrationRights(loggedInInfo)) {
                 throw new SecurityException("missing required sec object (_admin or _admin.misc)");
             }
-        } else if (!hasAdministrationRights
-                && !securityInfoManager.hasPrivilege(loggedInInfo, "_rx", "r", null)) {
+        } else if (!securityInfoManager.hasPrivilege(loggedInInfo, "_rx", "r", null)
+                && !hasAdministrationRights(loggedInInfo)) {
             throw new SecurityException("missing required sec object (_rx)");
         }
 
@@ -128,6 +133,16 @@ public class RxUpdateDrugref2Action extends ActionSupport {
             return status();
         }
         return getLastUpdate();
+    }
+
+    /**
+     * @return whether the caller may perform the administrative operations of this action, which
+     *         either administration security object grants. Not cached: each call re-reads the
+     *         caller's active roles, so call it only on the branch that needs it.
+     */
+    private boolean hasAdministrationRights(LoggedInInfo loggedInInfo) {
+        return securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
+                || securityInfoManager.hasPrivilege(loggedInInfo, "_admin.misc", "r", null);
     }
 
     public String updateDB() throws IOException, ServletException {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRef.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRef.java
@@ -440,9 +440,12 @@ public class RxDrugRef {
      * cannot say that an update failed, or why. DrugRef's {@code getUpdateStatus} can. The map
      * carries {@code state} ({@code IDLE}, {@code RUNNING}, {@code SUCCEEDED}, {@code FAILED}),
      * {@code step}, {@code message}, {@code startedAt}, {@code finishedAt} and {@code lastUpdate},
-     * every value a String (empty when absent).</p>
+     * every value a String, empty when the server did not supply one. Those keys are always
+     * present: this method seeds them before overlaying the struct, so a caller never has to
+     * tell "the server sent nothing" apart from "the server sent an empty value". Any further
+     * key the server sends is passed through.</p>
      *
-     * @return Map&lt;String, String&gt; of the status struct
+     * @return Map&lt;String, String&gt; of the status struct, never missing a documented key
      * @throws Exception if the DrugRef service is unavailable, predates {@code getUpdateStatus}
      *                   (an XML-RPC fault), or answers with something other than a struct
      * @since 2026-09-05
@@ -453,7 +456,31 @@ public class RxDrugRef {
         if (!(result instanceof Map<?, ?> struct)) {
             throw new Exception("DrugRef: 'getUpdateStatus' returned no struct for server " + server_url);
         }
+        return normalizeStatusStruct(struct);
+    }
+
+    /** The keys {@link #getUpdateStatus()} guarantees, whatever the DrugRef build answers with. */
+    static final String[] STATUS_KEYS =
+            {"state", "step", "message", "startedAt", "finishedAt", "lastUpdate"};
+
+    /**
+     * Applies {@link #getUpdateStatus()}'s contract to a raw XML-RPC struct: the documented keys
+     * are seeded to empty first, so an answer that omits one still yields a String rather than a
+     * gap, and any extra key the server sends is carried through.
+     *
+     * <p>Seeded, not merely null-normalized. The current DrugRef sends all six, but this is a
+     * relay across a version boundary — the pin can move — and an omitted key left the relayed
+     * JSON without it, reaching the admin page as {@code undefined} instead of the empty string
+     * the contract promises.
+     *
+     * <p>Package-private and separated from the call itself so the contract is testable without
+     * a DrugRef server and without widening the network method.
+     */
+    static Map<String, String> normalizeStatusStruct(Map<?, ?> struct) {
         Map<String, String> status = new HashMap<>();
+        for (String key : STATUS_KEYS) {
+            status.put(key, "");
+        }
         for (Map.Entry<?, ?> entry : struct.entrySet()) {
             status.put(String.valueOf(entry.getKey()),
                     entry.getValue() == null ? "" : String.valueOf(entry.getValue()));

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRef.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRef.java
@@ -459,6 +459,22 @@ public class RxDrugRef {
         return normalizeStatusStruct(struct);
     }
 
+    /**
+     * The status a caller should report when DrugRef cannot be reached at all: {@code state} of
+     * {@code UNAVAILABLE}, and every other documented key present and empty.
+     *
+     * <p>Exists so the outage payload is built from the same contract as a real answer instead of
+     * being hand-assembled at the call site. A client that meets the full set of keys on the
+     * success path and a bare {@code state} on the outage path has to cope with a shape change on
+     * exactly the path where it has least information to work with.</p>
+     *
+     * @return a mutable map carrying every key of {@link #getUpdateStatus()}
+     * @since 2026-09-06
+     */
+    public static Map<String, String> unavailableStatus() {
+        return normalizeStatusStruct(Map.of("state", "UNAVAILABLE"));
+    }
+
     /** The keys {@link #getUpdateStatus()} guarantees, whatever the DrugRef build answers with. */
     static final String[] STATUS_KEYS =
             {"state", "step", "message", "startedAt", "finishedAt", "lastUpdate"};

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRef.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRef.java
@@ -434,6 +434,34 @@ public class RxDrugRef {
     }
 
     /**
+     * Returns the outcome of the most recent {@link #updateDB()} attempt on the DrugRef server.
+     *
+     * <p>{@link #getLastUpdateTime()} answers only a date or the literal {@code "updating"}; it
+     * cannot say that an update failed, or why. DrugRef's {@code getUpdateStatus} can. The map
+     * carries {@code state} ({@code IDLE}, {@code RUNNING}, {@code SUCCEEDED}, {@code FAILED}),
+     * {@code step}, {@code message}, {@code startedAt}, {@code finishedAt} and {@code lastUpdate},
+     * every value a String (empty when absent).</p>
+     *
+     * @return Map&lt;String, String&gt; of the status struct
+     * @throws Exception if the DrugRef service is unavailable, predates {@code getUpdateStatus}
+     *                   (an XML-RPC fault), or answers with something other than a struct
+     * @since 2026-09-05
+     */
+    public Map<String, String> getUpdateStatus() throws Exception {
+        Vector params = new Vector();
+        Object result = callWebserviceLite("getUpdateStatus", params);
+        if (!(result instanceof Map<?, ?> struct)) {
+            throw new Exception("DrugRef: 'getUpdateStatus' returned no struct for server " + server_url);
+        }
+        Map<String, String> status = new HashMap<>();
+        for (Map.Entry<?, ?> entry : struct.entrySet()) {
+            status.put(String.valueOf(entry.getKey()),
+                    entry.getValue() == null ? "" : String.valueOf(entry.getValue()));
+        }
+        return status;
+    }
+
+    /**
      * Returns all matching drug search elements using the version 2 search API.
      * Search is case-insensitive.
      *

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -252,6 +252,7 @@ SearchDrug.js.savePrompt=Are you sure you want to save this prescription?
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=Drugref database is unavailable.
 oscarRx.drugrefUnavailableContact=Drugref database is unavailable. Contact support.
+oscarRx.drugrefUpdating=Drugref database is being updated. Drug lookups are limited until it finishes.
 
 oscarRx.DisplayRxRecord.title=Display Rx Record
 oscarRx.chartDrugProfile.title=Timeline Drug Profile

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -248,6 +248,7 @@ SearchDrug.js.savePrompt=\u00bfEst\u00e1 seguro de que desea guardar esta prescr
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=Base de datos Drugref no disponible.
 oscarRx.drugrefUnavailableContact=Base de datos Drugref no disponible. Contacte al soporte.
+oscarRx.drugrefUpdating=La base de datos Drugref se est\u00e1 actualizando. Las b\u00fasquedas de medicamentos son limitadas hasta que termine.
 oscarRx.DisplayRxRecord.title=Mostrar registro de recetas
 oscarRx.chartDrugProfile.title=Linea de tiempo
 oscarRx.Prescription.changeDrugLongTerm=Cambiar a tratamiento cr\u00f3nico?

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -248,7 +248,8 @@ SearchDrug.js.savePrompt=\u00bfEst\u00e1 seguro de que desea guardar esta prescr
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=Base de datos Drugref no disponible.
 oscarRx.drugrefUnavailableContact=Base de datos Drugref no disponible. Contacte al soporte.
-oscarRx.drugrefUpdating=La base de datos Drugref se est\u00e1 actualizando. Las b\u00fasquedas de medicamentos son limitadas hasta que termine.
+# TODO: translate
+oscarRx.drugrefUpdating=Drugref database is being updated. Drug lookups are limited until it finishes.
 oscarRx.DisplayRxRecord.title=Mostrar registro de recetas
 oscarRx.chartDrugProfile.title=Linea de tiempo
 oscarRx.Prescription.changeDrugLongTerm=Cambiar a tratamiento cr\u00f3nico?

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -186,6 +186,7 @@ SearchDrug.msgCustomDrugRx3=Rx personnalis\u00e9
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=La base de donn\u00e9es Drugref est indisponible.
 oscarRx.drugrefUnavailableContact=La base de donn\u00e9es Drugref est indisponible. Contactez le support.
+oscarRx.drugrefUpdating=La base de donn\u00e9es Drugref est en cours de mise \u00e0 jour. Les recherches de m\u00e9dicaments sont limit\u00e9es pendant ce temps.
 SearchDrug.help.Search=Voir les r\u00e9sultats de recherche (s\u00e9pare les r\u00e9sultats en g\u00e9n\u00e9riques et de marque)
 SearchDrug.help.CustomDrug=Cr\u00e9er un m\u00e9dicament personnalis\u00e9 si le m\u00e9dicament ne figure pas dans la base de donn\u00e9es
 SearchDrug.help.CustomNote=Cr\u00e9er une note personnalis\u00e9e (sans quantit\u00e9/r\u00e9p\u00e9titions/dur\u00e9e)

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -186,7 +186,8 @@ SearchDrug.msgCustomDrugRx3=Rx personnalis\u00e9
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=La base de donn\u00e9es Drugref est indisponible.
 oscarRx.drugrefUnavailableContact=La base de donn\u00e9es Drugref est indisponible. Contactez le support.
-oscarRx.drugrefUpdating=La base de donn\u00e9es Drugref est en cours de mise \u00e0 jour. Les recherches de m\u00e9dicaments sont limit\u00e9es pendant ce temps.
+# TODO: translate
+oscarRx.drugrefUpdating=Drugref database is being updated. Drug lookups are limited until it finishes.
 SearchDrug.help.Search=Voir les r\u00e9sultats de recherche (s\u00e9pare les r\u00e9sultats en g\u00e9n\u00e9riques et de marque)
 SearchDrug.help.CustomDrug=Cr\u00e9er un m\u00e9dicament personnalis\u00e9 si le m\u00e9dicament ne figure pas dans la base de donn\u00e9es
 SearchDrug.help.CustomNote=Cr\u00e9er une note personnalis\u00e9e (sans quantit\u00e9/r\u00e9p\u00e9titions/dur\u00e9e)

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -231,6 +231,7 @@ SearchDrug.js.savePrompt=Czy na pewno chcesz zapisa\u0107 t\u0119 recept\u0119?
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=Baza danych Drugref jest niedost\u0119pna.
 oscarRx.drugrefUnavailableContact=Baza danych Drugref jest niedost\u0119pna. Skontaktuj si\u0119 z pomoc\u0105 techniczn\u0105.
+oscarRx.drugrefUpdating=Baza danych Drugref jest aktualizowana. Wyszukiwanie lek\u00f3w jest ograniczone do czasu zako\u0144czenia.
 oscarRx.chartDrugProfile.title=Timeline Drug Profile
 oscarRx.sideLinks.msgSpecial=specjalne
 oscarRx.sideLinks.msgEditPharmacy=Edycja Apteka

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -231,7 +231,8 @@ SearchDrug.js.savePrompt=Czy na pewno chcesz zapisa\u0107 t\u0119 recept\u0119?
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=Baza danych Drugref jest niedost\u0119pna.
 oscarRx.drugrefUnavailableContact=Baza danych Drugref jest niedost\u0119pna. Skontaktuj si\u0119 z pomoc\u0105 techniczn\u0105.
-oscarRx.drugrefUpdating=Baza danych Drugref jest aktualizowana. Wyszukiwanie lek\u00f3w jest ograniczone do czasu zako\u0144czenia.
+# TODO: translate
+oscarRx.drugrefUpdating=Drugref database is being updated. Drug lookups are limited until it finishes.
 oscarRx.chartDrugProfile.title=Timeline Drug Profile
 oscarRx.sideLinks.msgSpecial=specjalne
 oscarRx.sideLinks.msgEditPharmacy=Edycja Apteka

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -271,7 +271,8 @@ SearchDrug.js.savePrompt=Tem certeza de que deseja salvar esta prescri\u00E7\u00
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=O banco de dados Drugref est\u00E1 indispon\u00EDvel.
 oscarRx.drugrefUnavailableContact=O banco de dados Drugref est\u00E1 indispon\u00EDvel. Entre em contato com o suporte.
-oscarRx.drugrefUpdating=O banco de dados Drugref est\u00e1 sendo atualizado. As buscas de medicamentos ficam limitadas at\u00e9 terminar.
+# TODO: translate
+oscarRx.drugrefUpdating=Drugref database is being updated. Drug lookups are limited until it finishes.
 oscarRx.DisplayRxRecord.title=Exibir registro Rx
 oscarRx.chartDrugProfile.title=Perfil do medicamento na linha do tempo
 oscarRx.Prescription.changeDrugLongTerm=Alterar medicamento para medicamento de longo prazo

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -271,6 +271,7 @@ SearchDrug.js.savePrompt=Tem certeza de que deseja salvar esta prescri\u00E7\u00
 oscarRx.header.title=Rx
 oscarRx.drugrefUnavailable=O banco de dados Drugref est\u00E1 indispon\u00EDvel.
 oscarRx.drugrefUnavailableContact=O banco de dados Drugref est\u00E1 indispon\u00EDvel. Entre em contato com o suporte.
+oscarRx.drugrefUpdating=O banco de dados Drugref est\u00e1 sendo atualizado. As buscas de medicamentos ficam limitadas at\u00e9 terminar.
 oscarRx.DisplayRxRecord.title=Exibir registro Rx
 oscarRx.chartDrugProfile.title=Perfil do medicamento na linha do tempo
 oscarRx.Prescription.changeDrugLongTerm=Alterar medicamento para medicamento de longo prazo

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -86,6 +86,13 @@
             // would otherwise overwrite the baseline with the value being compared against.
             var lastVerifiedUpdate = null;
             var lastUpdateBeforeRun = null;
+            // Whether a verify probe has answered definitely at all. Distinct from the timestamp
+            // above being null, which is ALSO what a healthy install that has never been updated
+            // answers -- and there the baseline is perfectly well known ("no history yet"), so a
+            // timestamp appearing afterwards is proof the first rebuild worked. Conflating the
+            // two reported a successful first-ever update as an unknown outcome.
+            var baselineKnown = false;
+            var baselineKnownBeforeRun = false;
 
             function getCsrfToken() {
                 var el = document.querySelector('input[name="CSRF-TOKEN"]');
@@ -145,6 +152,9 @@
                     show('statusDisplay', false);
                     show('updateButton', false);
                 } else if (json.lastUpdate == null) {
+                    // Definite: DrugRef answered, and it has no history. A known baseline.
+                    baselineKnown = true;
+                    lastVerifiedUpdate = null;
                     document.getElementById('dbInfo').textContent = 'Drugref database has not been updated, please update.';
                     show('dbInfo', true);
                     show('statusDisplay', false);
@@ -155,6 +165,7 @@
                     show('statusDisplay', false);
                     show('updateButton', false);
                 } else {
+                    baselineKnown = true;
                     lastVerifiedUpdate = json.lastUpdate;
                     document.getElementById('dbDateTime').textContent = json.lastUpdate;
                     document.getElementById('drugDatabaseVersion').textContent = json.version;
@@ -245,7 +256,7 @@
                                         + '(journalctl -u carlos-emr) before prescribing.', 'danger');
                                     show('updateButton', false);
                                     schedulePoll();
-                                } else if (lastUpdateBeforeRun == null) {
+                                } else if (!baselineKnownBeforeRun) {
                                     // The page never saw a pre-run timestamp (opened mid-run),
                                     // so there is nothing to compare against and neither
                                     // "succeeded" nor "failed" can be claimed. Say that, in
@@ -304,6 +315,7 @@
                 // page was opened mid-run this is null -- the baseline is genuinely unknown,
                 // and the legacy fallback says so rather than guessing either way.
                 lastUpdateBeforeRun = lastVerifiedUpdate;
+                baselineKnownBeforeRun = baselineKnown;
                 setResult('Starting the update...', 'info');
                 callDrugref('updateDB')
                     .then(function (json) {
@@ -356,7 +368,7 @@
                         });
                     })
                     .catch(function (err) {
-                        console.warn('Skipping getUpdateTime — CSRF token not available:', err);
+                        console.warn('Skipping getUpdateTime - CSRF token not available:', err);
                         document.getElementById('dbInfo').textContent =
                             'Could not load CSRF token. Refresh the page or contact support.';
                         // No token means every POST this page makes is rejected, the probe

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -125,8 +125,24 @@
                 });
             }
 
+            // Read on _admin / _admin.misc opens this page; only WRITE may start a rebuild.
+            // Set by ViewUpdateDrugref2Action from the same predicate RxUpdateDrugref2Action
+            // enforces, so the two cannot drift apart.
+            var canTriggerUpdate = ${canTriggerUpdate ? 'true' : 'false'};
+
             function show(id, visible) {
-                document.getElementById(id).style.display = visible ? 'block' : 'none';
+                // One choke point rather than a guard at each of the seventeen call sites: a
+                // view-only administrator must never be offered a trigger the action will refuse
+                // with an HTML 500, and a future branch that forgets to check would reintroduce
+                // exactly that. This is presentation only -- the control is the refusal in
+                // RxUpdateDrugref2Action, which does not consult anything the browser sends.
+                if (id === 'updateButton' && !canTriggerUpdate) {
+                    visible = false;
+                }
+                var el = document.getElementById(id);
+                if (el) {
+                    el.style.display = visible ? 'block' : 'none';
+                }
             }
 
             // Keep the strings this page builds ASCII. The JSP declares no page encoding and

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -160,10 +160,15 @@
                         return json;
                     })
                     .catch(function () {
+                        // Hidden, not shown: this is the transport-level twin of the
+                        // all-null branch in renderVerify, and it hid the trigger for the
+                        // same reason. An unreachable DrugRef says nothing about whether a
+                        // run is going, so offering Update here invites a second one on top
+                        // of the first.
                         document.getElementById('dbInfo').textContent = 'Drugref database is unavailable. Contact support.';
                         show('dbInfo', true);
                         show('statusDisplay', false);
-                        show('updateButton', true);
+                        show('updateButton', false);
                         return null;
                     });
             }
@@ -304,6 +309,10 @@
                         console.warn('Skipping getUpdateTime — CSRF token not available:', err);
                         document.getElementById('dbInfo').textContent =
                             'Could not load CSRF token. Refresh the page or contact support.';
+                        // No token means every POST this page makes is rejected, the probe
+                        // included, so the state is unknown and the trigger would fail if
+                        // pressed.
+                        show('updateButton', false);
                     });
             });
         </script>
@@ -333,7 +342,7 @@
             <label for="dbDateTime"><fmt:message key="admin.admin.DrugRef.updateDate"/>&colon; </label>
             <span id="dbDateTime"></span></div>
         </div>
-        <div id="updateButton">
+        <div id="updateButton" style="display:none;">
           <a id="updatedb" onclick="updateDB();" href="javascript:void(0);"
               class="btn btn-primary"><fmt:message key="admin.admin.UpdateDrugref"/></a>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -396,11 +396,21 @@
                         } else {
                             setResult('The update could not be started: DrugRef did not answer. Check that the '
                                 + 'DrugRef service is running (drug lookups also need it).', 'danger');
+                            // Nothing was started, so the trigger comes back: the operator can
+                            // start the service or fix the proxy and retry in place. It is
+                            // hidden before the POST to stop a double-click across the round
+                            // trip, and leaving it hidden here would strand them on a dead page
+                            // with a reload as the only way forward. show() still withholds it
+                            // from anyone without write rights.
+                            show('updateButton', true);
                         }
                     })
                     .catch(function (error) {
                         console.error('Error updating database:', error);
                         setResult('The update could not be started: ' + error.message, 'danger');
+                        // Same reasoning as above: the request failed, so no run is in flight
+                        // and a retry is exactly what the operator should be able to do.
+                        show('updateButton', true);
                     });
             }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -122,7 +122,16 @@
             }
 
             function renderVerify(json) {
-                if (!json || json.lastUpdate == null) {
+                // An all-null payload is RxUpdateDrugref2Action's unavailable fallback, not a
+                // database that has never been updated. Telling the operator to press Update
+                // when DrugRef cannot be reached invites a second run on top of one that may
+                // still be going, so the trigger is hidden until the status is definite.
+                if (!json || (json.lastUpdate == null && json.drugDatabase == null && json.version == null)) {
+                    document.getElementById('dbInfo').textContent = 'Drugref database is unavailable. Contact support.';
+                    show('dbInfo', true);
+                    show('statusDisplay', false);
+                    show('updateButton', false);
+                } else if (json.lastUpdate == null) {
                     document.getElementById('dbInfo').textContent = 'Drugref database has not been updated, please update.';
                     show('dbInfo', true);
                     show('statusDisplay', false);
@@ -182,6 +191,15 @@
                 return running;
             }
 
+            function schedulePoll() {
+                // Exactly one timer chain. Repeat clicks used to each start their own, and
+                // overwriting pollTimer orphaned the earlier ones rather than stopping them.
+                if (pollTimer) {
+                    clearTimeout(pollTimer);
+                }
+                pollTimer = setTimeout(pollStatus, POLL_MS);
+            }
+
             function pollStatus() {
                 callDrugref('status')
                     .then(function (status) {
@@ -192,7 +210,7 @@
                             return callDrugref('verify').then(function (v) {
                                 renderVerify(v);
                                 if (v && v.lastUpdate === 'updating') {
-                                    pollTimer = setTimeout(pollStatus, POLL_MS);
+                                    schedulePoll();
                                 } else if (!v || v.lastUpdate == null) {
                                     // DrugRef stopped answering mid-run. A null lastUpdate is
                                     // "cannot tell", NOT "finished": reporting success here
@@ -201,22 +219,32 @@
                                     setResult('DrugRef stopped responding, so the outcome of this update is '
                                         + 'unknown. Still checking. If this persists, check the DrugRef service '
                                         + '(journalctl -u carlos-emr) before prescribing.', 'danger');
-                                    pollTimer = setTimeout(pollStatus, POLL_MS);
+                                    show('updateButton', false);
+                                    schedulePoll();
                                 } else {
                                     setResult('Update finished at ' + v.lastUpdate + '.', 'success');
                                 }
                             });
                         }
                         if (running) {
-                            pollTimer = setTimeout(pollStatus, POLL_MS);
+                            schedulePoll();
                         } else {
-                            // Run ended: refresh the date/version panel to show the outcome.
-                            getUpdateTime();
+                            // Not RUNNING. That is usually the end of the run -- but it is also
+                            // what a status of IDLE looks like in the moment before a just-started
+                            // worker publishes RUNNING. Refresh the panel, and if the verify probe
+                            // still says "updating" keep following instead of stopping here, which
+                            // used to strand the page on "database is updating" until a reload.
+                            return getUpdateTime().then(function (v) {
+                                if (v && v.lastUpdate === 'updating') {
+                                    show('updateButton', false);
+                                    schedulePoll();
+                                }
+                            });
                         }
                     })
                     .catch(function (error) {
                         console.error('Error reading update status:', error);
-                        pollTimer = setTimeout(pollStatus, POLL_MS);
+                        schedulePoll();
                     });
             }
 
@@ -232,6 +260,7 @@
                             pollStatus();
                         } else if (json.result === 'updating') {
                             setResult('An update is already running.', 'info');
+                            show('updateButton', false);
                             pollStatus();
                         } else {
                             setResult('The update could not be started: DrugRef did not answer. Check that the '
@@ -254,7 +283,7 @@
                         // the outcome of the last one, and keep following a running one.
                         return callDrugref('status').then(function (status) {
                             if (renderStatus(status)) {
-                                pollTimer = setTimeout(pollStatus, POLL_MS);
+                                schedulePoll();
                                 return;
                             }
                             if (status && status.state === 'UNAVAILABLE'
@@ -265,7 +294,7 @@
                                 // was only ever armed off a RUNNING status.
                                 setResult('An update is already running. This page is following it.', 'info');
                                 show('updateButton', false);
-                                pollTimer = setTimeout(pollStatus, POLL_MS);
+                                schedulePoll();
                             }
                         }).catch(function (error) {
                             console.warn('Update status not available:', error);

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -78,6 +78,14 @@
             // nothing at all. Now it polls status until the run ends and says how it ended.
             var POLL_MS = 15000;
             var pollTimer = null;
+            // The newest history timestamp this page has seen from a verify probe, and a copy
+            // of it frozen at the moment a run starts. On a DrugRef too old for getUpdateStatus
+            // there is no outcome to read, and the timestamp moving is the only evidence a run
+            // succeeded -- the history row is written at the end of a good rebuild and not at
+            // all by a failed one. Frozen separately because the poll re-renders verify, which
+            // would otherwise overwrite the baseline with the value being compared against.
+            var lastVerifiedUpdate = null;
+            var lastUpdateBeforeRun = null;
 
             function getCsrfToken() {
                 var el = document.querySelector('input[name="CSRF-TOKEN"]');
@@ -142,6 +150,7 @@
                     show('statusDisplay', false);
                     show('updateButton', false);
                 } else {
+                    lastVerifiedUpdate = json.lastUpdate;
                     document.getElementById('dbDateTime').textContent = json.lastUpdate;
                     document.getElementById('drugDatabaseVersion').textContent = json.version;
                     document.getElementById('drugDatabase').textContent = json.drugDatabase;
@@ -216,18 +225,50 @@
                                 renderVerify(v);
                                 if (v && v.lastUpdate === 'updating') {
                                     schedulePoll();
-                                } else if (!v || v.lastUpdate == null) {
-                                    // DrugRef stopped answering mid-run. A null lastUpdate is
-                                    // "cannot tell", NOT "finished": reporting success here
-                                    // would tell the operator the rebuild completed when it
-                                    // may have died with the tables half-built. Keep looking.
+                                } else if (!v || (v.lastUpdate == null && v.drugDatabase == null
+                                        && v.version == null)) {
+                                    // DrugRef stopped answering mid-run. An ALL-null payload is
+                                    // the action's unavailable fallback; testing lastUpdate
+                                    // alone also caught a healthy DrugRef that has simply never
+                                    // been updated, and then accused it of being down and
+                                    // polled forever with the trigger hidden. "Cannot tell" is
+                                    // still not "finished": reporting success here would say
+                                    // the rebuild completed when it may have died with the
+                                    // tables half-built. Keep looking.
                                     setResult('DrugRef stopped responding, so the outcome of this update is '
                                         + 'unknown. Still checking. If this persists, check the DrugRef service '
                                         + '(journalctl -u carlos-emr) before prescribing.', 'danger');
                                     show('updateButton', false);
                                     schedulePoll();
-                                } else {
+                                } else if (lastUpdateBeforeRun == null) {
+                                    // The page never saw a pre-run timestamp (opened mid-run),
+                                    // so there is nothing to compare against and neither
+                                    // "succeeded" nor "failed" can be claimed. Say that, in
+                                    // those words, rather than picking one.
+                                    setResult('The update has ended. This DrugRef build cannot report '
+                                        + 'whether it succeeded, and this page did not see the previous '
+                                        + 'timestamp to compare against. DrugRef reports last updated '
+                                        + (v.lastUpdate || 'never')
+                                        + ' — confirm drug search before prescribing.', 'warning');
+                                    show('updateButton', true);
+                                } else if (v.lastUpdate != null && v.lastUpdate !== lastUpdateBeforeRun) {
+                                    // The history timestamp MOVED. On a DrugRef too old to
+                                    // report an outcome, that is the only positive evidence a
+                                    // run finished: the row is written at the end of a
+                                    // successful rebuild and not at all by a failed one.
                                     setResult('Update finished at ' + v.lastUpdate + '.', 'success');
+                                } else {
+                                    // The run ended and the timestamp did NOT move. Reporting
+                                    // "Update finished at <date>" here -- as this did -- painted
+                                    // a green success built entirely on the "updating" flag
+                                    // having cleared, quoting the PRE-RUN date back at the
+                                    // operator. A failed run clears that flag too.
+                                    setResult('The update has ended, but DrugRef reports no new update'
+                                        + (v.lastUpdate ? ' (still ' + v.lastUpdate + ')' : '')
+                                        + ', so it most likely FAILED. This DrugRef build is too old to '
+                                        + 'report why — check the service log (journalctl -u carlos-emr) '
+                                        + 'and confirm drug search before prescribing.', 'danger');
+                                    show('updateButton', true);
                                 }
                             });
                         }
@@ -254,6 +295,10 @@
             }
 
             function updateDB() {
+                // Frozen before the POST, while the panel still shows the pre-run value. If the
+                // page was opened mid-run this is null -- the baseline is genuinely unknown,
+                // and the legacy fallback says so rather than guessing either way.
+                lastUpdateBeforeRun = lastVerifiedUpdate;
                 setResult('Starting the update...', 'info');
                 callDrugref('updateDB')
                     .then(function (json) {

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -311,12 +311,60 @@
             }
 
             function updateDB() {
-                // Frozen before the POST, while the panel still shows the pre-run value. If the
-                // page was opened mid-run this is null -- the baseline is genuinely unknown,
-                // and the legacy fallback says so rather than guessing either way.
+                setResult('Starting the update...', 'info');
+                // Hidden now, not in startUpdate(): the re-probe below is a round trip, and the
+                // trigger must not stay clickable across it.
+                show('updateButton', false);
+                // Re-probe the baseline instead of reusing the one from page load. On a DrugRef
+                // too old to report an outcome, the legacy fallback decides success by whether
+                // the history timestamp MOVED, so a stale baseline is not a cosmetic problem:
+                // if another administrator completed an update while this page sat open, the
+                // timestamp has already moved, and THIS run -- however it ends -- would be
+                // reported as "Update finished at <their date>". A failed rebuild announced as
+                // a success is the one outcome this panel exists to prevent.
+                //
+                // The probe cannot fail the run: DrugRef refuses to start a second update while
+                // one is going, so the only cost of an unreachable probe is an unknown
+                // baseline, which the fallback already reports honestly rather than guessing.
+                verifyForBaseline()
+                    .then(startUpdate)
+                    .catch(function (error) {
+                        console.error('Could not re-read the baseline before updating:', error);
+                        baselineKnown = false;
+                        startUpdate();
+                    });
+            }
+
+            // Re-reads the last-update timestamp and refreshes the panel with it, so the
+            // baseline frozen a moment later is what DrugRef reports NOW, not at page load.
+            function verifyForBaseline() {
+                return callDrugref('verify').then(function (json) {
+                    var unavailable = !json
+                            || (json.lastUpdate == null && json.drugDatabase == null && json.version == null);
+                    if (unavailable || json.lastUpdate === 'updating') {
+                        // No usable baseline. Either DrugRef could not be reached, or a run is
+                        // already going -- and a timestamp frozen mid-run belongs to whatever
+                        // that run does, not to this one. Marking it unknown routes the legacy
+                        // fallback to its "cannot tell" message instead of a guess; leaving the
+                        // page-load value in place would be the stale baseline this re-probe
+                        // exists to eliminate.
+                        baselineKnown = false;
+                        return;
+                    }
+                    renderVerify(json);
+                });
+            }
+
+            function startUpdate() {
+                // Frozen immediately before the POST. If the page was opened mid-run, or the
+                // re-probe above could not reach DrugRef, this is unknown -- and the legacy
+                // fallback says so rather than guessing either way.
                 lastUpdateBeforeRun = lastVerifiedUpdate;
                 baselineKnownBeforeRun = baselineKnown;
-                setResult('Starting the update...', 'info');
+                // Again: the re-probe calls renderVerify(), which shows the trigger when the
+                // database looks updatable. That is right for the panel and wrong for the
+                // moment a run is starting, so the last word belongs here.
+                show('updateButton', false);
                 callDrugref('updateDB')
                     .then(function (json) {
                         if (json.result === 'running') {

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -122,6 +122,11 @@
                 document.getElementById(id).style.display = visible ? 'block' : 'none';
             }
 
+            // Keep the strings this page builds ASCII. The JSP declares no page encoding and
+            // web.xml sets none, so Jasper reads the source as ISO-8859-1: a UTF-8 em dash in
+            // a JS literal reaches the operator as three mojibake characters. Seen live on
+            // the packaged install; the bundle strings are unaffected (properties files are
+            // decoded separately).
             function setResult(text, kind) {
                 var el = document.getElementById('updateResult');
                 el.textContent = text;
@@ -249,7 +254,7 @@
                                         + 'whether it succeeded, and this page did not see the previous '
                                         + 'timestamp to compare against. DrugRef reports last updated '
                                         + (v.lastUpdate || 'never')
-                                        + ' — confirm drug search before prescribing.', 'warning');
+                                        + ' - confirm drug search before prescribing.', 'warning');
                                     show('updateButton', true);
                                 } else if (v.lastUpdate != null && v.lastUpdate !== lastUpdateBeforeRun) {
                                     // The history timestamp MOVED. On a DrugRef too old to
@@ -266,7 +271,7 @@
                                     setResult('The update has ended, but DrugRef reports no new update'
                                         + (v.lastUpdate ? ' (still ' + v.lastUpdate + ')' : '')
                                         + ', so it most likely FAILED. This DrugRef build is too old to '
-                                        + 'report why — check the service log (journalctl -u carlos-emr) '
+                                        + 'report why - check the service log (journalctl -u carlos-emr) '
                                         + 'and confirm drug search before prescribing.', 'danger');
                                     show('updateButton', true);
                                 }

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -64,6 +64,21 @@
         <script src="${carlos:forHtmlAttribute(ctx)}/share/javascript/csrfTokenFetch.js"></script>
 
         <script>
+            // Administration > Update Drugref.
+            //
+            // Three server calls, all to /rx/updateDrugrefDB:
+            //   method=verify   -> {lastUpdate, drugDatabase, version}   (lastUpdate is "updating" mid-run)
+            //   method=status   -> {state, step, message, startedAt, finishedAt, lastUpdate}
+            //                      state: IDLE | RUNNING | SUCCEEDED | FAILED, or UNAVAILABLE when
+            //                      DrugRef cannot answer (down, or a build without getUpdateStatus)
+            //   method=updateDB -> {result: "running" | "updating" | null}
+            //
+            // The page used to stop at "Update has started" and never look again. A run that
+            // died left "updating" on screen for good, and a call that failed outright showed
+            // nothing at all. Now it polls status until the run ends and says how it ended.
+            var POLL_MS = 15000;
+            var pollTimer = null;
+
             function getCsrfToken() {
                 var el = document.querySelector('input[name="CSRF-TOKEN"]');
                 if (!el) {
@@ -73,93 +88,163 @@
                 return el.value;
             }
 
-            function getUpdateTime() {
+            function callDrugref(method) {
                 const url = "${carlos:forJavaScript(ctx)}" + "/rx/updateDrugrefDB";
                 const formData = new URLSearchParams();
-                formData.append('method', 'verify');
+                formData.append('method', method);
                 formData.append('CSRF-TOKEN', getCsrfToken());
-
-                var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');
-                var csrfToken = csrfEl ? csrfEl.value : '';
-                fetch(url, {
+                return fetch(url, {
                     method: 'POST',
                     credentials: 'same-origin',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded',
-                        'CSRF-TOKEN': csrfToken,
+                        'CSRF-TOKEN': getCsrfToken(),
                         'X-Requested-With': 'XMLHttpRequest'
                     },
                     body: formData.toString()
-                })
-                .then(function(response) {
+                }).then(function (response) {
                     if (!response.ok) {
-                        throw new Error('Network response was not ok');
+                        throw new Error('HTTP ' + response.status + ' from ' + method);
                     }
                     return response.json();
-                })
-                .then(function(json) {
-                    if (json.lastUpdate == null) {
-                        document.getElementById('dbInfo').innerHTML = 'Drugref database has not been updated, please update.';
-                        document.getElementById('updatedb').style.display = 'block';
-                        document.getElementById('statusDisplay').style.display = 'none';
-                    } else if (json.lastUpdate === 'updating') {
-                        document.getElementById('dbInfo').innerHTML = 'Drugref database is updating';
-                        document.getElementById('statusDisplay').style.display = 'none';
-                        document.getElementById('updateButton').style.display = 'none';
-                    } else {
-                        document.getElementById('dbDateTime').textContent = json.lastUpdate;
-                        document.getElementById('drugDatabaseVersion').textContent = json.version;
-                        document.getElementById('drugDatabase').textContent = json.drugDatabase;
-                        document.getElementById('dbInfo').style.display = 'none';
-                        document.getElementById('statusDisplay').style.display = 'block';
-                    }
-                })
-                .catch(function(error) {
-                    document.getElementById('dbInfo').innerHTML = 'Drugref database has not been updated, please update.';
-                    document.getElementById('updatedb').style.display = 'block';
-                    document.getElementById('statusDisplay').style.display = 'none';
                 });
             }
 
-            function updateDB() {
-                const url = "${carlos:forJavaScript(ctx)}" + "/rx/updateDrugrefDB";
-                const formData = new URLSearchParams();
-                formData.append('method', 'updateDB');
-                formData.append('CSRF-TOKEN', getCsrfToken());
+            function show(id, visible) {
+                document.getElementById(id).style.display = visible ? 'block' : 'none';
+            }
 
-                var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');
-                var csrfToken = csrfEl ? csrfEl.value : '';
-                fetch(url, {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                        'CSRF-TOKEN': csrfToken,
-                        'X-Requested-With': 'XMLHttpRequest'
-                    },
-                    body: formData.toString()
-                })
-                .then(function(response) {
-                    if (!response.ok) {
-                        throw new Error('Network response was not ok');
-                    }
-                    return response.json();
-                })
-                .then(function(json) {
-                    if (json.result === 'running') {
-                        document.getElementById('updateResult').innerHTML = "Update has started, it'll take about 1 hour to finish";
-                    } else if (json.result === 'updating') {
-                        document.getElementById('updateResult').innerHTML = "Some one has already been updating it";
-                    }
-                })
-                .catch(function(error) {
-                    console.error('Error updating database:', error);
-                });
+            function setResult(text, kind) {
+                var el = document.getElementById('updateResult');
+                el.textContent = text;
+                el.className = kind ? 'alert alert-' + kind + ' mt-3' : '';
+                el.style.display = text ? 'block' : 'none';
+            }
+
+            function renderVerify(json) {
+                if (!json || json.lastUpdate == null) {
+                    document.getElementById('dbInfo').textContent = 'Drugref database has not been updated, please update.';
+                    show('dbInfo', true);
+                    show('statusDisplay', false);
+                    show('updateButton', true);
+                } else if (json.lastUpdate === 'updating') {
+                    document.getElementById('dbInfo').textContent = 'Drugref database is updating';
+                    show('dbInfo', true);
+                    show('statusDisplay', false);
+                    show('updateButton', false);
+                } else {
+                    document.getElementById('dbDateTime').textContent = json.lastUpdate;
+                    document.getElementById('drugDatabaseVersion').textContent = json.version;
+                    document.getElementById('drugDatabase').textContent = json.drugDatabase;
+                    show('dbInfo', false);
+                    show('statusDisplay', true);
+                    show('updateButton', true);
+                }
+            }
+
+            function getUpdateTime() {
+                return callDrugref('verify')
+                    .then(renderVerify)
+                    .catch(function () {
+                        document.getElementById('dbInfo').textContent = 'Drugref database is unavailable. Contact support.';
+                        show('dbInfo', true);
+                        show('statusDisplay', false);
+                        show('updateButton', true);
+                    });
+            }
+
+            // Renders the status struct; returns true while a run is in progress.
+            function renderStatus(status) {
+                var running = false;
+                if (!status || status.state === 'UNAVAILABLE' || status.state === 'IDLE') {
+                    return false;
+                }
+                if (status.state === 'RUNNING') {
+                    running = true;
+                    setResult('Update in progress' + (status.startedAt ? ' since ' + status.startedAt : '')
+                        + (status.step ? ': ' + status.step : '') + '. Drug lookups are limited until it finishes.', 'info');
+                    show('updateButton', false);
+                } else if (status.state === 'FAILED') {
+                    setResult('The last update' + (status.finishedAt ? ' (' + status.finishedAt + ')' : '')
+                        + ' FAILED and the previous drug data was kept: ' + (status.message || 'no details'), 'danger');
+                    show('updateButton', true);
+                } else if (status.state === 'SUCCEEDED') {
+                    setResult('Update completed' + (status.finishedAt ? ' at ' + status.finishedAt : '')
+                        + (status.message ? ': ' + status.message : '') + '.', 'success');
+                    show('updateButton', true);
+                }
+                return running;
+            }
+
+            function pollStatus() {
+                callDrugref('status')
+                    .then(function (status) {
+                        var running = renderStatus(status);
+                        if (!running && status && status.state === 'UNAVAILABLE') {
+                            // Older DrugRef without getUpdateStatus: fall back to the verify
+                            // probe, which still answers "updating" until the run ends.
+                            return callDrugref('verify').then(function (v) {
+                                renderVerify(v);
+                                if (v && v.lastUpdate === 'updating') {
+                                    pollTimer = setTimeout(pollStatus, POLL_MS);
+                                } else {
+                                    setResult('Update finished.', 'success');
+                                }
+                            });
+                        }
+                        if (running) {
+                            pollTimer = setTimeout(pollStatus, POLL_MS);
+                        } else {
+                            // Run ended: refresh the date/version panel to show the outcome.
+                            getUpdateTime();
+                        }
+                    })
+                    .catch(function (error) {
+                        console.error('Error reading update status:', error);
+                        pollTimer = setTimeout(pollStatus, POLL_MS);
+                    });
+            }
+
+            function updateDB() {
+                setResult('Starting the update...', 'info');
+                callDrugref('updateDB')
+                    .then(function (json) {
+                        if (json.result === 'running') {
+                            setResult("Update has started. It rebuilds the drug database from Health Canada's "
+                                + "extract and usually takes 15 to 60 minutes; drug lookups are limited until it "
+                                + "finishes. This page follows its progress.", 'info');
+                            show('updateButton', false);
+                            pollStatus();
+                        } else if (json.result === 'updating') {
+                            setResult('An update is already running.', 'info');
+                            pollStatus();
+                        } else {
+                            setResult('The update could not be started: DrugRef did not answer. Check that the '
+                                + 'DrugRef service is running (drug lookups also need it).', 'danger');
+                        }
+                    })
+                    .catch(function (error) {
+                        console.error('Error updating database:', error);
+                        setResult('The update could not be started: ' + error.message, 'danger');
+                    });
             }
 
             document.addEventListener("DOMContentLoaded", function () {
                 fetchCsrfToken("${carlos:forJavaScript(ctx)}")
-                    .then(getUpdateTime)
+                    .then(function () {
+                        return getUpdateTime();
+                    })
+                    .then(function () {
+                        // Report a run already in progress (started from another session) or
+                        // the outcome of the last one, and keep following a running one.
+                        return callDrugref('status').then(function (status) {
+                            if (renderStatus(status)) {
+                                pollTimer = setTimeout(pollStatus, POLL_MS);
+                            }
+                        }).catch(function (error) {
+                            console.warn('Update status not available:', error);
+                        });
+                    })
                     .catch(function (err) {
                         console.warn('Skipping getUpdateTime — CSRF token not available:', err);
                         document.getElementById('dbInfo').innerHTML =
@@ -197,7 +282,7 @@
           <a id="updatedb" onclick="updateDB();" href="javascript:void(0);"
               class="btn btn-primary"><fmt:message key="admin.admin.UpdateDrugref"/></a>
         </div>
-        <div><a id="updateResult"></a></div>
+        <div id="updateResult" role="status" style="display:none;"></div>
     </div>
     </body>
 

--- a/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updateDrugref.jsp
@@ -142,14 +142,20 @@
                 }
             }
 
+            // Resolves with the verify payload (null when DrugRef could not be reached),
+            // which the startup path needs to spot a run already going on an older build.
             function getUpdateTime() {
                 return callDrugref('verify')
-                    .then(renderVerify)
+                    .then(function (json) {
+                        renderVerify(json);
+                        return json;
+                    })
                     .catch(function () {
                         document.getElementById('dbInfo').textContent = 'Drugref database is unavailable. Contact support.';
                         show('dbInfo', true);
                         show('statusDisplay', false);
                         show('updateButton', true);
+                        return null;
                     });
             }
 
@@ -187,8 +193,17 @@
                                 renderVerify(v);
                                 if (v && v.lastUpdate === 'updating') {
                                     pollTimer = setTimeout(pollStatus, POLL_MS);
+                                } else if (!v || v.lastUpdate == null) {
+                                    // DrugRef stopped answering mid-run. A null lastUpdate is
+                                    // "cannot tell", NOT "finished": reporting success here
+                                    // would tell the operator the rebuild completed when it
+                                    // may have died with the tables half-built. Keep looking.
+                                    setResult('DrugRef stopped responding, so the outcome of this update is '
+                                        + 'unknown. Still checking. If this persists, check the DrugRef service '
+                                        + '(journalctl -u carlos-emr) before prescribing.', 'danger');
+                                    pollTimer = setTimeout(pollStatus, POLL_MS);
                                 } else {
-                                    setResult('Update finished.', 'success');
+                                    setResult('Update finished at ' + v.lastUpdate + '.', 'success');
                                 }
                             });
                         }
@@ -234,11 +249,22 @@
                     .then(function () {
                         return getUpdateTime();
                     })
-                    .then(function () {
+                    .then(function (verifyJson) {
                         // Report a run already in progress (started from another session) or
                         // the outcome of the last one, and keep following a running one.
                         return callDrugref('status').then(function (status) {
                             if (renderStatus(status)) {
+                                pollTimer = setTimeout(pollStatus, POLL_MS);
+                                return;
+                            }
+                            if (status && status.state === 'UNAVAILABLE'
+                                    && verifyJson && verifyJson.lastUpdate === 'updating') {
+                                // An older DrugRef with a run already going: status cannot see
+                                // it, so follow it through the verify probe. Without this the
+                                // page sat on "database is updating" for good, because polling
+                                // was only ever armed off a RUNNING status.
+                                setResult('An update is already running. This page is following it.', 'info');
+                                show('updateButton', false);
                                 pollTimer = setTimeout(pollStatus, POLL_MS);
                             }
                         }).catch(function (error) {
@@ -247,7 +273,7 @@
                     })
                     .catch(function (err) {
                         console.warn('Skipping getUpdateTime — CSRF token not available:', err);
-                        document.getElementById('dbInfo').innerHTML =
+                        document.getElementById('dbInfo').textContent =
                             'Could not load CSRF token. Refresh the page or contact support.';
                     });
             });

--- a/src/main/webapp/WEB-INF/jsp/rx/TopLinks2.jspf
+++ b/src/main/webapp/WEB-INF/jsp/rx/TopLinks2.jspf
@@ -74,7 +74,9 @@ function getDrugRefStatus() {
 				// 'updating' is a rebuild in progress (Administration > Update Drugref), not an
 				// outage: say so, because the two call for different reactions from the desk.
 				let statusDisplay = document.getElementById('statusDisplay');
-				statusDisplay.innerHTML = (json && json.lastUpdate === 'updating') ? msgDrugrefUpdating : msgDrugrefUnavailable;
+				// textContent, not innerHTML: these are plain-text bundle strings, and a
+				// translation that ever picked up markup should render as text, not HTML.
+				statusDisplay.textContent = (json && json.lastUpdate === 'updating') ? msgDrugrefUpdating : msgDrugrefUnavailable;
 				statusDisplay.style.color = 'red';
 				statusDisplay.style.fontWeight = 'bold';
 			} else {
@@ -91,7 +93,7 @@ function getDrugRefStatus() {
 		})
 		.catch(error => {
 			let statusDisplay = document.getElementById('statusDisplay');
-			statusDisplay.innerHTML = msgDrugrefUnavailableContact;
+			statusDisplay.textContent = msgDrugrefUnavailableContact;
 			statusDisplay.style.color = 'red';
 			statusDisplay.style.fontWeight = 'bold';
 		});

--- a/src/main/webapp/WEB-INF/jsp/rx/TopLinks2.jspf
+++ b/src/main/webapp/WEB-INF/jsp/rx/TopLinks2.jspf
@@ -37,6 +37,7 @@
 <script type="text/javascript">
 const msgDrugrefUnavailable = '<fmt:message key="oscarRx.drugrefUnavailable"/>';
 const msgDrugrefUnavailableContact = '<fmt:message key="oscarRx.drugrefUnavailableContact"/>';
+const msgDrugrefUpdating = '<fmt:message key="oscarRx.drugrefUpdating"/>';
 
 function newWindow(url) {
     var newwin = window.open(url, 'name', 'height=700,width=1000');
@@ -70,8 +71,10 @@ function getDrugRefStatus() {
 			// .catch below. 'updating' is still covered -- it is truthy and is
 			// handled by the same banner.
 			if (!json || !json.lastUpdate || json.lastUpdate === 'updating' ) {
+				// 'updating' is a rebuild in progress (Administration > Update Drugref), not an
+				// outage: say so, because the two call for different reactions from the desk.
 				let statusDisplay = document.getElementById('statusDisplay');
-				statusDisplay.innerHTML = msgDrugrefUnavailable;
+				statusDisplay.innerHTML = (json && json.lastUpdate === 'updating') ? msgDrugrefUpdating : msgDrugrefUnavailable;
 				statusDisplay.style.color = 'red';
 				statusDisplay.style.fontWeight = 'bold';
 			} else {

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -134,7 +134,7 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(SecurityException.class)
                 .hasMessage("missing required sec object (_admin or _admin.misc)");
 
-        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "r", null);
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "w", null);
         verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_rx"), any(), isNull());
     }
 
@@ -263,6 +263,47 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should refuse updateDB to a view-only administrator")
+    void shouldRefuseUpdateDb_forAViewOnlyAdministrator() throws Exception {
+        // Read on an administration object opens the page and answers status; it must not start
+        // a rebuild. That runs for half an hour, degrades drug lookups clinic-wide while it does,
+        // and can end with the dataset replaced -- a mutation, and CARLOS gates mutating
+        // administration on write (ManageFlowsheets2Action, LookupListManager2Action, the admin
+        // gate actions). Accepting read here let a view-only administrator trigger it.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("w"), isNull()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.misc"), eq("w"), isNull()))
+                .thenReturn(false);
+        mockRequest.setParameter("method", "updateDB");
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("missing required sec object (_admin or _admin.misc)");
+
+        // Refused before anything was written to the response, so no partial JSON escapes.
+        assertThat(mockResponse.getContentAsString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should still answer status to a view-only administrator")
+    void shouldStillAnswerStatus_forAViewOnlyAdministrator() throws Exception {
+        // The counterpart: tightening the trigger must not take the read-only view with it, or
+        // an administrator who can open the page cannot see what the update is doing.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("w"), isNull()))
+                .thenReturn(false);
+        mockRequest.setParameter("method", "status");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).startsWith("application/json");
+    }
+
+    @Test
     @DisplayName("should not query administration rights when prescriber rights already allow verify")
     void shouldNotQueryAdministrationRights_whenRxRightsAlreadyAllowVerify() throws Exception {
         // Ordering, not just outcome. Every hasPrivilege call re-runs
@@ -290,6 +331,8 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
                 .thenReturn(false);
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
                 .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("w"), isNull()))
+                .thenReturn(true);
         mockRequest.setParameter("method", "verify");
 
         String result = action.execute();
@@ -306,6 +349,8 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), any(), isNull()))
                 .thenReturn(false);
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("w"), isNull()))
                 .thenReturn(true);
         mockRequest.setMethod("POST");
         mockRequest.setParameter("method", "updateDB");
@@ -327,6 +372,8 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
                 .thenReturn(true);
         // status also demands administration rights: it relays DrugRef's root-cause text.
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("w"), isNull()))
                 .thenReturn(true);
         mockRequest.setParameter("method", "status");
 
@@ -358,6 +405,8 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
                 .thenReturn(true);
         // A rebuild is an administrative act: it also needs the page's right.
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("w"), isNull()))
                 .thenReturn(true);
         mockRequest.setParameter("method", "updateDB");
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -123,16 +123,19 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should demand write privilege when method is updateDB")
-    void shouldDemandWrite_whenMethodIsUpdateDb() {
+    @DisplayName("should demand administration rights when method is updateDB")
+    void shouldDemandAdministrationRights_whenMethodIsUpdateDb() {
+        // A rebuild is an administrative act, so it is gated like the page that offers it and
+        // NOT on _rx. Requiring both locked out an administrator who is not a prescriber.
         denyAllPrivileges();
         mockRequest.setParameter("method", "updateDB");
 
         assertThatThrownBy(() -> action.execute())
                 .isInstanceOf(SecurityException.class)
-                .hasMessage("missing required sec object (_rx)");
+                .hasMessage("missing required sec object (_admin or _admin.misc)");
 
-        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "w", null);
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "r", null);
+        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_rx"), any(), isNull());
     }
 
     @Test
@@ -189,14 +192,16 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should demand only read privilege when method is status")
-    void shouldDemandOnlyRead_whenMethodIsStatus() {
+    @DisplayName("should demand administration rights when method is status")
+    void shouldDemandAdministrationRights_whenMethodIsStatus() {
         denyAllPrivileges();
         mockRequest.setParameter("method", "status");
 
-        assertThatThrownBy(() -> action.execute()).isInstanceOf(SecurityException.class);
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("missing required sec object (_admin or _admin.misc)");
 
-        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "r", null);
     }
 
     @Test
@@ -253,7 +258,43 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
 
         assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
         assertThat(mockResponse.getContentType()).startsWith("application/json");
-        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_admin"), any(), isNull());
+        // No administration rights needed: prescriber read alone is enough.
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+    }
+
+    @Test
+    @DisplayName("should allow verify to an administrator who is not a prescriber")
+    void shouldAllowVerify_forAnAdministratorWithoutRxRights() throws Exception {
+        // The admin page fires verify too. Gating it on _rx alone would leave an administrator
+        // who does not prescribe able to open the page and see nothing but an outage banner.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), any(), isNull()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        mockRequest.setParameter("method", "verify");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).startsWith("application/json");
+    }
+
+    @Test
+    @DisplayName("should let an administrator without Rx rights start a rebuild")
+    void shouldAllowUpdateDb_forAnAdministratorWithoutRxRights() throws Exception {
+        // The defect this replaces: _rx was required on top of _admin, so a non-prescribing
+        // administrator could open the page and every call from it failed with an HTML 500.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), any(), isNull()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
+        mockRequest.setMethod("POST");
+        mockRequest.setParameter("method", "updateDB");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentAsString()).contains("result");
     }
 
     @Test
@@ -284,8 +325,9 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
                 .contains("\"startedAt\":\"\"")
                 .contains("\"finishedAt\":\"\"")
                 .contains("\"lastUpdate\":\"\"");
-        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+        // status is gated on administration rights alone; _rx is not consulted for it.
         verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "r", null);
+        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_rx"), any(), isNull());
         verifyNoMoreInteractions(mockSecurityInfoManager);
     }
 
@@ -337,8 +379,13 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
         // "UPDATEDB" routes to -- shouldRouteCaseVariant_toAReadOnlyBranch covers that half.
         mockRequest.setParameter("method", "UPDATEDB");
 
-        assertThatThrownBy(() -> action.execute()).isInstanceOf(SecurityException.class);
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("missing required sec object (_rx)");
 
+        // The read branch consults administration rights first (they also satisfy it), then _rx.
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "r", null);
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin.misc", "r", null);
         verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
         verifyNoMoreInteractions(mockSecurityInfoManager);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -295,12 +295,37 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
         // The page renders {"result":null} as "could not be started"; it used to render nothing.
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("w"), isNull()))
                 .thenReturn(true);
+        // A rebuild is an administrative act: it also needs the page's right.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(true);
         mockRequest.setParameter("method", "updateDB");
 
         String result = action.execute();
 
         assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
         assertThat(mockResponse.getContentAsString()).isEqualTo("{\"result\":null}");
+    }
+
+    @Test
+    @DisplayName("should refuse to start a rebuild for a prescriber without administration rights")
+    void shouldRefuseUpdateDb_whenTheCallerHasOnlyRxWrite() throws Exception {
+        // `_rx` write is every prescriber in the clinic. A rebuild degrades prescribing for
+        // half an hour and is an administrative act; the page that offers it is gated on
+        // _admin / _admin.misc, and the direct POST must be gated the same way or the page's
+        // gate is decorative.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("w"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.misc"), eq("r"), isNull()))
+                .thenReturn(false);
+        mockRequest.setMethod("POST");
+        mockRequest.setParameter("method", "updateDB");
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_admin or _admin.misc");
+        assertThat(mockResponse.getContentAsString()).as("nothing reached the response").isEmpty();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -213,7 +213,16 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
 
         assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
         assertThat(mockResponse.getContentType()).startsWith("application/json");
-        assertThat(mockResponse.getContentAsString()).contains("\"state\":\"UNAVAILABLE\"");
+        String body = mockResponse.getContentAsString();
+        assertThat(body).contains("\"state\":\"UNAVAILABLE\"");
+        // The outage payload must carry the SAME keys as a successful answer. A client meeting
+        // the documented set on the success path and a bare state here would have to cope with a
+        // shape change on exactly the path where it knows least.
+        assertThat(body).contains("\"step\":\"\"")
+                .contains("\"message\":\"\"")
+                .contains("\"startedAt\":\"\"")
+                .contains("\"finishedAt\":\"\"")
+                .contains("\"lastUpdate\":\"\"");
         verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
         verifyNoMoreInteractions(mockSecurityInfoManager);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -263,6 +263,25 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should not query administration rights when prescriber rights already allow verify")
+    void shouldNotQueryAdministrationRights_whenRxRightsAlreadyAllowVerify() throws Exception {
+        // Ordering, not just outcome. Every hasPrivilege call re-runs
+        // secUserRoleDao.findActiveByProviderNo -- there is no role cache -- and TopLinks2.jspf
+        // fires verify on every Rx page load. Evaluating the administration rights first cost
+        // ordinary prescribers two extra role queries per page load to answer a question `_rx`
+        // alone settles, so the short-circuit is the point and this pins it.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        mockRequest.setParameter("method", "verify");
+
+        action.execute();
+
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_admin"), any(), isNull());
+        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_admin.misc"), any(), isNull());
+    }
+
+    @Test
     @DisplayName("should allow verify to an administrator who is not a prescriber")
     void shouldAllowVerify_forAnAdministratorWithoutRxRights() throws Exception {
         // The admin page fires verify too. Gating it on _rx alone would leave an administrator

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -188,6 +188,51 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should demand only read privilege when method is status")
+    void shouldDemandOnlyRead_whenMethodIsStatus() {
+        denyAllPrivileges();
+        mockRequest.setParameter("method", "status");
+
+        assertThatThrownBy(() -> action.execute()).isInstanceOf(SecurityException.class);
+
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+    }
+
+    @Test
+    @DisplayName("should answer status JSON with state UNAVAILABLE when DrugRef cannot be reached")
+    void shouldAnswerUnavailableState_whenDrugRefUnreachable() throws Exception {
+        // No DrugRef is listening in a unit test, so the relay must degrade to a well-formed
+        // JSON payload the page can act on, not an HTTP 500. UNAVAILABLE is also what a DrugRef
+        // build without getUpdateStatus produces (an XML-RPC fault), and the page falls back to
+        // the verify probe on it.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        mockRequest.setParameter("method", "status");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).startsWith("application/json");
+        assertThat(mockResponse.getContentAsString()).contains("\"state\":\"UNAVAILABLE\"");
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+        verifyNoMoreInteractions(mockSecurityInfoManager);
+    }
+
+    @Test
+    @DisplayName("should answer a null result as JSON when updateDB cannot reach DrugRef")
+    void shouldAnswerNullResultAsJson_whenUpdateDbUnreachable() throws Exception {
+        // The page renders {"result":null} as "could not be started"; it used to render nothing.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("w"), isNull()))
+                .thenReturn(true);
+        mockRequest.setParameter("method", "updateDB");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentAsString()).isEqualTo("{\"result\":null}");
+    }
+
+    @Test
     @DisplayName("should gate a case variant of updateDB at read, not write")
     void shouldGateCaseVariant_atReadPrivilege() {
         denyAllPrivileges();

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2ActionUnitTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -199,6 +200,63 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should refuse status to a prescriber without administration rights")
+    void shouldRefuseStatus_whenTheCallerHasNoAdminRights() throws Exception {
+        // `status` relays DrugRef's root-cause failure text -- a JDBC URL, a database host and
+        // user, a filesystem path. `_rx` read is every prescriber in the clinic; the page that
+        // consumes this is gated on _admin / _admin.misc read by ViewUpdateDrugref2Action.
+        // Reporting is not automatically public just because it does not write.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.misc"), eq("r"), isNull()))
+                .thenReturn(false);
+        mockRequest.setParameter("method", "status");
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_admin or _admin.misc");
+        assertThat(mockResponse.getContentAsString()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should allow status on the misc administration right alone")
+    void shouldAllowStatus_whenTheCallerHasOnlyAdminMisc() throws Exception {
+        // ViewUpdateDrugref2Action accepts either right, so this must too -- gating on _admin
+        // alone would lock the relay away from operators who can open the page.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.misc"), eq("r"), isNull()))
+                .thenReturn(true);
+        mockRequest.setParameter("method", "status");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentAsString()).contains("\"state\":\"UNAVAILABLE\"");
+    }
+
+    @Test
+    @DisplayName("should still allow verify at prescriber read rights")
+    void shouldStillAllowVerify_atPrescriberReadRights() throws Exception {
+        // The counterpart to the two above: TopLinks2.jspf fires verify on every Rx page load,
+        // and it carries only a date, a version and a database name. Tightening status must not
+        // drag verify along with it, or every prescriber gets the "unavailable" banner again.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        mockRequest.setParameter("method", "verify");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(org.apache.struts2.ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).startsWith("application/json");
+        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), eq("_admin"), any(), isNull());
+    }
+
+    @Test
     @DisplayName("should answer status JSON with state UNAVAILABLE when DrugRef cannot be reached")
     void shouldAnswerUnavailableState_whenDrugRefUnreachable() throws Exception {
         // No DrugRef is listening in a unit test, so the relay must degrade to a well-formed
@@ -206,6 +264,9 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
         // build without getUpdateStatus produces (an XML-RPC fault), and the page falls back to
         // the verify probe on it.
         when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        // status also demands administration rights: it relays DrugRef's root-cause text.
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin"), eq("r"), isNull()))
                 .thenReturn(true);
         mockRequest.setParameter("method", "status");
 
@@ -224,6 +285,7 @@ class RxUpdateDrugref2ActionUnitTest extends CarlosUnitTestBase {
                 .contains("\"finishedAt\":\"\"")
                 .contains("\"lastUpdate\":\"\"");
         verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_rx", "r", null);
+        verify(mockSecurityInfoManager).hasPrivilege(mockLoggedInInfo, "_admin", "r", null);
         verifyNoMoreInteractions(mockSecurityInfoManager);
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRefStatusStructUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRefStatusStructUnitTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.prescript.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The contract {@code RxDrugRef.getUpdateStatus()} documents: every key it names is present as a
+ * String, whatever the DrugRef build on the other side of the pin actually answers with.
+ *
+ * <p>This matters because the value is relayed to the browser as JSON. A key the server omits
+ * used to be absent from the map and therefore from the JSON, reaching
+ * {@code updateDrugref.jsp} as {@code undefined} rather than the empty string the JavaDoc
+ * promises — so a caller could not tell "not supplied" from "supplied empty".
+ */
+@Tag("unit")
+class RxDrugRefStatusStructUnitTest {
+
+    @Test
+    @DisplayName("should supply every documented key as empty when the server omits it")
+    void shouldSupplyEveryDocumentedKey_whenTheStructIsSparse() {
+        Map<String, String> status = RxDrugRef.normalizeStatusStruct(new Hashtable<>(Map.of("state", "IDLE")));
+
+        assertThat(status).containsOnlyKeys(RxDrugRef.STATUS_KEYS);
+        assertThat(status.get("state")).isEqualTo("IDLE");
+        assertThat(status.get("step")).isEmpty();
+        assertThat(status.get("message")).isEmpty();
+        assertThat(status.get("startedAt")).isEmpty();
+        assertThat(status.get("finishedAt")).isEmpty();
+        assertThat(status.get("lastUpdate")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should keep the server values when the struct is complete")
+    void shouldKeepTheServerValues_whenTheStructIsComplete() {
+        Hashtable<String, Object> struct = new Hashtable<>();
+        struct.put("state", "FAILED");
+        struct.put("step", "downloading Health Canada DPD archives");
+        struct.put("message", "ConnectException: Connection refused");
+        struct.put("startedAt", "2026-09-05 23:44:10");
+        struct.put("finishedAt", "2026-09-05 23:44:21");
+        struct.put("lastUpdate", "2020-05-28 00:00:00.0");
+
+        Map<String, String> status = RxDrugRef.normalizeStatusStruct(struct);
+
+        assertThat(status).containsOnlyKeys(RxDrugRef.STATUS_KEYS);
+        assertThat(status.get("state")).isEqualTo("FAILED");
+        assertThat(status.get("message")).isEqualTo("ConnectException: Connection refused");
+        assertThat(status.get("lastUpdate")).isEqualTo("2020-05-28 00:00:00.0");
+    }
+
+    @Test
+    @DisplayName("should render a null value as empty rather than the string null")
+    void shouldRenderANullValue_asEmpty() {
+        // HashMap, not Hashtable: XML-RPC cannot carry a null, but the relay must not depend on
+        // that to avoid writing the literal "null" into the page.
+        Map<String, Object> struct = new HashMap<>();
+        struct.put("state", "SUCCEEDED");
+        struct.put("message", null);
+
+        Map<String, String> status = RxDrugRef.normalizeStatusStruct(struct);
+
+        assertThat(status.get("message")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should pass through a key the documented set does not name")
+    void shouldPassThroughAnExtraKey_fromANewerServer() {
+        Map<String, String> status = RxDrugRef.normalizeStatusStruct(
+                new Hashtable<>(Map.of("state", "RUNNING", "percentComplete", "42")));
+
+        assertThat(status.get("percentComplete")).isEqualTo("42");
+        assertThat(status.keySet()).contains(RxDrugRef.STATUS_KEYS);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRefStatusStructUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxDrugRefStatusStructUnitTest.java
@@ -90,6 +90,16 @@ class RxDrugRefStatusStructUnitTest {
     }
 
     @Test
+    @DisplayName("should shape the unavailable fallback exactly like a real answer")
+    void shouldShapeTheUnavailableFallback_likeARealAnswer() {
+        Map<String, String> status = RxDrugRef.unavailableStatus();
+
+        assertThat(status).containsOnlyKeys(RxDrugRef.STATUS_KEYS);
+        assertThat(status.get("state")).isEqualTo("UNAVAILABLE");
+        assertThat(status.values()).doesNotContainNull();
+    }
+
+    @Test
     @DisplayName("should pass through a key the documented set does not name")
     void shouldPassThroughAnExtraKey_fromANewerServer() {
         Map<String, String> status = RxDrugRef.normalizeStatusStruct(


### PR DESCRIPTION
## Description

**Administration → Update Drugref** appeared to do nothing on a packaged alpha11 install. The click did reach DrugRef; everything after it was invisible or broken.

The page fired `updateDB`, printed *"Update has started, it'll take about 1 hour to finish"*, and never looked again. Behind it the DrugRef run had dropped every drug table and died (three defects, fixed in carlos-emr/drugref2026#11). The operator saw "started", then the status probe answered `"updating"` forever, then drug search returned nothing when prescribing — with no indication anywhere that the update had failed, or why. A call that failed outright rendered nothing at all: `updateDB()` answers `{"result":null}` when DrugRef is unreachable, and that matched no branch in the page's handler.

Nothing in the browser suite drove this page, which is how it shipped.

This PR is the CARLOS half: report the outcome, and pin the DrugRef build that produces one.

- **`RxDrugRef.getUpdateStatus()`** relays DrugRef's new `getUpdateStatus` struct (`state`, `step`, `message`, `startedAt`, `finishedAt`, `lastUpdate`).
- **`RxUpdateDrugref2Action`** gains `method=status`, gated at **read** privilege like `verify` (it reports; it does not mutate), answering `state=UNAVAILABLE` when DrugRef cannot be reached — which is also what a DrugRef build predating the method returns, and the page degrades to the `verify` probe on it. The direct-response methods now `return NONE` instead of a bare `null`, per the Direct Response Actions rule in CLAUDE.md.
- **`updateDrugref.jsp`** polls status every 15 s while a run is in progress, shows the current step, and ends with the outcome: *"Update completed at … : updated in 14 min; 39198 products, 80065 search entries"*, or *"The last update (…) FAILED and the previous drug data was kept: …"*. It also reports a run already in progress from another session, and says plainly when the trigger did not reach DrugRef at all.
- **`TopLinks2.jspf`** distinguishes a rebuild in progress from an outage: prescribers now see *"Drugref database is being updated. Drug lookups are limited until it finishes."* rather than *"unavailable"* (new `oscarRx.drugrefUpdating` key in all five bundles).
- **`debian/drugref.pin`** advances to the DrugRef fix, with the reason recorded in the pin file. `README.Debian` and `docs/install-deb.md` document the outbound HTTPS the Tomcat JVM needs to reach `www.canada.ca` and how to pass a proxy through `CARLOS_JAVA_OPTS` — the failure mode that first hid this bug.

## Related Issues

None filed — reported directly by a tester against the 2026.08.0-alpha11 debs. Companion PR: carlos-emr/drugref2026#11 (must merge first; see Notes).

## Target Branch

`release/2026.08` — a supported fix for the release line where the defect was found (2026.08.0-alpha11). The topic branch was cut from `main`, which currently sits at the alpha11 preparation commit `33f3c8a`; that commit is already in `release/2026.08`, so this PR carries **exactly one commit** against this base. Targeting `develop` from this branch would have dragged in the 62 main-line commits `develop` has not yet taken. No version or SCM metadata is touched. Please forward-merge rather than opening a duplicate cherry-pick PR.

## How Was This Tested?

Full deb install in a disposable Ubuntu 26.04 container (MariaDB 11.8.6, nginx + ModSecurity, self-signed TLS), using the released `carlos-emr` and `carlos-emr-drugref` 2026.08.0-alpha11 packages plus the demo dataset — the `docs/ui-tests/deb-install-validation.md` procedure. Everything through `:443`, never bare Tomcat.

**Reproduced first, on the stock packages:** clicking the button emptied all thirteen DPD tables, the worker died on the Hibernate 7 `SemanticException`, status stuck at `"updating"`, `list_search_element3("amox")` → `None found`.

**Then with the fixed DrugRef WAR and these changes deployed:**

| Scenario | Result |
|---|---|
| Failure path (DPD source unreachable) | Page shows *"The last update (2026-09-05 23:44:21) FAILED and the previous drug data was kept: failed during 'downloading Health Canada DPD archives': ConnectException: Connection refused"*. All tables intact, retriggerable. |
| Success path, browser click → completion | 14-minute rebuild followed live by the page; ends *"Update completed at 2026-09-05 23:59:32: updated in 14 min; 39198 products, 80065 search entries"*; panel date advances 2020-05-28 → 2026-09-05; Rx picker returns 47 results for `amox`. |
| Rx banner during a run | *"Drugref database is being updated. Drug lookups are limited until it finishes."* |
| Trigger cannot reach DrugRef | Page reports it instead of rendering nothing. |

Automated:

- `RxUpdateDrugref2ActionUnitTest` — 10 pass, 3 new: `status` demands only read privilege; the relay degrades to `state=UNAVAILABLE` as well-formed JSON rather than an HTTP 500; `updateDB` answers `{"result":null}` as JSON when DrugRef is unreachable. The existing privilege-split and GET-rejection assertions are unchanged.
- **`scripts/drugref-update-playwright-checks.js`** (new) reaches the page the way an operator does — the Administration panel link, not the JSP path — and asserts the verify probe, the status relay and the button. Read-only by default, so it is safe in the suite loop; `DRUGREF_UPDATE_TRIGGER=true` also clicks and follows a full rebuild to `SUCCEEDED`, the date moving forward and drug search still answering. Both modes pass; the runbook §6 documents the env contract.
- `scripts/lint/check-encoder-null-safety.sh` — PASS (the rewritten JSP writes through `textContent`, and the `${carlos:…}` EL functions are unchanged).

## Screenshots

Not attached — the visual change is the status text quoted in the table above (a Bootstrap `alert-info` while running, `alert-success` on completion, `alert-danger` with the reason on failure, in the previously-empty `#updateResult`).

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`) — **not signed off; say the word and I will re-commit with `-s`**
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
- [x] I did not modify a Flyway migration that exists in a published release tag

## Notes

**Merge order.** `debian/drugref.pin` points at `a53deaa`, the head of the companion branch in `drugref2026`. Merge carlos-emr/drugref2026#11 first, then move the pin here to that merge commit before this lands — a branch head must not be what a release build fetches. Everything else in this PR is independent of the pin and degrades safely against an older DrugRef (`state=UNAVAILABLE` → the page falls back to the `verify` probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014T8jst7AUJAxLnA3PTJJuW

---
_Generated by [Claude Code](https://claude.ai/code/session_014T8jst7AUJAxLnA3PTJJuW)_

## Summary by Sourcery

Make Administration > Update Drugref track each rebuild through completion and clearly report success, failure, or service unavailability.

New Features:
- Add live status reporting for DrugRef updates, including progress, completion, failure reasons, and unavailable-service states.
- Show prescribers a distinct message while the DrugRef database is being rebuilt.
- Add an operator-facing Playwright check for the Update Drugref workflow, with optional end-to-end rebuild validation.

Bug Fixes:
- Prevent the Update Drugref page from remaining indefinitely in an updating state or rendering no result when DrugRef is unreachable.
- Preserve the previous drug data and clearly report failed or uncontactable update attempts.
- Prevent view-only administrators and unauthorized prescribers from starting administrative DrugRef rebuilds.

Enhancements:
- Expose and normalize DrugRef update status data through the application relay, with compatibility fallback for older or unavailable DrugRef services.
- Align endpoint privileges with administrative read and write access and hide the update trigger when the caller cannot start a rebuild.
- Improve login test support for fresh Debian installs that require an initial password reset.

Build:
- Advance the Debian DrugRef package pin to the fixed companion build.

Deployment:
- Document required outbound HTTPS access and Java proxy configuration for DrugRef downloads.

Documentation:
- Document DrugRef update failure troubleshooting and the browser validation workflow for Debian installations.

Tests:
- Add unit coverage for status normalization, unavailable responses, update failure responses, and privilege separation.
- Add browser coverage for opening the Administration workflow, checking status, optionally following a rebuild, and verifying drug search afterward.

Chores:
- Add the DrugRef update status message to all supported resource bundles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Administration > Update Drugref report how the update ends. The page used to leave "updating" on screen forever after a failed run, or render nothing when DrugRef was unreachable. It now polls status every 15 seconds, shows the current step, and ends with the completion summary, the failure reason with the previous dataset kept, or — when DrugRef stops answering mid-run — says the outcome is unknown and keeps checking. An unreachable DrugRef is an outage, not an empty database: the Update button is hidden in markup and revealed only when status is definite, so an operator cannot start a rebuild over one that may still be running. A failed start attempt re-offers the trigger, so an operator who fixes the outage can retry without reloading the page. Prescribers see "Drugref database is being updated" instead of "unavailable" during a rebuild.

- `RxUpdateDrugref2Action` gates endpoints by audience and action: `updateDB` needs write on `_admin`/`_admin.misc`, `status` needs read on either, and `verify`/`getLastUpdate` take `_rx` read or administration rights so the Admin page and the Rx banner both work. The check is cheapest-first so ordinary prescribers don't pay for admin role lookups on every Rx page load, and the Admin page renders the trigger from the same predicate the action enforces, so a view-only administrator can open it but never sees the Update button. The split was verified live on the packaged install with doctor-only and admin-only accounts.
- `RxDrugRef.getUpdateStatus()` relays DrugRef's status struct (`state`, `step`, `message`, `startedAt`, `finishedAt`, `lastUpdate`) and always returns every documented key as a string, even when the DrugRef build omits one; the `UNAVAILABLE` outage payload goes through the same normalization.
- The page falls back to the verify probe on builds that predate `getUpdateStatus`, claiming success only when the pre-run timestamp moves; the baseline is re-read right before the trigger fires so a timestamp that moved while the page sat open can't be credited to this run (a first-ever run with no prior history counts once a timestamp appears), and unchanged means the run most likely failed.
- The direct-response methods now return `NONE` instead of a bare `null`. One 15-second poll timer replaces the per-click chains, and any non-running state re-checks the verify probe and keeps following while it says "updating". The page's own strings are ASCII because the JSP declares no page encoding, and the legacy fallback's timestamp inference was verified live against a simulated older DrugRef.
- `debian/drugref.pin` advances to the DrugRef fix, verified end to end on a packaged Ubuntu 26.04 install: download-before-drop, rollback on failure (including a swap-marker rollback that survives a crash between the marker's create and insert), startup-repair and crash-safety fixes, refusal to commit a rebuild that produced no drug rows, and a restore that uses the recorded moved-set so an import-created orphan is emptied and an unreached table is left alone.
- New `scripts/drugref-update-playwright-checks.js` drives the page from the Administration panel; read-only by default, or with `DRUGREF_UPDATE_TRIGGER=true` it follows a full rebuild to completion, refusing that mode against a non-loopback target. It checks drug search before and after the rebuild so a pre-broken dataset fails the run early, and rejects a search term shorter than three characters up front. The shared test `login()` now completes the forced password reset a fresh deb ships with (`RESET_PASSWORD`), which had made every browser check time out; the reset must run once, isolated, before the suite loop, after which `TEST_PASSWORD` becomes the new password.
- `README.Debian` and `docs/install-deb.md` document the outbound HTTPS the Tomcat JVM needs for `www.canada.ca` and how to pass a proxy through `CARLOS_JAVA_OPTS`.
- New unit tests cover the audience-based privilege gate, the `UNAVAILABLE` fallback shape, the null-result `updateDB` response, and the status struct's key guarantee.

**Migration**

- Merge the companion DrugRef PR (`carlos-emr/drugref2026#11`) first, then update `debian/drugref.pin` to that merge commit before this lands.

<sup>Written for commit 646bf58a30c159f5637d149692724253a2a95544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

