### PR TITLE
fix(edoc): keep the navigation header tabs when adding a document

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:pr-hardening-playwright": "node scripts/pr-hardening-playwright-checks.js",
     "test:error-sanitization-playwright": "node scripts/error-sanitization-playwright-checks.js",
     "test:eform-admin-schedule-nav-playwright": "node scripts/eform-admin-schedule-navigation-playwright-checks.js",
+    "test:edoc-schedule-nav-playwright": "node scripts/edoc-schedule-navigation-playwright-checks.js",
     "test:schedule-links-playwright": "node scripts/schedule-links-playwright-checks.js",
     "test:schedule-setting-playwright": "node scripts/schedule-setting-playwright-checks.js",
     "test:scripts": "node --test scripts/*.test.js",

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for the eDoc navigation header, driven the way an
+ * operator hits it: open eDoc from the schedule menu (which lands on
+ * /documentManager/ViewDocumentReport?...&scheduleNav=1, so the page renders the
+ * shared navigation header), add a document, and look at the header again.
+ *
+ * The reported defect: adding a document lost the header tabs. documentReport.jsp
+ * renders /WEB-INF/jsp/provider/mainMenu.jsp only while the REQUEST carries
+ * scheduleNav=1. The add form did not post the flag and AddEditDocument2Action
+ * answers success with a REDIRECT -- a brand-new request -- so the flag was gone
+ * by the time the document list re-rendered and the provider was stranded on a
+ * bare page with no way back but the browser's Back button.
+ *
+ * Nothing covered this: the unit tests assert the redirect's other query
+ * parameters, and eform-admin-schedule-navigation covers the same class of bug on
+ * a different surface entirely.
+ *
+ * Three scenarios:
+ *   1. Entering eDoc with scheduleNav=1 renders the header AND puts the flag in
+ *      the add form (the missing hidden input is the root cause; assert it
+ *      directly so a regression is diagnosed, not just detected).
+ *   2. Adding a document keeps the header and keeps scheduleNav=1 on the URL.
+ *   3. Deleting that document -- the same page's other mutation redirect -- keeps
+ *      them too.
+ * Plus the negative: entering eDoc WITHOUT the flag must still render no header,
+ * so the fix cannot be "always show the header".
+ *
+ * Defaults are for the local devcontainer:
+ *   node scripts/edoc-schedule-navigation-playwright-checks.js
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc  TEST_PASSWORD=carlos2026  TEST_PIN=2026
+ *   EDOC_NAV_SCREENSHOT_DIR=/tmp   ALLOW_NON_LOCAL_BASE_URL=true
+ *
+ * FIXTURE SAFETY: uploads one PDF this script generates under a unique,
+ * timestamped description, only ever asserts on that document, and deletes it
+ * through the UI on the way out -- which is scenario 3, so the cleanup is the
+ * check. The description is printed, so a failed run is still traceable:
+ *   SELECT doc_no FROM document WHERE docdesc LIKE 'carlos-nav-probe-%';
+ */
+
+const { chromium } = require('playwright');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  screenshotDir: process.env.EDOC_NAV_SCREENSHOT_DIR || '/tmp',
+};
+
+const NAV_SELECTOR = '#firstTable #navlist';
+const docDescription = `carlos-nav-probe-${Date.now()}`;
+const docTypeName = 'CARLOS Nav Probe';
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
+  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+function appUrl(appPath) {
+  if (!appPath.startsWith('/') || appPath.startsWith('//')) {
+    throw new Error(`Application path must be root-relative, got ${appPath}`);
+  }
+  const [rawPath, search = ''] = appPath.split('?');
+  const url = new URL(config.baseUrl.href);
+  url.pathname = `${config.baseUrl.pathname}${rawPath}`.replace(/\/{2,}/g, '/');
+  url.search = search;
+  return url.toString();
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function gotoApp(page, appPath, options) {
+  return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
+}
+
+/** Minimal one-page PDF; the report list only needs a real %PDF file, not real content. */
+function createPdfFixture() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-edoc-nav-'));
+  const pdfPath = path.join(tempDir, `${docDescription}.pdf`);
+  const body = [
+    '%PDF-1.4',
+    '1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj',
+    '2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj',
+    '3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >> endobj',
+    'trailer << /Root 1 0 R >>',
+    '%%EOF',
+    '',
+  ].join('\n');
+  fs.writeFileSync(pdfPath, body, 'latin1');
+  return { tempDir, pdfPath };
+}
+
+async function screenshot(page, name) {
+  const target = path.join(config.screenshotDir, `edoc-nav-${name}.png`);
+  await page.screenshot({ path: target, fullPage: true }).catch(() => {});
+  return target;
+}
+
+async function login(context) {
+  const page = await context.newPage();
+  await gotoApp(page, '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.locator('#username').fill(config.testUser);
+  await page.locator('#password').fill(config.testPassword);
+  await page.locator('#pin').fill(config.testPin);
+  await Promise.all([
+    page.waitForURL(/providercontrol/, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  return page;
+}
+
+/**
+ * Reads the eDoc destination out of the schedule menu's own link rather than
+ * guessing the provider number, so the check follows whatever URL the deployment
+ * actually serves.
+ */
+async function readEdocPath(schedulePage) {
+  const link = schedulePage.locator("a[onclick*='/documentManager/ViewDocumentReport']").first();
+  await link.waitFor({ state: 'attached', timeout: 20000 });
+  const onclick = await link.getAttribute('onclick');
+  const match = /['"](\S*?\/documentManager\/ViewDocumentReport\?[^'"]*)['"]/.exec(onclick || '');
+  assert(match, `Could not read the eDoc menu link target from: ${onclick}`);
+  const url = new URL(match[1], schedulePage.url());
+  return `${url.pathname.replace(config.baseUrl.pathname, '')}${url.search}`;
+}
+
+async function assertNavHeader(page, present, label) {
+  const count = await page.locator(NAV_SELECTOR).count();
+  if (present) {
+    assert(count > 0, `${label}: the navigation header tabs are gone (${page.url()})`);
+  } else {
+    assert(count === 0, `${label}: the navigation header rendered without scheduleNav=1 (${page.url()})`);
+  }
+}
+
+function assertScheduleNavRetained(page, label) {
+  const flag = new URL(page.url()).searchParams.get('scheduleNav');
+  assert(flag === '1', `${label}: scheduleNav was dropped from the URL (${page.url()})`);
+}
+
+/** Picks an existing document type, or creates one through the page's own prompt(). */
+async function chooseDocType(page) {
+  const values = await page.locator('#docType option').evaluateAll(
+    (options) => options.map((option) => option.value).filter((value) => value !== ''),
+  );
+  if (values.length > 0) {
+    await page.selectOption('#docType', values[0]);
+    return;
+  }
+  page.once('dialog', (dialog) => dialog.accept(docTypeName));
+  await page.locator('#docTypeinput').click();
+  await page.locator(`#docType option[value="${docTypeName}"]`).waitFor({ state: 'attached', timeout: 10000 });
+  await page.selectOption('#docType', docTypeName);
+}
+
+async function addDocument(page, pdfPath) {
+  await page.locator('button[data-bs-target="#addDocDiv"]').click();
+  await page.locator('#addDocDiv #docDesc').waitFor({ state: 'visible', timeout: 15000 });
+
+  // Scenario 1: the hidden input is the root cause. Assert it on the rendered page,
+  // before submitting, so a regression names the cause instead of the symptom.
+  assert(
+    await page.locator('#addDocDiv input[name="scheduleNav"][value="1"]').count(),
+    'The Add Document form did not carry scheduleNav=1',
+  );
+
+  await chooseDocType(page);
+  await page.locator('#docDesc').fill(docDescription);
+  await page.locator('#docFile').setInputFiles(pdfPath);
+
+  await Promise.all([
+    page.waitForLoadState('networkidle', { timeout: 60000 }).catch(() => {}),
+    page.locator('#addDocDiv input[name="Submit"]').click(),
+  ]);
+  await page.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {});
+}
+
+async function deleteDocument(page) {
+  const row = page.locator('tr', { has: page.locator(`a[title="${docDescription}"]`) }).first();
+  await row.waitFor({ state: 'visible', timeout: 15000 });
+  page.once('dialog', (dialog) => dialog.accept());
+  await Promise.all([
+    page.waitForLoadState('networkidle', { timeout: 60000 }).catch(() => {}),
+    row.locator('a[onclick^="checkDelete("]').first().click(),
+  ]);
+  await page.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {});
+}
+
+async function run() {
+  const { tempDir, pdfPath } = createPdfFixture();
+  const launchOptions = { headless: true };
+  if (config.chromePath) {
+    launchOptions.executablePath = config.chromePath;
+  }
+  const browser = await chromium.launch(launchOptions);
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  let page;
+
+  try {
+    const schedulePage = await login(context);
+    const edocPath = await readEdocPath(schedulePage);
+
+    // Negative control first: without the flag there must be no header, so a
+    // green run cannot mean "the header is now unconditional".
+    page = await context.newPage();
+    await gotoApp(page, edocPath, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await assertNavHeader(page, false, 'eDoc without scheduleNav');
+    await page.close();
+
+    page = await context.newPage();
+    const shellPath = `${edocPath}${edocPath.includes('?') ? '&' : '?'}scheduleNav=1`;
+    await gotoApp(page, shellPath, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await assertNavHeader(page, true, 'eDoc entry');
+    console.log(`eDoc opened in the schedule shell: ${page.url()}`);
+
+    await addDocument(page, pdfPath);
+    assertScheduleNavRetained(page, 'after adding a document');
+    await assertNavHeader(page, true, 'after adding a document');
+    assert(
+      await page.locator(`a[title="${docDescription}"]`).count(),
+      `The added document "${docDescription}" is not listed after the redirect`,
+    );
+    await screenshot(page, 'after-add');
+    console.log(`document "${docDescription}" added; navigation header intact`);
+
+    await deleteDocument(page);
+    assertScheduleNavRetained(page, 'after deleting a document');
+    await assertNavHeader(page, true, 'after deleting a document');
+    await screenshot(page, 'after-delete');
+    console.log(`document "${docDescription}" deleted; navigation header intact`);
+
+    console.log('PASS: eDoc keeps its navigation header tabs across add and delete');
+  } catch (error) {
+    if (page) {
+      console.error(`failure screenshot: ${await screenshot(page, 'failure')}`);
+      console.error(`failure url: ${page.url()}`);
+    }
+    console.error(`FAIL: ${error.message}`);
+    console.error(`probe document description (clean up if it survived): ${docDescription}`);
+    process.exitCode = 1;
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+run();

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -48,14 +48,16 @@
  *   TEST_USER=carlosdoc  TEST_PASSWORD=carlos2026  TEST_PIN=2026
  *   EDOC_NAV_SCREENSHOT_DIR=/tmp   ALLOW_NON_LOCAL_BASE_URL=true
  *   MYSQL_HOST/USER/PASSWORD/DATABASE (fixture teardown; see below)
+ *   ALLOW_NON_LOCAL_MYSQL_HOST=true only for a disposable non-local test database
  *
  * FIXTURE SAFETY: uploads one PDF this script generates under a unique,
  * timestamped description and only ever asserts on that document. Note that the
  * UI delete in scenario 3 is the application's SOFT delete -- status='D', row and
  * file both still there -- so it is an assertion, NOT teardown. The row is removed
  * for real in the `finally` block, pass or fail, so an interrupted run leaves
- * nothing behind either. Cleanup never fails the run; if it could not connect it
- * warns, and strays are then removable with:
+ * nothing behind either -- including on SIGINT/SIGTERM, which skip `finally`.
+ * Cleanup never fails the run; if it could not connect it warns, and strays are
+ * then removable with:
  *   DELETE FROM document WHERE docdesc LIKE 'carlos-nav-probe-%';
  */
 
@@ -65,6 +67,31 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+/*
+ * Hosts that are unambiguously this machine or its compose network. The teardown below
+ * DELETEs document rows, so the database target is held to this narrower set rather than
+ * BASE_URL's (which also admits private IPv4). Same sets as
+ * assign-role-playwright-checks.js, which seeds rows for the same reason.
+ */
+const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
+
+function normalizeHost(rawHost) {
+  return String(rawHost).toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+function isExactLocalHost(rawHost) {
+  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
+}
+
+/** Refuses to point the fixture teardown's DELETEs at a database that is not plainly local. */
+function validateMysqlHost(rawHost) {
+  if (!isExactLocalHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
+    throw new Error(`Refusing to delete probe document rows from non-local MYSQL_HOST ${rawHost};`
+      + ' set ALLOW_NON_LOCAL_MYSQL_HOST=true for a disposable test database');
+  }
+  return rawHost;
+}
+
 const config = {
   baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
   chromePath: process.env.CHROME_PATH || '',
@@ -72,7 +99,7 @@ const config = {
   testPassword: process.env.TEST_PASSWORD || 'carlos2026',
   testPin: process.env.TEST_PIN || '2026',
   screenshotDir: process.env.EDOC_NAV_SCREENSHOT_DIR || '/tmp',
-  mysqlHost: process.env.MYSQL_HOST || '127.0.0.1',
+  mysqlHost: validateMysqlHost(process.env.MYSQL_HOST || '127.0.0.1'),
   mysqlUser: process.env.MYSQL_USER || 'root',
   mysqlPassword: process.env.MYSQL_PASSWORD || 'password',
   mysqlDatabase: process.env.MYSQL_DATABASE || 'carlos',
@@ -104,8 +131,7 @@ function validateBaseUrl(rawBaseUrl) {
 
 /** True when BASE_URL points at this machine, the only case where a bad cert is expected. */
 function isLoopbackTarget() {
-  const host = config.baseUrl.hostname.toLowerCase();
-  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+  return isExactLocalHost(config.baseUrl.hostname);
 }
 
 function appUrl(appPath) {
@@ -159,7 +185,12 @@ function sql(query) {
  * both the row and the uploaded PDF in place -- so it is an assertion, not teardown. This runs
  * unconditionally, pass or fail, so an interrupted run leaves nothing behind either.
  */
+let cleanupDone = false;
 function cleanupProbeDocuments() {
+  if (cleanupDone) {
+    return;
+  }
+  cleanupDone = true;
   try {
     const ids = sql(
       `SELECT document_no FROM document WHERE docdesc LIKE '${docDescription}%'`,
@@ -167,6 +198,12 @@ function cleanupProbeDocuments() {
     if (!ids.length) return;
     const list = ids.join(',');
     console.log(`cleanup: removing probe document row(s) ${list} for ${docDescription}`);
+    // document_storage is empty in the default file-backed mode, but carries the file's bytes
+    // when database-backed storage is on (AddEditDocument2Action writes it), so the blob has to
+    // go before the row that names it. The uploaded file itself lives in the server's document
+    // store, which a browser-driven check cannot reach -- same limitation as
+    // document-upload-playwright-checks.js.
+    sql(`DELETE FROM document_storage WHERE documentNo IN (${list})`);
     sql(`DELETE FROM ctl_document WHERE document_no IN (${list})`);
     sql(`DELETE FROM document WHERE document_no IN (${list})`);
   } catch (e) {
@@ -361,6 +398,25 @@ async function run() {
     cleanupMysqlDefaults();
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+/*
+ * Node does not run finally blocks on SIGINT/SIGTERM, so an interrupted run would strand the
+ * probe document row and the cleartext mysql password file. Both cleanups are idempotent, so
+ * running them here is safe even when the finally block has already fired. The browser is left
+ * to the OS; only the row and that file matter.
+ */
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    console.error(`\n${signal} received; removing the probe document before exiting.`);
+    try {
+      cleanupProbeDocuments();
+    } catch (error) {
+      console.error(`WARN: cleanup after ${signal} failed: ${error.message}`);
+    }
+    cleanupMysqlDefaults();
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  });
 }
 
 run();

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -75,12 +75,23 @@ const path = require('node:path');
  */
 const EXACT_LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'db', 'carlos']);
 
+/*
+ * Strictly this machine's own loopback interface. Deliberately NARROWER than EXACT_LOCAL_HOSTS,
+ * which also admits the compose service names: those resolve over a real network, so a
+ * certificate served on one has to be verified. Only this set may switch TLS checking off.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
 function normalizeHost(rawHost) {
   return String(rawHost).toLowerCase().replace(/^\[|\]$/g, '');
 }
 
 function isExactLocalHost(rawHost) {
   return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
+}
+
+function isLoopbackHost(rawHost) {
+  return LOOPBACK_HOSTS.has(normalizeHost(rawHost));
 }
 
 /** Refuses to point the fixture teardown's DELETEs at a database that is not plainly local. */
@@ -131,7 +142,7 @@ function validateBaseUrl(rawBaseUrl) {
 
 /** True when BASE_URL points at this machine, the only case where a bad cert is expected. */
 function isLoopbackTarget() {
-  return isExactLocalHost(config.baseUrl.hostname);
+  return isLoopbackHost(config.baseUrl.hostname);
 }
 
 function appUrl(appPath) {

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -47,15 +47,20 @@
  *   CHROME_PATH=/path/to/chrome-or-chromium
  *   TEST_USER=carlosdoc  TEST_PASSWORD=carlos2026  TEST_PIN=2026
  *   EDOC_NAV_SCREENSHOT_DIR=/tmp   ALLOW_NON_LOCAL_BASE_URL=true
+ *   MYSQL_HOST/USER/PASSWORD/DATABASE (fixture teardown; see below)
  *
  * FIXTURE SAFETY: uploads one PDF this script generates under a unique,
- * timestamped description, only ever asserts on that document, and deletes it
- * through the UI on the way out -- which is scenario 3, so the cleanup is the
- * check. The description is printed, so a failed run is still traceable:
- *   SELECT doc_no FROM document WHERE docdesc LIKE 'carlos-nav-probe-%';
+ * timestamped description and only ever asserts on that document. Note that the
+ * UI delete in scenario 3 is the application's SOFT delete -- status='D', row and
+ * file both still there -- so it is an assertion, NOT teardown. The row is removed
+ * for real in the `finally` block, pass or fail, so an interrupted run leaves
+ * nothing behind either. Cleanup never fails the run; if it could not connect it
+ * warns, and strays are then removable with:
+ *   DELETE FROM document WHERE docdesc LIKE 'carlos-nav-probe-%';
  */
 
 const { chromium } = require('playwright');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -67,6 +72,10 @@ const config = {
   testPassword: process.env.TEST_PASSWORD || 'carlos2026',
   testPin: process.env.TEST_PIN || '2026',
   screenshotDir: process.env.EDOC_NAV_SCREENSHOT_DIR || '/tmp',
+  mysqlHost: process.env.MYSQL_HOST || '127.0.0.1',
+  mysqlUser: process.env.MYSQL_USER || 'root',
+  mysqlPassword: process.env.MYSQL_PASSWORD || 'password',
+  mysqlDatabase: process.env.MYSQL_DATABASE || 'carlos',
 };
 
 const NAV_SELECTOR = '#firstTable #navlist';
@@ -78,6 +87,11 @@ function validateBaseUrl(rawBaseUrl) {
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
   }
+  // Credentials in the URL would ride along on every navigation and surface in Playwright's
+  // own error messages, which this script prints on failure.
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not embed a username or password');
+  }
   const host = parsed.hostname.toLowerCase();
   const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
   const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
@@ -86,6 +100,12 @@ function validateBaseUrl(rawBaseUrl) {
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
+}
+
+/** True when BASE_URL points at this machine, the only case where a bad cert is expected. */
+function isLoopbackTarget() {
+  const host = config.baseUrl.hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
 }
 
 function appUrl(appPath) {
@@ -107,6 +127,52 @@ function assert(condition, message) {
 
 function gotoApp(page, appPath, options) {
   return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
+}
+
+let mysqlDefaults = null;
+function initMysqlDefaults() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'edoc-nav-sql-'));
+  const file = path.join(dir, 'mysql-defaults.cnf');
+  fs.writeFileSync(file, `[client]\npassword=${config.mysqlPassword}\n`, { mode: 0o600 });
+  mysqlDefaults = { dir, file };
+}
+
+function cleanupMysqlDefaults() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+
+function sql(query) {
+  assert(mysqlDefaults, 'MySQL defaults file has not been initialized');
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', config.mysqlHost, '-u', config.mysqlUser, config.mysqlDatabase, '-N', '-B', '-e', query,
+  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000 }).trim();
+}
+
+/**
+ * Removes the rows this run created, keyed on its unique description only.
+ *
+ * The UI delete in scenario 3 is the application's SOFT delete -- it sets status='D' and leaves
+ * both the row and the uploaded PDF in place -- so it is an assertion, not teardown. This runs
+ * unconditionally, pass or fail, so an interrupted run leaves nothing behind either.
+ */
+function cleanupProbeDocuments() {
+  try {
+    const ids = sql(
+      `SELECT document_no FROM document WHERE docdesc LIKE '${docDescription}%'`,
+    ).split(/\s+/).filter(Boolean);
+    if (!ids.length) return;
+    const list = ids.join(',');
+    console.log(`cleanup: removing probe document row(s) ${list} for ${docDescription}`);
+    sql(`DELETE FROM ctl_document WHERE document_no IN (${list})`);
+    sql(`DELETE FROM document WHERE document_no IN (${list})`);
+  } catch (e) {
+    // Housekeeping, never an assertion: a cleanup problem must not turn a passing run red.
+    console.warn(`WARN: could not clean up probe documents for ${docDescription}: ${e.message}`);
+  }
 }
 
 /** Minimal one-page PDF; the report list only needs a real %PDF file, not real content. */
@@ -235,12 +301,15 @@ async function deleteDocument(page) {
 
 async function run() {
   const { tempDir, pdfPath } = createPdfFixture();
+  initMysqlDefaults();
   const launchOptions = { headless: true };
   if (config.chromePath) {
     launchOptions.executablePath = config.chromePath;
   }
   const browser = await chromium.launch(launchOptions);
-  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  // The packaged install serves a self-signed certificate, so loopback runs must accept it --
+  // but a run pointed at a real host with ALLOW_NON_LOCAL_BASE_URL must still verify TLS.
+  const context = await browser.newContext({ ignoreHTTPSErrors: isLoopbackTarget() });
   let page;
 
   try {
@@ -283,11 +352,13 @@ async function run() {
       console.error(`failure url: ${page.url()}`);
     }
     console.error(`FAIL: ${error.message}`);
-    console.error(`probe document description (clean up if it survived): ${docDescription}`);
+    console.error(`probe document description: ${docDescription}`);
     process.exitCode = 1;
   } finally {
     await context.close().catch(() => {});
     await browser.close().catch(() => {});
+    cleanupProbeDocuments();
+    cleanupMysqlDefaults();
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -146,6 +146,13 @@ async function login(context) {
   return page;
 }
 
+/** Decodes the \xNN and \uNNNN escapes SafeEncode.forJavaScriptAttribute emits. */
+function decodeJsEscapes(value) {
+  return value
+    .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
 /**
  * Reads the eDoc destination out of the schedule menu's own link rather than
  * guessing the provider number, so the check follows whatever URL the deployment
@@ -157,7 +164,10 @@ async function readEdocPath(schedulePage) {
   const onclick = await link.getAttribute('onclick');
   const match = /['"](\S*?\/documentManager\/ViewDocumentReport\?[^'"]*)['"]/.exec(onclick || '');
   assert(match, `Could not read the eDoc menu link target from: ${onclick}`);
-  const url = new URL(match[1], schedulePage.url());
+  // The href is built with SafeEncode.forJavaScriptAttribute, so '&' arrives as the JS escape
+  // \x26 (and non-ASCII as \uXXXX). Decode before parsing or the whole query string collapses
+  // into one parameter named "function".
+  const url = new URL(decodeJsEscapes(match[1]), schedulePage.url());
   return `${url.pathname.replace(config.baseUrl.pathname, '')}${url.search}`;
 }
 

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -117,6 +117,19 @@ const config = {
 };
 
 const NAV_SELECTOR = '#firstTable #navlist';
+
+/*
+ * Uncaught script errors, collected across every page. This matters more than it looks: the
+ * delete and undelete handlers live in one <script> block on documentReport.jsp, so a single
+ * syntax error (an unescaped apostrophe in a translated string, say) wipes out submitDocAction
+ * entirely. Clicking a dead handler then does nothing -- the page does not navigate, so the URL
+ * and the header still look right and the delete leg passes without deleting anything.
+ */
+const pageErrors = [];
+
+function watchForPageErrors(page, label) {
+  page.on('pageerror', (error) => pageErrors.push(`${label}: ${error.message}`));
+}
 const docDescription = `carlos-nav-probe-${Date.now()}`;
 const docTypeName = 'CARLOS Nav Probe';
 
@@ -248,6 +261,7 @@ async function screenshot(page, name) {
 
 async function login(context) {
   const page = await context.newPage();
+  watchForPageErrors(page, 'schedule');
   await gotoApp(page, '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
   await page.locator('#username').fill(config.testUser);
   await page.locator('#password').fill(config.testPassword);
@@ -367,11 +381,13 @@ async function run() {
     // Negative control first: without the flag there must be no header, so a
     // green run cannot mean "the header is now unconditional".
     page = await context.newPage();
+    watchForPageErrors(page, 'eDoc without scheduleNav');
     await gotoApp(page, edocPath, { waitUntil: 'domcontentloaded', timeout: 30000 });
     await assertNavHeader(page, false, 'eDoc without scheduleNav');
     await page.close();
 
     page = await context.newPage();
+    watchForPageErrors(page, 'eDoc');
     const shellPath = `${edocPath}${edocPath.includes('?') ? '&' : '?'}scheduleNav=1`;
     await gotoApp(page, shellPath, { waitUntil: 'domcontentloaded', timeout: 30000 });
     await assertNavHeader(page, true, 'eDoc entry');
@@ -390,8 +406,16 @@ async function run() {
     await deleteDocument(page);
     assertScheduleNavRetained(page, 'after deleting a document');
     await assertNavHeader(page, true, 'after deleting a document');
+    // The document must be GONE from the active list. Without this the leg passes when the click
+    // did nothing at all -- which is exactly what a broken script block looks like from outside.
+    assert(
+      (await page.locator(`a[title="${docDescription}"]`).count()) === 0,
+      `The document "${docDescription}" is still listed after the delete; the delete did not happen`,
+    );
     await screenshot(page, 'after-delete');
     console.log(`document "${docDescription}" deleted; navigation header intact`);
+
+    assert(!pageErrors.length, `Uncaught script errors on the page: ${pageErrors.join(' | ')}`);
 
     console.log('PASS: eDoc keeps its navigation header tabs across add and delete');
   } catch (error) {

--- a/scripts/edoc-schedule-navigation-playwright-checks.js
+++ b/scripts/edoc-schedule-navigation-playwright-checks.js
@@ -179,11 +179,28 @@ function gotoApp(page, appPath, options) {
   return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
 }
 
+/*
+ * MySQL option files treat an unquoted '#' as a comment and a backslash as an escape, so a
+ * perfectly valid password containing either is silently corrupted and the teardown then fails
+ * "Access denied" -- leaving the probe rows it was meant to remove. Quote and escape, as
+ * assign-role-playwright-checks.js and login-playwright-checks.js do.
+ */
+function encodeOptionFileValue(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 let mysqlDefaults = null;
 function initMysqlDefaults() {
+  if (/[\r\n]/.test(config.mysqlPassword)) {
+    throw new Error('MYSQL_PASSWORD must not contain newline characters');
+  }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'edoc-nav-sql-'));
   const file = path.join(dir, 'mysql-defaults.cnf');
-  fs.writeFileSync(file, `[client]\npassword=${config.mysqlPassword}\n`, { mode: 0o600 });
+  fs.writeFileSync(
+    file,
+    `[client]\npassword=${encodeOptionFileValue(config.mysqlPassword)}\n`,
+    { mode: 0o600 },
+  );
   mysqlDefaults = { dir, file };
 }
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
@@ -76,6 +76,7 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import io.github.carlos_emr.carlos.utility.SafeEncode;
+import io.github.carlos_emr.carlos.utility.ScheduleNav;
 import io.github.carlos_emr.carlos.utility.SessionConstants;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.springframework.web.context.WebApplicationContext;
@@ -358,6 +359,12 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
                 if (filled(this.getParentAjaxId())) {
                     appendQueryParameter(redirect, PARAM_PARENT_AJAX_ID, this.getParentAjaxId());
                     appendQueryParameter(redirect, "updateParent", "true");
+                }
+                // A redirect starts a new request, so the schedule-shell flag the add form
+                // posted is gone unless it is re-appended here. Without it the provider lands
+                // back on the document list with the navigation header tabs missing.
+                if (ScheduleNav.isActive(request)) {
+                    appendQueryParameter(redirect, ScheduleNav.PARAM, ScheduleNav.ENABLED);
                 }
                 try {
                     response.sendRedirect(redirect.toString());

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
@@ -349,25 +349,8 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
         } else if (this.getMode().equals("add")) {
             // if add/edit success then send redirect, if failed send a forward (need the formdata and errors hashtables while trying to avoid POSTDATA messages)
             if (addDocument(request)) { // if success
-                String contextPath = request.getContextPath();
-                StringBuilder redirect = new StringBuilder(contextPath + "/documentManager/ViewDocumentReport");
-                redirect.append("?docerrors=docerrors"); // Allows the JSP to check if the document was just submitted
-                appendQueryParameter(redirect, PARAM_FUNCTION, this.getFunction());
-                appendQueryParameter(redirect, PARAM_FUNCTION_ID, this.getFunctionId());
-                appendQueryParameter(redirect, PARAM_APPOINTMENT_NO, this.getAppointmentNo());
-                // if we're called with parent ajax id inform jsp that parent needs to be updated
-                if (filled(this.getParentAjaxId())) {
-                    appendQueryParameter(redirect, PARAM_PARENT_AJAX_ID, this.getParentAjaxId());
-                    appendQueryParameter(redirect, "updateParent", "true");
-                }
-                // A redirect starts a new request, so the schedule-shell flag the add form
-                // posted is gone unless it is re-appended here. Without it the provider lands
-                // back on the document list with the navigation header tabs missing.
-                if (ScheduleNav.isActive(request)) {
-                    appendQueryParameter(redirect, ScheduleNav.PARAM, ScheduleNav.ENABLED);
-                }
                 try {
-                    response.sendRedirect(redirect.toString());
+                    response.sendRedirect(buildAddSuccessRedirect());
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -383,6 +366,36 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
         } else {
             return editDocument(request);
         }
+    }
+
+    /**
+     * Builds the post-add redirect back to the document report.
+     *
+     * <p>Extracted from {@link #execute2()} to keep that method's cognitive complexity within the
+     * project's limit; the query it assembles is unchanged. Every value goes through
+     * {@link #appendQueryParameter} so it is URI-component encoded.
+     *
+     * @return an application-relative redirect target
+     */
+    private String buildAddSuccessRedirect() {
+        StringBuilder redirect = new StringBuilder(
+                request.getContextPath() + "/documentManager/ViewDocumentReport");
+        redirect.append("?docerrors=docerrors"); // Allows the JSP to check if the document was just submitted
+        appendQueryParameter(redirect, PARAM_FUNCTION, this.getFunction());
+        appendQueryParameter(redirect, PARAM_FUNCTION_ID, this.getFunctionId());
+        appendQueryParameter(redirect, PARAM_APPOINTMENT_NO, this.getAppointmentNo());
+        // if we're called with parent ajax id inform jsp that parent needs to be updated
+        if (filled(this.getParentAjaxId())) {
+            appendQueryParameter(redirect, PARAM_PARENT_AJAX_ID, this.getParentAjaxId());
+            appendQueryParameter(redirect, "updateParent", "true");
+        }
+        // A redirect starts a new request, so the schedule-shell flag the add form posted is gone
+        // unless it is re-appended here. Without it the provider lands back on the document list
+        // with the navigation header tabs missing.
+        if (ScheduleNav.isActive(request)) {
+            appendQueryParameter(redirect, ScheduleNav.PARAM, ScheduleNav.ENABLED);
+        }
+        return redirect.toString();
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
@@ -163,12 +163,11 @@ public class AddEditHtml2Action extends ActionSupport {
         redirect.append("?function=").append(functionParam != null ? URLEncoder.encode(functionParam, StandardCharsets.UTF_8) : "");
         redirect.append("&functionid=").append(functionIdParam != null ? URLEncoder.encode(functionIdParam, StandardCharsets.UTF_8) : "");
         // The redirect is a fresh request: re-append the schedule-shell flag the Add Link form
-        // posted, or the document list comes back without its navigation header tabs.
-        if (ScheduleNav.isActive(request)) {
-            redirect.append('&').append(ScheduleNav.PARAM).append('=').append(ScheduleNav.ENABLED);
-        }
+        // posted, or the document list comes back without its navigation header tabs. The helper
+        // is a no-op when the shell is not active.
+        String target = ScheduleNav.append(redirect.toString(), request);
         try {
-            response.sendRedirect(redirect.toString());
+            response.sendRedirect(target);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
@@ -47,6 +47,7 @@ import io.github.carlos_emr.carlos.documentManager.data.AddEditDocument2Form;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
+import io.github.carlos_emr.carlos.utility.ScheduleNav;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.util.UtilDateUtilities;
@@ -161,6 +162,11 @@ public class AddEditHtml2Action extends ActionSupport {
         String functionIdParam = request.getParameter("functionid");
         redirect.append("?function=").append(functionParam != null ? URLEncoder.encode(functionParam, StandardCharsets.UTF_8) : "");
         redirect.append("&functionid=").append(functionIdParam != null ? URLEncoder.encode(functionIdParam, StandardCharsets.UTF_8) : "");
+        // The redirect is a fresh request: re-append the schedule-shell flag the Add Link form
+        // posted, or the document list comes back without its navigation header tabs.
+        if (ScheduleNav.isActive(request)) {
+            redirect.append('&').append(ScheduleNav.PARAM).append('=').append(ScheduleNav.ENABLED);
+        }
         try {
             response.sendRedirect(redirect.toString());
         } catch (IOException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentDelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentDelete2Action.java
@@ -31,6 +31,7 @@ import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.ScheduleNav;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -97,6 +98,10 @@ public class DocumentDelete2Action extends ActionSupport {
                 .param("view", view)
                 .param("viewstatus", viewstatus)
                 .param("categorykey", categorykey)
+                // Redirect => new request, so the schedule-shell flag the report page posted
+                // with this action would otherwise be dropped and the navigation header tabs
+                // would disappear. paramValue() yields null (and is skipped) when inactive.
+                .param(ScheduleNav.PARAM, ScheduleNav.paramValue(request))
                 .toString();
         response.sendRedirect(redirect);
         return NONE;

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUndelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUndelete2Action.java
@@ -32,6 +32,7 @@ import io.github.carlos_emr.carlos.documentManager.EDoc;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.ScheduleNav;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -115,6 +116,10 @@ public class DocumentUndelete2Action extends ActionSupport {
                 .param("view", view)
                 .param("viewstatus", viewstatus)
                 .param("categorykey", categorykey)
+                // Redirect => new request, so the schedule-shell flag the report page posted
+                // with this action would otherwise be dropped and the navigation header tabs
+                // would disappear. paramValue() yields null (and is skipped) when inactive.
+                .param(ScheduleNav.PARAM, ScheduleNav.paramValue(request))
                 .toString();
         response.sendRedirect(redirect);
         return NONE;

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ScheduleNav.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ScheduleNav.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 CARLOS EMR Project. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Helpers for the {@code scheduleNav} request flag that keeps a page inside the
+ * schedule navigation shell.
+ *
+ * <p>When a provider's schedule navigation mode is {@code tab} or {@code focused},
+ * menu links carry {@code scheduleNav=1} and the destination page renders the
+ * shared header ({@code /WEB-INF/jsp/provider/mainMenu.jsp}) instead of opening a
+ * bare popup. The flag lives only in the request, so any action that answers with
+ * a <em>redirect</em> starts a new request and drops it unless it is re-appended:
+ * the user lands on the same screen with the navigation tabs gone and no way back
+ * except the browser's Back button.
+ *
+ * <p>Forwards keep the flag on their own (same request, same parameters), so only
+ * redirect targets and cross-request form posts need these helpers.
+ *
+ * @since 2026-09-06
+ */
+public final class ScheduleNav {
+
+    /** Request parameter carrying the flag. */
+    public static final String PARAM = "scheduleNav";
+
+    /** The only value that enables the shell; anything else is treated as absent. */
+    public static final String ENABLED = "1";
+
+    private ScheduleNav() {
+        // static utility
+    }
+
+    /**
+     * Returns {@code true} when the current request is being rendered inside the
+     * schedule navigation shell.
+     *
+     * @param request the current servlet request; {@code null} is treated as "not active"
+     */
+    public static boolean isActive(HttpServletRequest request) {
+        return request != null && ENABLED.equals(request.getParameter(PARAM));
+    }
+
+    /**
+     * Returns {@code ENABLED} when the shell is active, otherwise {@code null}.
+     *
+     * <p>Shaped for the {@code documentManager} redirect builders, which skip
+     * null-valued parameters, so a caller can add the flag unconditionally.
+     */
+    public static String paramValue(HttpServletRequest request) {
+        return isActive(request) ? ENABLED : null;
+    }
+
+    /**
+     * Appends {@code scheduleNav=1} to {@code url} when the shell is active, choosing
+     * {@code ?} or {@code &} from the URL already built. Returns {@code url} unchanged
+     * when the shell is not active, so a caller never has to branch.
+     *
+     * @param url     an application-relative redirect target
+     * @param request the current servlet request
+     */
+    public static String append(String url, HttpServletRequest request) {
+        if (url == null || !isActive(request)) {
+            return url;
+        }
+        return url + (url.indexOf('?') >= 0 ? "&" : "?") + PARAM + "=" + ENABLED;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ScheduleNav.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ScheduleNav.java
@@ -64,6 +64,10 @@ public final class ScheduleNav {
      * {@code ?} or {@code &} from the URL already built. Returns {@code url} unchanged
      * when the shell is not active, so a caller never has to branch.
      *
+     * <p>A fragment is split off first and re-attached after: a parameter written after
+     * {@code #} never reaches the server, so appending naively would drop the flag on any
+     * redirect target that carries one.
+     *
      * @param url     an application-relative redirect target
      * @param request the current servlet request
      */
@@ -71,6 +75,9 @@ public final class ScheduleNav {
         if (url == null || !isActive(request)) {
             return url;
         }
-        return url + (url.indexOf('?') >= 0 ? "&" : "?") + PARAM + "=" + ENABLED;
+        int fragmentIndex = url.indexOf('#');
+        String base = fragmentIndex >= 0 ? url.substring(0, fragmentIndex) : url;
+        String fragment = fragmentIndex >= 0 ? url.substring(fragmentIndex) : "";
+        return base + (base.indexOf('?') >= 0 ? "&" : "?") + PARAM + "=" + ENABLED + fragment;
     }
 }

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -3110,6 +3110,7 @@ dms.documentReport.msgBrowser=View in Document Browser
 dms.documentReport.msgPrivateDocuments=Private Documents
 dms.documentReport.msgPublicDocuments=Public Documents
 dms.documentReport.msgNoDocSelected=No documents selected
+dms.documentReport.msgCsrfTokenMissing=Your session security token is missing. Please reload the page and try again.
 dms.documentReport.msgAnnotation=Annotation
 dms.documentReport.msgTickler=Tickler
 dms.documentReport.titleDocumentManager=Document Manager

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -12550,6 +12550,8 @@ dms.addDocument.labelType=Type
 dms.addDocument.msgEnterNewDocType=Please enter new document type:
 dms.documentReport.msgAnnotation=Annotation
 dms.documentReport.msgNoDocSelected=No documents selected
+# TODO: translate
+dms.documentReport.msgCsrfTokenMissing=Your session security token is missing. Please reload the page and try again.
 dms.documentReport.msgPublicDocuments=Public Documents
 dms.documentReport.msgTickler=Tickler
 dms.documentReport.titleDocumentManager=Document Manager

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -8654,6 +8654,8 @@ dms.documentReport.msgBrowser=Afficher dans le navigateur de documents
 dms.documentReport.msgPrivateDocuments=Documents priv\u00e9s
 dms.documentReport.msgPublicDocuments=Documents publics
 dms.documentReport.msgNoDocSelected=Aucun document s\u00e9lectionn\u00e9
+# TODO: translate
+dms.documentReport.msgCsrfTokenMissing=Your session security token is missing. Please reload the page and try again.
 dms.documentReport.msgAnnotation=Annotation
 dms.documentReport.msgTickler=Rappel
 dms.documentReport.titleDocumentManager=Gestionnaire de documents

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -12577,6 +12577,8 @@ dms.addDocument.labelType=Typ
 dms.addDocument.msgEnterNewDocType=Prosz\u0119 poda\u0107 nowy typ dokumentu:
 dms.documentReport.msgAnnotation=Adnotacja
 dms.documentReport.msgNoDocSelected=Nie wybrano \u017cadnych dokument\u00f3w
+# TODO: translate
+dms.documentReport.msgCsrfTokenMissing=Your session security token is missing. Please reload the page and try again.
 dms.documentReport.msgPublicDocuments=Dokumenty publiczne
 dms.documentReport.msgTickler=\u0141askotek
 dms.documentReport.titleDocumentManager=Mened\u017cer dokument\u00f3w

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -12750,6 +12750,8 @@ dms.addDocument.labelType=Type
 dms.addDocument.msgEnterNewDocType=Please enter new document type:
 dms.documentReport.msgAnnotation=Annotation
 dms.documentReport.msgNoDocSelected=No documents selected
+# TODO: translate
+dms.documentReport.msgCsrfTokenMissing=Your session security token is missing. Please reload the page and try again.
 dms.documentReport.msgPublicDocuments=Public Documents
 dms.documentReport.msgTickler=Tickler
 dms.documentReport.titleDocumentManager=Document Manager

--- a/src/main/webapp/WEB-INF/jsp/documentManager/addDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/addDocument.jsp
@@ -54,6 +54,7 @@
 <%@ page import="io.github.carlos_emr.carlos.documentManager.data.AddEditDocument2Form" %>
 <%@ page import="io.github.carlos_emr.carlos.documentManager.EDocUtil" %>
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.ScheduleNav" %>
 <%--This is included in documentReport.jsp - wasn't meant to be displayed as a separate page --%>
 <%
     String user_no = (String) session.getAttribute("user");
@@ -133,6 +134,13 @@
             }
         }
     }
+
+// Schedule navigation shell. documentReport.jsp renders the shared header only when the request
+// carries scheduleNav=1, and every submit below LEAVES the current request (a forward on a
+// validation failure, a redirect on success), so the flag has to travel with the form or the
+// provider lands back on the document list with the navigation header tabs gone.
+    boolean showScheduleNav = ScheduleNav.isActive(request);
+    String scheduleNavQuerySuffix = showScheduleNav ? "&" + ScheduleNav.PARAM + "=" + ScheduleNav.ENABLED : "";
 
     // Determine which panel to open on load based on errors or mode
     boolean openDocPanel = (request.getAttribute("docerrors") != null) || "add".equals(mode);
@@ -298,6 +306,12 @@
             <input type="hidden" name="parentAjaxId" value="<carlos:encode value='<%= parentAjaxId %>' context="htmlAttribute"/>">
             <input type="hidden" name="curUser" value="<carlos:encode value='<%= curUser %>' context="htmlAttribute"/>">
             <input type="hidden" name="appointmentNo" value="<carlos:encode value='<%= formdata.getAppointmentNo() %>' context="htmlAttribute"/>"/>
+            <% if (showScheduleNav) { %>
+            <%-- Carries the schedule shell across both outcomes: the failAdd forward reads it back
+                 as a request parameter, and AddEditDocument2Action re-appends it to the success
+                 redirect. --%>
+            <input type="hidden" name="scheduleNav" value="1">
+            <% } %>
 
             <div class="mb-3">
                 <label for="docType"><fmt:message key="dms.addDocument.labelType"/></label>
@@ -388,7 +402,7 @@
                        value="<fmt:message key='dms.addDocument.btnAdd'/>">
                 <input type="button" name="Button" class="btn btn-warning"
                        value="<fmt:message key='global.btnCancel'/>"
-                       onclick="window.location='<%= request.getContextPath() %>/documentManager/ViewDocumentReport?function=<carlos:encode value='<%= module %>' context="uriComponent"/>&functionid=<carlos:encode value='<%= moduleid %>' context="uriComponent"/>'">
+                       onclick="window.location='<%= request.getContextPath() %>/documentManager/ViewDocumentReport?function=<carlos:encode value='<%= module %>' context="uriComponent"/>&functionid=<carlos:encode value='<%= moduleid %>' context="uriComponent"/><%=scheduleNavQuerySuffix%>'">
             </div>
         </form>
     </div>
@@ -413,6 +427,10 @@
             <input type="hidden" name="observationDate" value="<carlos:encode value='<%= formdata.getObservationDate() %>' context="htmlAttribute"/>">
             <input type="hidden" name="appointmentNo" value="<carlos:encode value='<%= formdata.getAppointmentNo() %>' context="htmlAttribute"/>"/>
             <input type="hidden" name="docCreator" value="<carlos:encode value='<%= formdata.getDocCreator() %>' context="htmlAttribute"/>">
+            <% if (showScheduleNav) { %>
+            <%-- AddEditHtml2Action redirects back to the report; the flag has to survive the hop. --%>
+            <input type="hidden" name="scheduleNav" value="1">
+            <% } %>
 
             <div class="mb-3">
                 <label for="docType1"><fmt:message key="dms.addDocument.labelLinkType"/></label>
@@ -489,7 +507,7 @@
             <div class="d-flex gap-2 mb-2">
                 <input class="btn btn-warning" type="button" name="Button"
                        value="<fmt:message key='global.btnCancel'/>"
-                       onclick="window.location='<%= request.getContextPath() %>/documentManager/ViewDocumentReport?function=<carlos:encode value='<%= module %>' context="uriComponent"/>&functionid=<carlos:encode value='<%= moduleid %>' context="uriComponent"/>'">
+                       onclick="window.location='<%= request.getContextPath() %>/documentManager/ViewDocumentReport?function=<carlos:encode value='<%= module %>' context="uriComponent"/>&functionid=<carlos:encode value='<%= moduleid %>' context="uriComponent"/><%=scheduleNavQuerySuffix%>'">
             </div>
 
         </form>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
@@ -231,6 +231,29 @@
                 }
             }
 
+            /**
+             * Copies the CSRFGuard token the client script injected into this page's own
+             * (combine-PDF) form into a dynamically built one.
+             *
+             * CSRFGuard injects into forms that exist when its script runs; a form created and
+             * submitted in the same tick misses that (its injectIntoDynamicNodes observer has not
+             * fired yet), so the POST arrives with no token and CSRFGuard answers 403 -- which is
+             * what deleting a document from this page did. Same helper as
+             * MultiPageDocDisplay.jsp.
+             */
+            function appendCsrfToken(form) {
+                var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');
+                if (csrfEl) {
+                    var csrfInput = document.createElement('input');
+                    csrfInput.type = 'hidden';
+                    csrfInput.name = 'CSRF-TOKEN';
+                    csrfInput.value = csrfEl.value;
+                    form.appendChild(csrfInput);
+                } else {
+                    console.warn('CSRF token not found on page; form submission may be rejected by server.');
+                }
+            }
+
             /** Creates a dynamic POST form to submit a document action (delete/undelete) to the appropriate action route. */
             function submitDocAction(paramName, docId, func, funcId, viewStatus) {
                 var form = document.createElement('form');
@@ -259,6 +282,7 @@
                     input.value = fields[key];
                     form.appendChild(input);
                 }
+                appendCsrfToken(form);
                 document.body.appendChild(form);
                 form.submit();
             }

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
@@ -243,15 +243,19 @@
              */
             function appendCsrfToken(form) {
                 var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');
-                if (csrfEl) {
-                    var csrfInput = document.createElement('input');
-                    csrfInput.type = 'hidden';
-                    csrfInput.name = 'CSRF-TOKEN';
-                    csrfInput.value = csrfEl.value;
-                    form.appendChild(csrfInput);
-                } else {
-                    console.warn('CSRF token not found on page; form submission may be rejected by server.');
+                if (!csrfEl || !csrfEl.value) {
+                    // Fail closed. Submitting anyway only trades a silent no-op for CSRFGuard's
+                    // 403 error page, which is the failure this helper exists to prevent; tell
+                    // the user to reload instead, so the action can actually be retried.
+                    console.warn('CSRF token not found on page; document action not submitted.');
+                    return false;
                 }
+                var csrfInput = document.createElement('input');
+                csrfInput.type = 'hidden';
+                csrfInput.name = 'CSRF-TOKEN';
+                csrfInput.value = csrfEl.value;
+                form.appendChild(csrfInput);
+                return true;
             }
 
             /** Creates a dynamic POST form to submit a document action (delete/undelete) to the appropriate action route. */
@@ -282,7 +286,10 @@
                     input.value = fields[key];
                     form.appendChild(input);
                 }
-                appendCsrfToken(form);
+                if (!appendCsrfToken(form)) {
+                    showListAlert(msgCsrfTokenMissing);
+                    return;
+                }
                 document.body.appendChild(form);
                 form.submit();
             }
@@ -297,6 +304,7 @@
             }
 
             var msgNoDocSelected = '<fmt:message key="dms.documentReport.msgNoDocSelected"/>';
+            var msgCsrfTokenMissing = '<fmt:message key="dms.documentReport.msgCsrfTokenMissing"/>';
 
             /**
              * Displays a dismissable Bootstrap alert-danger in the document list alert container.

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
@@ -238,8 +238,12 @@
              * CSRFGuard injects into forms that exist when its script runs; a form created and
              * submitted in the same tick misses that (its injectIntoDynamicNodes observer has not
              * fired yet), so the POST arrives with no token and CSRFGuard answers 403 -- which is
-             * what deleting a document from this page did. Same helper as
-             * MultiPageDocDisplay.jsp.
+             * what deleting a document from this page did.
+             *
+             * Adapted from MultiPageDocDisplay.jsp's helper of the same name, not identical to
+             * it: that one warns and lets the caller submit regardless, while this one returns
+             * false on a missing or empty token so submitDocAction can abort and tell the user
+             * to reload. Keep the two in mind together if either changes.
              */
             function appendCsrfToken(form) {
                 var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
@@ -304,7 +304,11 @@
             }
 
             var msgNoDocSelected = '<fmt:message key="dms.documentReport.msgNoDocSelected"/>';
-            var msgCsrfTokenMissing = '<fmt:message key="dms.documentReport.msgCsrfTokenMissing"/>';
+            <%-- Emitted through forJavaScript: a translation containing an apostrophe or a
+                 backslash would otherwise terminate this string literal and break the whole
+                 script block, taking the delete/undelete handlers down with it. --%>
+            <fmt:message key="dms.documentReport.msgCsrfTokenMissing" var="csrfTokenMissingText"/>
+            var msgCsrfTokenMissing = '${carlos:forJavaScript(csrfTokenMissingText)}';
 
             /**
              * Displays a dismissable Bootstrap alert-danger in the document list alert container.

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
@@ -34,7 +34,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DocumentReportJspRegressionTest {
 
     private static final Path DOCUMENT_REPORT_JSP =
-            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "documentManager", "documentReport.jsp");
+            resolveProjectPath(Path.of("src", "main", "webapp", "WEB-INF", "jsp", "documentManager",
+                    "documentReport.jsp"));
+
+    /**
+     * Resolves a repo-relative fixture by walking up from the working directory, so the test
+     * passes whether Surefire or an IDE picked the module root or a parent as {@code user.dir}.
+     */
+    private static Path resolveProjectPath(Path relativePath) {
+        Path current = Path.of(System.getProperty("basedir", System.getProperty("user.dir")))
+                .toAbsolutePath()
+                .normalize();
+        for (int checkedParents = 0; current != null && checkedParents < 6; checkedParents++) {
+            Path candidate = current.resolve(relativePath).normalize();
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate " + relativePath);
+    }
 
     /**
      * {@code submitDocAction()} creates a form and submits it in the same tick, so CSRFGuard's
@@ -54,7 +73,7 @@ class DocumentReportJspRegressionTest {
 
         // The call has to sit inside submitDocAction, before the submit -- a defined-but-uncalled
         // helper looks identical to a fix and ships the same 403.
-        int helperCall = documentReport.indexOf("appendCsrfToken(form);");
+        int helperCall = documentReport.indexOf("if (!appendCsrfToken(form)) {");
         int submit = documentReport.indexOf("form.submit();");
         assertThat(helperCall)
                 .as("submitDocAction must call appendCsrfToken")
@@ -62,5 +81,22 @@ class DocumentReportJspRegressionTest {
         assertThat(helperCall)
                 .as("the token must be appended before the form is submitted")
                 .isLessThan(submit);
+    }
+
+    /**
+     * Without a token the helper must refuse rather than submit anyway: submitting only trades a
+     * silent no-op for CSRFGuard's 403 error page, which is the failure the helper exists to
+     * prevent. The user gets a reload-and-retry message instead.
+     */
+    @Test
+    @DisplayName("should abort the document action when no CSRF token is on the page")
+    void shouldAbortDocumentAction_whenCsrfTokenMissing() throws IOException {
+        String documentReport = Files.readString(DOCUMENT_REPORT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(documentReport)
+                .contains("if (!csrfEl || !csrfEl.value) {")
+                .contains("showListAlert(msgCsrfTokenMissing);")
+                .contains("var msgCsrfTokenMissing = '<fmt:message"
+                        + " key=\"dms.documentReport.msgCsrfTokenMissing\"/>';");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the eDoc document-report page's dynamically built mutation form.
+ *
+ * @since 2026-09-06
+ */
+@DisplayName("documentReport.jsp regressions")
+@Tag("unit")
+@Tag("documentManager")
+class DocumentReportJspRegressionTest {
+
+    private static final Path DOCUMENT_REPORT_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "documentManager", "documentReport.jsp");
+
+    /**
+     * {@code submitDocAction()} creates a form and submits it in the same tick, so CSRFGuard's
+     * injection never reaches it: its client script injects into the forms present when it runs,
+     * and the {@code injectIntoDynamicNodes} observer has not fired yet. Without the token copied
+     * across, every delete and undelete from this page is answered 403 ("Required Token is missing
+     * from the Request") and the document silently stays put.
+     */
+    @Test
+    @DisplayName("should copy the CSRF token into the dynamic document-action form")
+    void shouldCopyCsrfToken_intoDynamicDocumentActionForm() throws IOException {
+        String documentReport = Files.readString(DOCUMENT_REPORT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(documentReport)
+                .contains("function appendCsrfToken(form) {")
+                .contains("document.querySelector('input[name=\"CSRF-TOKEN\"]')");
+
+        // The call has to sit inside submitDocAction, before the submit -- a defined-but-uncalled
+        // helper looks identical to a fix and ships the same 403.
+        int helperCall = documentReport.indexOf("appendCsrfToken(form);");
+        int submit = documentReport.indexOf("form.submit();");
+        assertThat(helperCall)
+                .as("submitDocAction must call appendCsrfToken")
+                .isGreaterThan(0);
+        assertThat(helperCall)
+                .as("the token must be appended before the form is submitted")
+                .isLessThan(submit);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
@@ -76,10 +76,8 @@ class DocumentReportJspRegressionTest {
         int helperCall = documentReport.indexOf("if (!appendCsrfToken(form)) {");
         int submit = documentReport.indexOf("form.submit();");
         assertThat(helperCall)
-                .as("submitDocAction must call appendCsrfToken")
-                .isGreaterThan(0);
-        assertThat(helperCall)
-                .as("the token must be appended before the form is submitted")
+                .as("submitDocAction must call appendCsrfToken, before the form is submitted")
+                .isGreaterThan(0)
                 .isLessThan(submit);
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentReportJspRegressionTest.java
@@ -94,7 +94,10 @@ class DocumentReportJspRegressionTest {
         assertThat(documentReport)
                 .contains("if (!csrfEl || !csrfEl.value) {")
                 .contains("showListAlert(msgCsrfTokenMissing);")
-                .contains("var msgCsrfTokenMissing = '<fmt:message"
-                        + " key=\"dms.documentReport.msgCsrfTokenMissing\"/>';");
+                // Through forJavaScript, not raw: a translated apostrophe would otherwise close
+                // the string literal and break every handler in this script block.
+                .contains("<fmt:message key=\"dms.documentReport.msgCsrfTokenMissing\""
+                        + " var=\"csrfTokenMissingText\"/>")
+                .contains("var msgCsrfTokenMissing = '${carlos:forJavaScript(csrfTokenMissingText)}';");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2ActionUnitTest.java
@@ -801,6 +801,74 @@ class AddEditDocument2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should keep scheduleNav on the add-document success redirect")
+    void shouldKeepScheduleNav_whenAddDocumentSucceedsInScheduleShell() throws Exception {
+        // The document list renders the shared navigation header only while the request carries
+        // scheduleNav=1. The success answer is a REDIRECT, so unless the flag is re-appended the
+        // provider lands back on eDoc with the header tabs gone.
+        assertThat(addDocumentAndCaptureRedirect(true))
+                .contains("&scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should not add scheduleNav to the redirect outside the schedule shell")
+    void shouldOmitScheduleNav_whenAddDocumentSucceedsOutsideScheduleShell() throws Exception {
+        assertThat(addDocumentAndCaptureRedirect(false))
+                .doesNotContain("scheduleNav");
+    }
+
+    /**
+     * Drives one successful add through {@code execute2()} and returns the redirect it sent,
+     * with the schedule-shell flag posted or not as {@code inScheduleShell} says.
+     */
+    private String addDocumentAndCaptureRedirect(boolean inScheduleShell) throws Exception {
+        tempUploadFile = File.createTempFile("add-edit-document-nav", ".txt");
+        Files.writeString(tempUploadFile.toPath(), "test");
+        Path documentDir = Files.createTempDirectory("add-edit-document-nav-output");
+        String originalDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+        CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", documentDir.toString());
+
+        action.setMode("add");
+        action.setFunction("provider");
+        action.setFunctionId("123");
+        action.setDocDesc("Consult note");
+        action.setDocType("Consultant Report");
+        action.setDocCreator("999998");
+        action.setResponsibleId("999998");
+        action.setSource("local");
+        action.setDocPublic("0");
+        action.setObservationDate("2026-05-21");
+        action.setAppointmentNo("45");
+        bindDocFileUpload(tempUploadFile, "consult-note.txt", "text/plain");
+
+        if (inScheduleShell) {
+            request.addParameter("scheduleNav", "1");
+        }
+
+        try (MockedStatic<EDocUtil> eDocUtilMock = mockStatic(EDocUtil.class, CALLS_REAL_METHODS)) {
+            eDocUtilMock.when(() -> EDocUtil.getDoctypes("provider"))
+                    .thenReturn(new ArrayList<>(List.of("Consultant Report")));
+            eDocUtilMock.when(() -> EDocUtil.addDocumentSQL(any(EDoc.class))).thenReturn("321");
+
+            assertThat(action.execute2()).isEqualTo(ActionSupport.NONE);
+            return response.getRedirectedUrl();
+        } finally {
+            if (originalDocumentDir == null) {
+                CarlosProperties.getInstance().remove("DOCUMENT_DIR");
+            } else {
+                CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", originalDocumentDir);
+            }
+            File[] writtenFiles = documentDir.toFile().listFiles();
+            if (writtenFiles != null) {
+                for (File writtenFile : writtenFiles) {
+                    Files.deleteIfExists(writtenFile.toPath());
+                }
+            }
+            Files.deleteIfExists(documentDir);
+        }
+    }
+
+    @Test
     @DisplayName("should not expose direct upload file setters as Struts parameters")
     void shouldNotExposeDirectUploadFileSetters_asStrutsParameters() throws Exception {
         assertThatThrownBy(() -> AddEditDocument2Action.class.getMethod("setDocFile", File.class))

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2ActionUnitTest.java
@@ -12,9 +12,14 @@
  */
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.carlos.documentManager.EDoc;
+import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.documentManager.data.AddEditDocument2Form;
+import io.github.carlos_emr.carlos.managers.ProgramManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
@@ -27,9 +32,16 @@ import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link AddEditHtml2Action}'s lowercase parameter alias.
@@ -51,17 +63,21 @@ import static org.mockito.Mockito.mockStatic;
 class AddEditHtml2ActionUnitTest extends CarlosUnitTestBase {
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private SecurityInfoManager securityInfoManager;
 
     @BeforeEach
     void setUp() {
         // The action resolves SecurityInfoManager and the servlet request/response in field
         // initializers, so both have to be in place before the constructor runs.
-        registerMock(SecurityInfoManager.class, mock(SecurityInfoManager.class));
+        securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
         servletActionContextMock = mockStatic(ServletActionContext.class);
-        servletActionContextMock.when(ServletActionContext::getRequest)
-                .thenReturn(new MockHttpServletRequest());
-        servletActionContextMock.when(ServletActionContext::getResponse)
-                .thenReturn(new MockHttpServletResponse());
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
     }
 
     @AfterEach
@@ -132,5 +148,53 @@ class AddEditHtml2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(retry.getReviewerId()).isEqualTo("303");
         assertThat(retry.getReviewDateTime()).isEqualTo("2026-08-31 10:00:00");
         assertThat(retry.getHtml()).isEqualTo("<p>report body</p>");
+    }
+
+    @Test
+    @DisplayName("should keep scheduleNav on the add-link redirect")
+    void shouldKeepScheduleNav_whenAddLinkSucceedsInScheduleShell() {
+        request.addParameter("scheduleNav", "1");
+
+        assertThat(addLinkAndCaptureRedirect()).contains("scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should not add scheduleNav to the add-link redirect outside the schedule shell")
+    void shouldOmitScheduleNav_whenAddLinkSucceedsOutsideScheduleShell() {
+        assertThat(addLinkAndCaptureRedirect()).doesNotContain("scheduleNav");
+    }
+
+    /** Drives one successful Add Link through {@code execute()} and returns the redirect it sent. */
+    private String addLinkAndCaptureRedirect() {
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
+        request.addParameter("function", "demographic");
+        request.addParameter("functionid", "42");
+
+        ProgramManager2 programManager = mock(ProgramManager2.class);
+        registerMock(ProgramManager2.class, programManager);
+
+        AddEditHtml2Action action = new AddEditHtml2Action();
+        action.setMode("addLink");
+        action.setFunction("demographic");
+        action.setFunctionId("42");
+        action.setDocType("Lab");
+        action.setDocDesc("Reference site");
+        action.setDocCreator("999998");
+        action.setResponsibleId("999998");
+        action.setObservationDate("2026-09-06");
+        action.setHtml("http://example.invalid/report");
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class);
+             MockedStatic<EDocUtil> eDocUtilMock = mockStatic(EDocUtil.class)) {
+            LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+            when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class))).thenReturn(loggedInInfo);
+            eDocUtilMock.when(() -> EDocUtil.getDoctypes("demographic"))
+                    .thenReturn(new ArrayList<>(List.of("Lab")));
+            eDocUtilMock.when(() -> EDocUtil.addDocumentSQL(any(EDoc.class))).thenReturn("777");
+
+            assertThat(action.execute()).isEqualTo(AddEditHtml2Action.NONE);
+            return response.getRedirectedUrl();
+        }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentDelete2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentDelete2ActionTest.java
@@ -162,6 +162,25 @@ class DocumentDelete2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should keep scheduleNav on the redirect when posted from the schedule shell")
+    void shouldKeepScheduleNav_whenPostedFromScheduleShell() throws Exception {
+        // documentReport.jsp's submitDocAction() already posts scheduleNav=1; the redirect back
+        // has to carry it or the report re-renders without the navigation header tabs.
+        mockRequest.addParameter("scheduleNav", "1");
+        action.setDelDocumentNo("42");
+        action.execute();
+        assertThat(mockResponse.getRedirectedUrl()).contains("scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should omit scheduleNav from the redirect outside the schedule shell")
+    void shouldOmitScheduleNav_whenNotInScheduleShell() throws Exception {
+        action.setDelDocumentNo("42");
+        action.execute();
+        assertThat(mockResponse.getRedirectedUrl()).doesNotContain("scheduleNav");
+    }
+
+    @Test
     @DisplayName("should redirect without deleting when delDocumentNo is empty")
     void shouldRedirectWithoutDeleting_whenEmpty() throws Exception {
         action.setDelDocumentNo("");

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUndelete2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUndelete2ActionTest.java
@@ -121,6 +121,27 @@ class DocumentUndelete2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should keep scheduleNav on the redirect when posted from the schedule shell")
+    void shouldKeepScheduleNav_whenPostedFromScheduleShell() throws Exception {
+        grantAdmin(true);
+        grantEdocWrite(false);
+        mockRequest.addParameter("scheduleNav", "1");
+        action.setUndelDocumentNo("42");
+        action.execute();
+        assertThat(mockResponse.getRedirectedUrl()).contains("scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should omit scheduleNav from the redirect outside the schedule shell")
+    void shouldOmitScheduleNav_whenNotInScheduleShell() throws Exception {
+        grantAdmin(true);
+        grantEdocWrite(false);
+        action.setUndelDocumentNo("42");
+        action.execute();
+        assertThat(mockResponse.getRedirectedUrl()).doesNotContain("scheduleNav");
+    }
+
+    @Test
     @DisplayName("should allow creator with _edoc w to undelete own document")
     void shouldAllowCreator_toUndeleteOwnDoc() throws Exception {
         grantAdmin(false);

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
@@ -51,6 +51,8 @@ class ScheduleNavigationAssetRegressionTest {
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "providerupdatepreference.jsp");
     private static final Path DOCUMENT_REPORT_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "documentManager", "documentReport.jsp");
+    private static final Path ADD_DOCUMENT_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "documentManager", "addDocument.jsp");
     private static final Path DISPLAY_MESSAGES_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "messenger", "DisplayMessages.jsp");
     private static final Path VIEW_MESSAGE_JSP =
@@ -340,5 +342,46 @@ class ScheduleNavigationAssetRegressionTest {
      */
     private static String normalizeWhitespace(String content) {
         return content.replaceAll("\\s+", " ").trim();
+    }
+
+    /**
+     * The eDoc add-document and add-link forms leave the current request on every outcome — a
+     * forward on a validation failure, a redirect on success — so the schedule-shell flag has to
+     * be posted with them. Without the hidden inputs below, adding a document dropped the provider
+     * back onto the document list with the navigation header tabs gone (the header is rendered
+     * only while {@code scheduleNav=1} is on the request).
+     */
+    @Test
+    @DisplayName("should carry the schedule navigation flag through the eDoc add forms")
+    void shouldCarryScheduleNav_throughEdocAddForms() throws IOException {
+        String addDocument = Files.readString(ADD_DOCUMENT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(addDocument)
+                .contains("boolean showScheduleNav = ScheduleNav.isActive(request);")
+                .contains("String scheduleNavQuerySuffix = showScheduleNav ? \"&\" + ScheduleNav.PARAM"
+                        + " + \"=\" + ScheduleNav.ENABLED : \"\";");
+
+        // One hidden input per form: the upload form and the Add Link form.
+        assertThat(countOccurrences(addDocument, "<input type=\"hidden\" name=\"scheduleNav\" value=\"1\">"))
+                .as("both eDoc add forms must post scheduleNav")
+                .isEqualTo(2);
+
+        // Both Cancel buttons navigate away, so they need the flag on the query string instead.
+        assertThat(countOccurrences(addDocument,
+                "/documentManager/ViewDocumentReport?function=<carlos:encode value='<%= module %>'"))
+                .isEqualTo(2);
+        assertThat(countOccurrences(addDocument, "<%=scheduleNavQuerySuffix%>'\">"))
+                .as("both Cancel buttons must keep the schedule shell")
+                .isEqualTo(2);
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int index = haystack.indexOf(needle);
+        while (index >= 0) {
+            count++;
+            index = haystack.indexOf(needle, index + needle.length());
+        }
+        return count;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ScheduleNavUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ScheduleNavUnitTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ScheduleNav}.
+ *
+ * @since 2026-09-06
+ */
+@DisplayName("ScheduleNav")
+@Tag("unit")
+class ScheduleNavUnitTest {
+
+    private static MockHttpServletRequest requestWith(String scheduleNavValue) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        if (scheduleNavValue != null) {
+            request.addParameter(ScheduleNav.PARAM, scheduleNavValue);
+        }
+        return request;
+    }
+
+    @Test
+    @DisplayName("should report active when scheduleNav=1 is present")
+    void shouldReportActive_whenFlagIsOne() {
+        assertThat(ScheduleNav.isActive(requestWith("1"))).isTrue();
+    }
+
+    @Test
+    @DisplayName("should report inactive when the flag is absent, empty or not 1")
+    void shouldReportInactive_whenFlagIsNotOne() {
+        assertThat(ScheduleNav.isActive(requestWith(null))).isFalse();
+        assertThat(ScheduleNav.isActive(requestWith(""))).isFalse();
+        assertThat(ScheduleNav.isActive(requestWith("0"))).isFalse();
+        assertThat(ScheduleNav.isActive(requestWith("true"))).isFalse();
+        assertThat(ScheduleNav.isActive(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("should append with ? when the url carries no query string")
+    void shouldAppendWithQuestionMark_whenUrlHasNoQuery() {
+        assertThat(ScheduleNav.append("/carlos/documentManager/ViewDocumentReport", requestWith("1")))
+                .isEqualTo("/carlos/documentManager/ViewDocumentReport?scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should append with & when the url already has a query string")
+    void shouldAppendWithAmpersand_whenUrlHasQuery() {
+        assertThat(ScheduleNav.append("/carlos/documentManager/ViewDocumentReport?function=providers",
+                requestWith("1")))
+                .isEqualTo("/carlos/documentManager/ViewDocumentReport?function=providers&scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should leave the url untouched when the shell is not active")
+    void shouldLeaveUrlUnchanged_whenShellInactive() {
+        String url = "/carlos/documentManager/ViewDocumentReport?function=providers";
+        assertThat(ScheduleNav.append(url, requestWith(null))).isEqualTo(url);
+        assertThat(ScheduleNav.append(null, requestWith("1"))).isNull();
+    }
+
+    @Test
+    @DisplayName("should yield a skippable null param value when the shell is not active")
+    void shouldYieldNullParamValue_whenShellInactive() {
+        // The documentManager redirect builders drop null-valued parameters, so this is what
+        // lets the delete/undelete actions add the flag unconditionally.
+        assertThat(ScheduleNav.paramValue(requestWith("1"))).isEqualTo("1");
+        assertThat(ScheduleNav.paramValue(requestWith(null))).isNull();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ScheduleNavUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ScheduleNavUnitTest.java
@@ -68,6 +68,19 @@ class ScheduleNavUnitTest {
     }
 
     @Test
+    @DisplayName("should insert the flag before a fragment rather than after it")
+    void shouldInsertBeforeFragment_whenUrlHasFragment() {
+        // A parameter written after '#' never reaches the server, so appending naively would
+        // silently drop the flag on any redirect target carrying a fragment.
+        assertThat(ScheduleNav.append("/carlos/documentManager/ViewDocumentReport#docs",
+                requestWith("1")))
+                .isEqualTo("/carlos/documentManager/ViewDocumentReport?scheduleNav=1#docs");
+        assertThat(ScheduleNav.append("/carlos/documentManager/ViewDocumentReport?function=providers#docs",
+                requestWith("1")))
+                .isEqualTo("/carlos/documentManager/ViewDocumentReport?function=providers&scheduleNav=1#docs");
+    }
+
+    @Test
     @DisplayName("should leave the url untouched when the shell is not active")
     void shouldLeaveUrlUnchanged_whenShellInactive() {
         String url = "/carlos/documentManager/ViewDocumentReport?function=providers";


### PR DESCRIPTION
## Description

Adding a document to eDoc lost the navigation header tabs, as reported by an alpha tester.

`documentReport.jsp` renders the shared navigation header (`/WEB-INF/jsp/provider/mainMenu.jsp`) only while the **request** carries `scheduleNav=1` — the flag the schedule menu adds when the provider's navigation mode is `tab` or `focused`. The Add Document and Add Link forms did not post that flag, and `AddEditDocument2Action` / `AddEditHtml2Action` answer success with a **redirect** — a brand-new request — so by the time the document list re-rendered the flag was gone. The provider was left on the document list with no navigation and no way back except the browser's Back button.

Observed directly on a packaged install before the fix:

```
after add -> url: .../ViewDocumentReport?docerrors=docerrors&function=providers&functionid=999998&appointmentNo=0
after add -> navigation header present: false
```

The same defect sat on the delete and undelete redirects, where it was already half-built: `documentReport.jsp`'s `submitDocAction()` posts `scheduleNav=1` today and the redirect threw it away.

**Changes**

- New `utility/ScheduleNav` — the single place that reads and re-appends the flag, alongside the existing `NavPath` navigation helper. Fragment-safe, so a redirect target carrying a `#` does not silently lose the flag.
- `addDocument.jsp` — post the flag from both add forms (so the `failAdd` forward keeps it too) and carry it on both Cancel buttons.
- `AddEditDocument2Action`, `AddEditHtml2Action` — re-append it to the success redirect.
- `DocumentDelete2Action`, `DocumentUndelete2Action` — carry it through `RedirectUrlBuilder`, which skips the `null` the helper returns when the shell is not active.

**Second defect found while verifying (commit 2)**

Deleting a document from eDoc is answered **403** on a packaged install; Tomcat's `csrf.log` records `Required Token is missing from the Request`, and the document silently stays put. `submitDocAction()` builds its POST form with `document.createElement` and submits it in the same tick — CSRFGuard injects into the forms that exist when its script runs, and its `injectIntoDynamicNodes` observer has not fired yet. Fixed by copying the token from the input CSRFGuard already injected into the page's combine-PDF form, using the same `appendCsrfToken()` helper `MultiPageDocDisplay.jsp` already uses for its own dynamic delete form. The helper fails closed: with no token it aborts the submit and shows a reload-and-retry message rather than walking into CSRFGuard's 403 page.

**Review findings (commit 3)**

Codex and cubic each raised real defects on the first two commits; all were checked against the tree before changing anything, and the seven valid ones are fixed in `db06c53`. Details are on the individual (now resolved) threads. The one not taken: extracting `appendCsrfToken` into a shared JS file also used by `MultiPageDocDisplay.jsp` — cubic marked its own finding addressed by the cross-reference comment, and the extraction reaches a page outside this fix.

**Deliberately out of scope:** `documentBrowser.jsp` does not render the schedule shell at all (`documentReport.jsp` links to it with the flag, which that page ignores). That is a separate gap and is untouched here.

## Related Issues

Reported by an alpha tester; no issue number was supplied.

## Target Branch

`release/2026.08` — this is a supported-release fix against the branch the alpha build (`2026.08.0-alphaN`) comes from, and the branch the reporter is running. No version or SCM metadata was touched.

## How Was This Tested?

**Unit / regression tests** — `ScheduleNavUnitTest` (including the fragment case); keep-and-omit redirect pairs on all four actions; an `addDocument.jsp` assertion in `ScheduleNavigationAssetRegressionTest`; `DocumentReportJspRegressionTest` for the CSRF helper, pinning that it exists, that `submitDocAction` calls it *before* submitting, and that it aborts when no token is present.

```
mvn test -Dtest='ScheduleNavUnitTest,AddEditDocument2ActionUnitTest,AddEditHtml2ActionUnitTest,\
DocumentDelete2ActionTest,DocumentUndelete2ActionTest,DocumentRefile2ActionTest,\
ScheduleNavigationAssetRegressionTest,DocumentReportJspRegressionTest,ManageDocument2ActionTest,\
ViewDocumentReportRead2ActionTest,MutatorActionGetRejectionContractUnitTest'
=> all green
```

**End-to-end on a packaged install.** Built the `carlos-emr` Debian package from this branch and installed it into a clean Ubuntu 26.04 container (`carlos-ctl check` → *All checks passed*: WAF blocking, loopback-only Tomcat/MariaDB, 19 Flyway migrations). Every check below went through the real front door on `:443` (nginx + ModSecurity/CRS in blocking mode), not bare Tomcat.

New browser check `scripts/edoc-schedule-navigation-playwright-checks.js` (`npm run test:edoc-schedule-nav-playwright`) opens eDoc from the schedule menu's own link, adds a document, deletes it, and asserts the header and the flag survive both — plus a negative control asserting that entering eDoc *without* the flag still renders no header, so the fix cannot degenerate into an unconditional header.

Before the fix (pre-fix classes and JSP swapped into the same install):

```
FAIL: The Add Document form did not carry scheduleNav=1
after add -> navigation header present: false
```

After:

```
eDoc opened in the schedule shell: .../ViewDocumentReport?function=providers&functionid=999998&scheduleNav=1
document "carlos-nav-probe-..." added; navigation header intact
document "carlos-nav-probe-..." deleted; navigation header intact
PASS: eDoc keeps its navigation header tabs across add and delete
```

**Fixture handling.** The check uploads one uniquely named PDF and asserts only on it. Note that the UI delete it performs is the application's *soft* delete (`status='D'` — row and file both retained), so it is an assertion, not teardown; real teardown runs in the `finally` block, pass or fail, mirroring `document-upload-playwright-checks.js`. Verified against the real schema on the packaged install: the teardown statements took the accumulated probe count from 5 to 0, and cleanup degrades to a warning (never a failure) when the mysql client is unavailable.

One note on the local run: `ManageDocument2ActionTest` errors in a POSIX-locale sandbox on a test fixture named `Fax (A+B) Résumé.pdf` (`InvalidPathException`). It passes 35/35 under `LC_ALL=C.UTF-8`; unrelated to this change.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata
- [x] I did not modify a Flyway migration that exists in a published release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVUEAbLtPhvSdiHtuVNMzX

## Summary by Sourcery

Keep eDoc navigation available after document mutations and make dynamic document actions pass CSRF validation safely.

Bug Fixes:
- Preserve the eDoc schedule navigation header across document and link additions, deletions, and undeletions.
- Prevent dynamically submitted eDoc delete actions from failing CSRF validation by carrying the page token into the generated form and aborting safely when it is unavailable.

Enhancements:
- Centralize schedule navigation flag handling for request detection and redirect propagation, including fragment-safe URLs.

Build:
- Add an npm command for the eDoc schedule-navigation Playwright check.

Tests:
- Add unit, JSP, action, asset, and packaged-install browser regression coverage for schedule navigation retention and dynamic CSRF protection.