### PR TITLE
feat(portal): add demographic-style account controls

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/integration/patientportal/PatientPortalAccountDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/patientportal/PatientPortalAccountDto.java
@@ -53,6 +53,12 @@ public record PatientPortalAccountDto(
         Instant disabledAt,
         String disabledReason) {
 
+    /** Maximum length accepted by the portal for an account-access audit reason. */
+    public static final int MAX_DISABLED_REASON_LENGTH = 64;
+
+    private static final String INVALID_DISABLED_REASON =
+            "portal returned an invalid account disable reason";
+
     static PatientPortalAccountDto fromJson(JsonNode node) {
         return new PatientPortalAccountDto(
                 PortalJson.positiveLong(node, "id"),
@@ -62,7 +68,38 @@ public record PatientPortalAccountDto(
                 PortalJson.requiredBool(node, "locked"),
                 PortalJson.requiredBool(node, "force_password_reset"),
                 PortalJson.nullableTimestamp(node, "disabled_at"),
-                PortalJson.nullableText(node, "disabled_reason"));
+                validatedDisabledReason(PortalJson.nullableText(node, "disabled_reason")));
+    }
+
+    private static String validatedDisabledReason(String reason) {
+        if (reason != null
+                && (reason.length() > MAX_DISABLED_REASON_LENGTH
+                        || !hasSafeDisabledReasonCharacters(reason))) {
+            throw new PortalContractException(INVALID_DISABLED_REASON);
+        }
+        return reason;
+    }
+
+    /**
+     * Reports whether text is safe to preserve verbatim in the portal account audit trail.
+     *
+     * <p>Controls, line separators, and Unicode formatting characters can forge line-oriented
+     * audit output or make stored text appear to say something different when rendered.
+     *
+     * @param reason non-null audit reason
+     * @return {@code true} when the text contains none of those characters
+     */
+    public static boolean hasSafeDisabledReasonCharacters(String reason) {
+        return reason.codePoints()
+                .noneMatch(PatientPortalAccountDto::isUnsafeDisabledReasonCharacter);
+    }
+
+    private static boolean isUnsafeDisabledReasonCharacter(int codePoint) {
+        int type = Character.getType(codePoint);
+        return Character.isISOControl(codePoint)
+                || type == Character.FORMAT
+                || type == Character.LINE_SEPARATOR
+                || type == Character.PARAGRAPH_SEPARATOR;
     }
 
     private static final String DESCRIPTION =

--- a/src/main/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalAccount2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalAccount2Action.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.integration.patientportal.web;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.carlos_emr.carlos.integration.patientportal.PatientPortalAccountAcknowledgementDto;
+import io.github.carlos_emr.carlos.integration.patientportal.PatientPortalAccountDto;
 import io.github.carlos_emr.carlos.integration.patientportal.PatientPortalException;
 import io.github.carlos_emr.carlos.integration.patientportal.PatientPortalService;
 import io.github.carlos_emr.carlos.integration.patientportal.PatientPortalStaffContext;
@@ -75,6 +76,10 @@ public class PortalAccount2Action extends PortalJsonAction {
     private static final String UNKNOWN_METHOD = "unsupported portal account action";
     private static final String REASON_REQUIRED =
             "a reason is required when disabling a portal account";
+    private static final String REASON_TOO_LONG =
+            "the portal account reason must be at most 64 characters";
+    private static final String REASON_HAS_UNSAFE_CHARACTER =
+            "the portal account reason must not contain control or formatting characters";
 
     private final transient SecurityInfoManager securityInfoManager;
     private final transient PortalStaffContextResolver staffContextResolver;
@@ -199,11 +204,18 @@ public class PortalAccount2Action extends PortalJsonAction {
         if (!enabledValue && reasonMissing) {
             return badRequest(response, REASON_REQUIRED);
         }
+        String normalizedReason = reasonMissing ? "staff_action" : reason.strip();
+        if (normalizedReason.length() > PatientPortalAccountDto.MAX_DISABLED_REASON_LENGTH) {
+            return badRequest(response, REASON_TOO_LONG);
+        }
+        if (!PatientPortalAccountDto.hasSafeDisabledReasonCharacters(normalizedReason)) {
+            return badRequest(response, REASON_HAS_UNSAFE_CHARACTER);
+        }
         PatientPortalAccountAcknowledgementDto account =
                 portal.setAccountAccess(
                         demographicNo,
                         enabledValue,
-                        reasonMissing ? "staff_action" : reason.strip(),
+                        normalizedReason,
                         staff);
         ObjectNode payload = newPayload();
         payload.put("ok", true);

--- a/src/main/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalPatient2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalPatient2Action.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.integration.patientportal.web;
+
+import io.github.carlos_emr.carlos.integration.patientportal.PortalStaffContextResolver;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+
+/**
+ * Patient-scoped view gate for the staff portal-account screen.
+ *
+ * <p>The page itself contains no account data. It receives only the selected demographic number
+ * and capability flags, then obtains current state through {@link PortalPanel2Action}. The JSON
+ * read and every mutation repeat their authorization checks, so keeping a stale browser page open
+ * cannot preserve authority after a role change.
+ *
+ * @since 2026-09-10
+ */
+public final class PortalPatient2Action extends ActionSupport {
+
+    private static final long serialVersionUID = 1L;
+
+    private final transient SecurityInfoManager securityInfoManager;
+
+    /** Struts instantiates actions reflectively. */
+    public PortalPatient2Action() {
+        this(SpringUtils.getBean(SecurityInfoManager.class));
+    }
+
+    PortalPatient2Action(SecurityInfoManager securityInfoManager) {
+        this.securityInfoManager = securityInfoManager;
+    }
+
+    @Override
+    public String execute() {
+        HttpServletRequest request = ServletActionContext.getRequest();
+        HttpServletResponse response = ServletActionContext.getResponse();
+        if (!"GET".equals(request.getMethod())) {
+            response.setHeader("Allow", "GET");
+            response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
+
+        int demographicNo = PortalJsonAction.positiveInt(request.getParameter("demographicNo"));
+        if (demographicNo <= 0) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return NONE;
+        }
+
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        PortalJsonAction.requirePatientAccess(securityInfoManager, loggedInInfo, demographicNo);
+        PortalJsonAction.requirePatientPrivilege(
+                securityInfoManager,
+                loggedInInfo,
+                PortalStaffContextResolver.OBJECT_ACCOUNT,
+                SecurityInfoManager.READ,
+                demographicNo);
+
+        String patientScope = String.valueOf(demographicNo);
+        request.setAttribute("demographicNo", patientScope);
+        request.setAttribute(
+                "canManagePortalAccount",
+                securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        PortalStaffContextResolver.OBJECT_ACCOUNT,
+                        SecurityInfoManager.WRITE,
+                        patientScope));
+        request.setAttribute(
+                "canUnlockPortalAccount",
+                securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        PortalStaffContextResolver.OBJECT_ACCOUNT_UNLOCK,
+                        SecurityInfoManager.WRITE,
+                        patientScope));
+        return SUCCESS;
+    }
+}

--- a/src/main/webapp/WEB-INF/classes/struts-demographic.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-demographic.xml
@@ -47,13 +47,16 @@
             <result name="caisiSearch">/PMmodule/ClientSearch2</result>
         </action>
         <!--
-          Patient portal invitations (issue #3475). No <result> elements: every route writes JSON
-          directly and returns NONE, so a named result would resolve to a JSP forward and append
-          HTML to the response body.
+          Patient portal integration (issue #3475). The JSON routes have no <result> elements
+          because they write their responses directly. The page route remains deliberately absent
+          from normal navigation and is reachable only by direct URL for now.
         -->
         <action name="demographic/portalInvite" class="io.github.carlos_emr.carlos.integration.patientportal.web.PortalInvite2Action"/>
         <action name="demographic/portalAccount" class="io.github.carlos_emr.carlos.integration.patientportal.web.PortalAccount2Action"/>
         <action name="demographic/portalPanel" class="io.github.carlos_emr.carlos.integration.patientportal.web.PortalPanel2Action"/>
+        <action name="demographic/portalPatient" class="io.github.carlos_emr.carlos.integration.patientportal.web.PortalPatient2Action">
+            <result name="success">/WEB-INF/jsp/demographic/portalPatient.jsp</result>
+        </action>
         <action name="demographic/printDemoLabelAction" class="io.github.carlos_emr.carlos.demographic.PrintDemoLabel2Action"/>
         <action name="demographic/printDemoAddressLabelAction" class="io.github.carlos_emr.carlos.demographic.PrintDemoAddressLabel2Action"/>
         <action name="demographic/printDemoChartLabelAction" class="io.github.carlos_emr.carlos.demographic.PrintDemoChartLabel2Action"/>

--- a/src/main/webapp/WEB-INF/jsp/demographic/portalPatient.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/portalPatient.jsp
@@ -1,0 +1,92 @@
+<%--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+
+    Staff-facing patient portal account screen. PortalPatient2Action is the public gate; this JSP
+    remains under WEB-INF and obtains current account state only through the separately authorized
+    portal JSON actions. No patient name or other demographic detail is rendered here.
+
+    @since 2026-09-10
+--%>
+<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
+<!DOCTYPE html>
+<html lang="${pageContext.request.locale.language}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/images/favicon.ico">
+    <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
+    <title>Patient portal account</title>
+    <style>
+        .portal-account { max-width: 52rem; margin: 1rem auto; padding: 0 1rem; }
+        .portal-account__card { border: 1px solid #bbb; border-radius: .25rem; padding: 1rem; }
+        .portal-account__status { min-height: 1.5rem; margin-bottom: 1rem; }
+        .portal-account__status--error { color: #9c1c1c; }
+        .portal-account__details { display: grid; grid-template-columns: max-content 1fr; gap: .5rem 1rem; }
+        .portal-account__details dt { font-weight: 700; }
+        .portal-account__details dd { margin: 0; }
+        .portal-account__actions { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1rem; }
+        .portal-account__actions button { min-height: 2.5rem; }
+    </style>
+</head>
+<body class="BodyStyle">
+<%@ include file="/WEB-INF/jspf/csrf-token.jspf" %>
+<main class="portal-account"
+      id="portal-account"
+      data-context-path="${carlos:forHtmlAttribute(pageContext.request.contextPath)}"
+      data-demographic-no="${carlos:forHtmlAttribute(requestScope.demographicNo)}"
+      data-can-manage="${carlos:forHtmlAttribute(requestScope.canManagePortalAccount)}"
+      data-can-unlock="${carlos:forHtmlAttribute(requestScope.canUnlockPortalAccount)}">
+    <h1>Patient portal account</h1>
+    <p>
+        This screen manages the selected patient's portal access. It does not change the patient's
+        CARLOS EMR login or chart.
+    </p>
+    <p>
+        CARLOS patient number:
+        <strong>${carlos:forHtmlContent(requestScope.demographicNo)}</strong>
+    </p>
+    <section class="portal-account__card" aria-labelledby="portal-account-heading">
+        <h2 id="portal-account-heading">Current status</h2>
+        <div id="portal-account-status" class="portal-account__status" role="status" aria-live="polite">
+            Loading portal account&hellip;
+        </div>
+        <dl id="portal-account-details" class="portal-account__details" hidden>
+            <dt>Status</dt><dd id="portal-account-state"></dd>
+            <dt>Locked</dt><dd id="portal-account-locked"></dd>
+            <dt>Password reset required</dt><dd id="portal-account-reset"></dd>
+            <dt id="portal-account-disabled-at-label" hidden>Disabled at</dt>
+            <dd id="portal-account-disabled-at" hidden></dd>
+            <dt id="portal-account-disabled-reason-label" hidden>Disabled reason</dt>
+            <dd id="portal-account-disabled-reason" hidden></dd>
+        </dl>
+        <c:if test="${requestScope.canManagePortalAccount}">
+            <div id="portal-account-disable-fields" hidden>
+                <label for="portal-account-disable-reason">Reason for disabling</label>
+                <input id="portal-account-disable-reason" type="text" maxlength="64" autocomplete="off">
+            </div>
+        </c:if>
+        <div class="portal-account__actions">
+            <button id="portal-account-refresh" type="button">Refresh</button>
+            <c:if test="${requestScope.canUnlockPortalAccount}">
+                <button id="portal-account-unlock" type="button" hidden>Clear lockout</button>
+            </c:if>
+            <c:if test="${requestScope.canManagePortalAccount}">
+                <button id="portal-account-access" type="button" hidden></button>
+            </c:if>
+        </div>
+    </section>
+</main>
+<script src="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/share/javascript/patientPortalAccount.js"></script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/demographic/portalPatient.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/portalPatient.jsp
@@ -26,67 +26,99 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/images/favicon.ico">
     <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
+    <link rel="stylesheet"
+          href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/demographic/patientPortalAccount.css">
     <title>Patient portal account</title>
-    <style>
-        .portal-account { max-width: 52rem; margin: 1rem auto; padding: 0 1rem; }
-        .portal-account__card { border: 1px solid #bbb; border-radius: .25rem; padding: 1rem; }
-        .portal-account__status { min-height: 1.5rem; margin-bottom: 1rem; }
-        .portal-account__status--error { color: #9c1c1c; }
-        .portal-account__details { display: grid; grid-template-columns: max-content 1fr; gap: .5rem 1rem; }
-        .portal-account__details dt { font-weight: 700; }
-        .portal-account__details dd { margin: 0; }
-        .portal-account__actions { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: 1rem; }
-        .portal-account__actions button { min-height: 2.5rem; }
-    </style>
 </head>
-<body class="BodyStyle">
+<body class="BodyStyle portal-account-page">
 <%@ include file="/WEB-INF/jspf/csrf-token.jspf" %>
-<main class="portal-account"
-      id="portal-account"
-      data-context-path="${carlos:forHtmlAttribute(pageContext.request.contextPath)}"
-      data-demographic-no="${carlos:forHtmlAttribute(requestScope.demographicNo)}"
-      data-can-manage="${carlos:forHtmlAttribute(requestScope.canManagePortalAccount)}"
-      data-can-unlock="${carlos:forHtmlAttribute(requestScope.canUnlockPortalAccount)}">
-    <h1>Patient portal account</h1>
-    <p>
-        This screen manages the selected patient's portal access. It does not change the patient's
-        CARLOS EMR login or chart.
-    </p>
-    <p>
-        CARLOS patient number:
-        <strong>${carlos:forHtmlContent(requestScope.demographicNo)}</strong>
-    </p>
-    <section class="portal-account__card" aria-labelledby="portal-account-heading">
-        <h2 id="portal-account-heading">Current status</h2>
-        <div id="portal-account-status" class="portal-account__status" role="status" aria-live="polite">
-            Loading portal account&hellip;
-        </div>
-        <dl id="portal-account-details" class="portal-account__details" hidden>
-            <dt>Status</dt><dd id="portal-account-state"></dd>
-            <dt>Locked</dt><dd id="portal-account-locked"></dd>
-            <dt>Password reset required</dt><dd id="portal-account-reset"></dd>
-            <dt id="portal-account-disabled-at-label" hidden>Disabled at</dt>
-            <dd id="portal-account-disabled-at" hidden></dd>
-            <dt id="portal-account-disabled-reason-label" hidden>Disabled reason</dt>
-            <dd id="portal-account-disabled-reason" hidden></dd>
-        </dl>
-        <c:if test="${requestScope.canManagePortalAccount}">
-            <div id="portal-account-disable-fields" hidden>
-                <label for="portal-account-disable-reason">Reason for disabling</label>
-                <input id="portal-account-disable-reason" type="text" maxlength="64" autocomplete="off">
+<div id="portal-account"
+     data-context-path="${carlos:forHtmlAttribute(pageContext.request.contextPath)}"
+     data-demographic-no="${carlos:forHtmlAttribute(requestScope.demographicNo)}"
+     data-can-manage="${carlos:forHtmlAttribute(requestScope.canManagePortalAccount)}"
+     data-can-unlock="${carlos:forHtmlAttribute(requestScope.canUnlockPortalAccount)}">
+    <header class="portal-patient-header">
+        <span class="portal-patient-header__title">Patient portal account</span>
+        <span class="portal-patient-header__details">
+            CARLOS patient #${carlos:forHtmlContent(requestScope.demographicNo)}
+        </span>
+    </header>
+
+    <div class="portal-layout">
+        <nav class="portal-sidebar" aria-label="Patient navigation">
+            <a href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/demographic/DemographicEdit?demographic_no=${carlos:forHtmlAttribute(requestScope.demographicNo)}">
+                Demographic record
+            </a>
+            <a href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/demographic/DemographicApptHistory?demographic_no=${carlos:forHtmlAttribute(requestScope.demographicNo)}&amp;orderby=appttime&amp;dboperation=appt_history&amp;limit1=0&amp;limit2=25">
+                Appointment history
+            </a>
+            <span class="portal-sidebar__current" aria-current="page">Portal account</span>
+        </nav>
+
+        <main class="portal-content">
+            <div class="portal-toolbar">
+                <strong>Patient #${carlos:forHtmlContent(requestScope.demographicNo)}</strong>
+                <a class="portal-button portal-button--primary"
+                   href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/demographic/DemographicEdit?demographic_no=${carlos:forHtmlAttribute(requestScope.demographicNo)}">
+                    Back to demographic
+                </a>
             </div>
-        </c:if>
-        <div class="portal-account__actions">
-            <button id="portal-account-refresh" type="button">Refresh</button>
-            <c:if test="${requestScope.canUnlockPortalAccount}">
-                <button id="portal-account-unlock" type="button" hidden>Clear lockout</button>
-            </c:if>
-            <c:if test="${requestScope.canManagePortalAccount}">
-                <button id="portal-account-access" type="button" hidden></button>
-            </c:if>
-        </div>
-    </section>
-</main>
+
+            <div class="portal-account__intro">
+                <h1>Portal access</h1>
+                <p>
+                    Manage the selected patient's portal access. These controls do not change the
+                    patient's CARLOS EMR login or chart.
+                </p>
+            </div>
+
+            <section class="portal-account__card" aria-labelledby="portal-account-heading">
+                <h2 id="portal-account-heading">Current status</h2>
+                <div class="portal-account__card-body">
+                    <div id="portal-account-status"
+                         class="portal-account__status"
+                         role="status"
+                         aria-live="polite">
+                        Loading portal account&hellip;
+                    </div>
+                    <dl id="portal-account-details" class="portal-account__details" hidden>
+                        <dt>Status</dt><dd id="portal-account-state"></dd>
+                        <dt>Locked</dt><dd id="portal-account-locked"></dd>
+                        <dt>Password reset required</dt><dd id="portal-account-reset"></dd>
+                        <dt id="portal-account-disabled-at-label" hidden>Disabled at</dt>
+                        <dd id="portal-account-disabled-at" hidden></dd>
+                        <dt id="portal-account-disabled-reason-label" hidden>Disabled reason</dt>
+                        <dd id="portal-account-disabled-reason" hidden></dd>
+                    </dl>
+                    <c:if test="${requestScope.canManagePortalAccount}">
+                        <div id="portal-account-disable-fields" class="portal-account__disable-fields" hidden>
+                            <label for="portal-account-disable-reason">Reason for disabling</label>
+                            <input id="portal-account-disable-reason"
+                                   type="text"
+                                   maxlength="64"
+                                   autocomplete="off"
+                                   aria-describedby="portal-account-disable-help">
+                            <small id="portal-account-disable-help">Required, up to 64 characters.</small>
+                        </div>
+                    </c:if>
+                    <div class="portal-account__actions">
+                        <button id="portal-account-refresh" class="portal-button portal-button--secondary" type="button">
+                            Refresh
+                        </button>
+                        <c:if test="${requestScope.canUnlockPortalAccount}">
+                            <button id="portal-account-unlock" class="portal-button portal-button--primary" type="button" hidden>
+                                Clear lockout
+                            </button>
+                        </c:if>
+                        <c:if test="${requestScope.canManagePortalAccount}">
+                            <button id="portal-account-access" class="portal-button portal-button--primary" type="button" hidden></button>
+                        </c:if>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+</div>
 <script src="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/share/javascript/patientPortalAccount.js"></script>
 </body>
 </html>

--- a/src/main/webapp/demographic/patientPortalAccount.css
+++ b/src/main/webapp/demographic/patientPortalAccount.css
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * Licensed under GPL-2.0-or-later.
+ *
+ * Patient portal account layout aligned with the demographic screen.
+ */
+
+.portal-account-page {
+    --portal-primary: var(--carlos-primary, #337ab7);
+    --portal-primary-dark: #286090;
+    --portal-border: #d5d5d5;
+    --portal-light: var(--carlos-bg-light, #f5f5f5);
+    margin: 0;
+    color: #333;
+    background: #fff;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 13px;
+}
+
+.portal-account-page *,
+.portal-account-page *::before,
+.portal-account-page *::after {
+    box-sizing: border-box;
+}
+
+.portal-account-page [hidden] {
+    display: none !important;
+}
+
+.portal-patient-header {
+    display: flex;
+    min-height: 48px;
+    align-items: baseline;
+    gap: 16px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--portal-primary-dark);
+    background: var(--portal-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, .2);
+    color: #fff;
+}
+
+.portal-patient-header__title {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.portal-patient-header__details {
+    font-size: 14px;
+}
+
+.portal-layout {
+    display: grid;
+    grid-template-columns: 270px minmax(0, 1fr);
+    min-height: calc(100vh - 48px);
+}
+
+.portal-sidebar {
+    background: var(--portal-primary);
+}
+
+.portal-sidebar a,
+.portal-sidebar__current {
+    display: block;
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, .15);
+    color: #fff;
+    font-weight: 700;
+    line-height: 1.35;
+    text-decoration: none;
+}
+
+.portal-sidebar a:hover,
+.portal-sidebar a:focus-visible {
+    background: var(--portal-primary-dark);
+    color: #fff;
+    text-decoration: underline;
+}
+
+.portal-sidebar__current {
+    border-left: 4px solid #fff;
+    background: var(--portal-primary-dark);
+    padding-left: 8px;
+}
+
+.portal-content {
+    min-width: 0;
+    padding: 8px;
+    background: var(--portal-light);
+}
+
+.portal-toolbar {
+    display: flex;
+    min-height: 38px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+    padding: 6px 10px;
+    border: 1px solid var(--portal-border);
+    border-radius: 4px;
+    background: #fff;
+}
+
+.portal-account__intro {
+    margin-bottom: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--portal-border);
+    border-radius: 4px;
+    background: #fff;
+}
+
+.portal-account__intro h1 {
+    margin: 0 0 4px;
+    color: #333;
+    font-size: 16px;
+    line-height: 1.3;
+}
+
+.portal-account__intro p {
+    margin: 0;
+    line-height: 1.45;
+}
+
+.portal-account__card {
+    overflow: hidden;
+    width: 100%;
+    border: 1px solid var(--portal-border);
+    border-radius: 4px;
+    background: #fff;
+}
+
+.portal-account__card h2 {
+    margin: 0;
+    padding: 8px 12px;
+    background: var(--portal-primary);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+.portal-account__card-body {
+    padding: 12px;
+}
+
+.portal-account__status {
+    min-height: 36px;
+    margin-bottom: 12px;
+    padding: 9px 12px;
+    border-left: 4px solid var(--portal-primary);
+    background: #f3f8fc;
+    line-height: 1.35;
+}
+
+.portal-account__status--error {
+    border-left-color: #a94442;
+    background: #f9eded;
+    color: #8a1f1d;
+}
+
+.portal-account__details {
+    display: grid;
+    grid-template-columns: minmax(170px, 240px) minmax(0, 1fr);
+    margin: 0;
+    border: 1px solid #e1e1e1;
+    border-bottom: 0;
+}
+
+.portal-account__details[hidden] {
+    display: none;
+}
+
+.portal-account__details dt,
+.portal-account__details dd {
+    min-height: 35px;
+    margin: 0;
+    padding: 8px 10px;
+    border-bottom: 1px solid #e1e1e1;
+    line-height: 1.35;
+}
+
+.portal-account__details dt {
+    background: #f7f7f7;
+    font-weight: 700;
+}
+
+.portal-account__details dd {
+    overflow-wrap: anywhere;
+}
+
+.portal-account__disable-fields {
+    display: grid;
+    max-width: 520px;
+    gap: 5px;
+    margin-top: 12px;
+}
+
+.portal-account__disable-fields[hidden] {
+    display: none;
+}
+
+.portal-account__disable-fields label {
+    font-weight: 700;
+}
+
+.portal-account__disable-fields input {
+    width: 100%;
+    min-height: 34px;
+    padding: 6px 10px;
+    border: 1px solid #b8b8b8;
+    border-radius: 4px;
+    background: #fff;
+    color: #333;
+    font: inherit;
+}
+
+.portal-account__disable-fields input:focus {
+    border-color: #66afe9;
+    outline: 0;
+    box-shadow: 0 0 0 2px rgba(102, 175, 233, .3);
+}
+
+.portal-account__disable-fields small {
+    color: #666;
+}
+
+.portal-account__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid #e1e1e1;
+}
+
+.portal-button {
+    display: inline-flex;
+    min-height: 34px;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 14px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    font: inherit;
+    font-weight: 700;
+    line-height: 1.35;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.portal-button--primary {
+    border-color: #2e6da4;
+    background: var(--portal-primary);
+    color: #fff;
+}
+
+.portal-button--primary:hover,
+.portal-button--primary:focus-visible {
+    border-color: #204d74;
+    background: var(--portal-primary-dark);
+    color: #fff;
+    text-decoration: none;
+}
+
+.portal-button--secondary {
+    border-color: #aaa;
+    background: #fff;
+    color: #333;
+}
+
+.portal-button--secondary:hover,
+.portal-button--secondary:focus-visible {
+    background: #e8e8e8;
+    color: #222;
+}
+
+.portal-button:disabled {
+    cursor: wait;
+    opacity: .6;
+}
+
+@media (max-width: 760px) {
+    .portal-patient-header {
+        flex-wrap: wrap;
+        gap: 2px 12px;
+        padding: 10px 12px;
+    }
+
+    .portal-layout {
+        display: block;
+        min-height: 0;
+    }
+
+    .portal-sidebar {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .portal-sidebar a,
+    .portal-sidebar__current {
+        flex: 1 1 auto;
+        border-right: 1px solid rgba(255, 255, 255, .15);
+        text-align: center;
+    }
+
+    .portal-sidebar__current {
+        border-left: 0;
+        border-bottom: 3px solid #fff;
+        padding-left: 12px;
+    }
+
+    .portal-account__details {
+        display: block;
+    }
+
+    .portal-account__details dt,
+    .portal-account__details dd {
+        min-height: auto;
+    }
+
+    .portal-account__details dt {
+        padding-bottom: 3px;
+        border-bottom: 0;
+    }
+
+    .portal-account__details dd {
+        padding-top: 3px;
+    }
+}
+
+@media (max-width: 440px) {
+    .portal-toolbar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .portal-account__actions,
+    .portal-account__actions .portal-button {
+        width: 100%;
+    }
+}

--- a/src/main/webapp/share/javascript/patientPortalAccount.js
+++ b/src/main/webapp/share/javascript/patientPortalAccount.js
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * Licensed under GPL-2.0-or-later.
+ *
+ * Staff-facing patient portal account controls. All server-provided text is assigned through
+ * textContent; no portal response is interpreted as markup.
+ */
+(function () {
+    "use strict";
+
+    const root = document.getElementById("portal-account");
+    if (!root) {
+        return;
+    }
+
+    const contextPath = root.dataset.contextPath;
+    const demographicNo = root.dataset.demographicNo;
+    const mayManage = root.dataset.canManage === "true";
+    const mayUnlock = root.dataset.canUnlock === "true";
+    const status = document.getElementById("portal-account-status");
+    const details = document.getElementById("portal-account-details");
+    const state = document.getElementById("portal-account-state");
+    const locked = document.getElementById("portal-account-locked");
+    const reset = document.getElementById("portal-account-reset");
+    const disabledAtLabel = document.getElementById("portal-account-disabled-at-label");
+    const disabledAt = document.getElementById("portal-account-disabled-at");
+    const disabledReasonLabel = document.getElementById("portal-account-disabled-reason-label");
+    const disabledReasonValue = document.getElementById("portal-account-disabled-reason");
+    const refresh = document.getElementById("portal-account-refresh");
+    const unlock = document.getElementById("portal-account-unlock");
+    const access = document.getElementById("portal-account-access");
+    const disableFields = document.getElementById("portal-account-disable-fields");
+    const disableReason = document.getElementById("portal-account-disable-reason");
+    let account = null;
+
+    function showStatus(message, error) {
+        status.textContent = message;
+        status.classList.toggle("portal-account__status--error", Boolean(error));
+    }
+
+    function setBusy(busy) {
+        refresh.disabled = busy;
+        if (unlock) {
+            unlock.disabled = busy;
+        }
+        if (access) {
+            access.disabled = busy;
+        }
+    }
+
+    function hideAccountControls() {
+        if (unlock) {
+            unlock.hidden = true;
+        }
+        if (access) {
+            access.hidden = true;
+        }
+        if (disableFields) {
+            disableFields.hidden = true;
+        }
+    }
+
+    function renderAccount(value) {
+        account = value;
+        const isDisabled = value.status === "disabled";
+        state.textContent = value.status;
+        locked.textContent = value.locked ? "Yes" : "No";
+        reset.textContent = value.forcePasswordReset ? "Yes" : "No";
+        disabledAt.textContent = value.disabledAt || "Not recorded";
+        disabledReasonValue.textContent = value.disabledReason || "Not recorded";
+        disabledAtLabel.hidden = !isDisabled;
+        disabledAt.hidden = !isDisabled;
+        disabledReasonLabel.hidden = !isDisabled;
+        disabledReasonValue.hidden = !isDisabled;
+        details.hidden = false;
+        if (unlock) {
+            unlock.hidden = !mayUnlock || !value.locked;
+        }
+        if (access) {
+            access.hidden = !mayManage;
+            access.textContent = isDisabled ? "Re-enable account" : "Disable account";
+            access.dataset.enable = String(isDisabled);
+            if (disableFields) {
+                disableFields.hidden = isDisabled || !mayManage;
+            }
+        }
+    }
+
+    async function jsonResponse(response) {
+        const contentType = response.headers.get("content-type") || "";
+        if (!contentType.toLowerCase().startsWith("application/json")) {
+            throw new Error("CARLOS returned an unreadable response.");
+        }
+        return response.json();
+    }
+
+    async function loadAccount(successMessage) {
+        setBusy(true);
+        details.hidden = true;
+        hideAccountControls();
+        account = null;
+        showStatus("Loading portal account…", false);
+        try {
+            const parameters = new URLSearchParams({demographicNo: demographicNo});
+            const response = await fetch(contextPath + "/demographic/portalPanel?" + parameters, {
+                method: "GET",
+                credentials: "same-origin",
+                headers: {"Accept": "application/json"}
+            });
+            const payload = await jsonResponse(response);
+            if (!response.ok) {
+                throw new Error(payload.message || "The portal account could not be loaded.");
+            }
+            if (!payload.account) {
+                throw new Error(
+                    "The portal account status is unavailable. If this affects every patient, check the portal connection."
+                );
+            }
+            renderAccount(payload.account);
+            showStatus(successMessage || "Portal account loaded.", false);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "The portal account could not be loaded.";
+            showStatus(message, true);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function csrfToken() {
+        const input = document.querySelector('input[name="CSRF-TOKEN"]');
+        if (input && !input.value && typeof window.fetchCsrfToken === "function") {
+            await window.fetchCsrfToken(contextPath);
+        }
+        if (!input || !input.value) {
+            throw new Error("The security token could not be loaded. Refresh the page and try again.");
+        }
+        return input.value;
+    }
+
+    async function mutate(parameters) {
+        setBusy(true);
+        showStatus("Updating portal account…", false);
+        try {
+            const token = await csrfToken();
+            const response = await fetch(contextPath + "/demographic/portalAccount", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: {
+                    "Accept": "application/json",
+                    "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+                    "X-Requested-With": "XMLHttpRequest",
+                    "CSRF-TOKEN": token
+                },
+                body: new URLSearchParams(Object.assign({demographicNo: demographicNo}, parameters))
+            });
+            const payload = await jsonResponse(response);
+            if (!response.ok || !payload.ok) {
+                throw new Error(payload.message || "The portal account could not be updated.");
+            }
+            if (disableReason && parameters.method === "access" && parameters.enabled === "false") {
+                disableReason.value = "";
+            }
+            await loadAccount(payload.note || "Portal account updated.");
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "The portal account could not be updated.";
+            showStatus(message, true);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    refresh.addEventListener("click", function () {
+        loadAccount();
+    });
+    if (unlock) {
+        unlock.addEventListener("click", function () {
+            if (window.confirm(
+                "Clear the lockout for CARLOS patient " + demographicNo
+                    + " and require a password reset?"
+            )) {
+                mutate({method: "unlock"});
+            }
+        });
+    }
+    if (access) {
+        access.addEventListener("click", function () {
+            if (!account) {
+                return;
+            }
+            const enable = access.dataset.enable === "true";
+            if (enable) {
+                if (window.confirm("Re-enable the portal account for CARLOS patient " + demographicNo + "?")) {
+                    mutate({method: "access", enabled: "true"});
+                }
+                return;
+            }
+            const normalized = disableReason ? disableReason.value.trim() : "";
+            if (!normalized || normalized.length > 64) {
+                showStatus("Enter a reason between 1 and 64 characters.", true);
+                if (disableReason) {
+                    disableReason.focus();
+                }
+                return;
+            }
+            if (window.confirm("Disable the portal account for CARLOS patient " + demographicNo + "?")) {
+                mutate({method: "access", enabled: "false", reason: normalized});
+            }
+        });
+    }
+
+    loadAccount();
+}());

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
@@ -327,6 +327,7 @@ class MutatorActionGetRejectionContractUnitTest {
      */
     private static final Set<String> NON_MUTATOR_GATES = Set.of(
         "io.github.carlos_emr.carlos.integration.patientportal.web.PortalPanel2Action",
+        "io.github.carlos_emr.carlos.integration.patientportal.web.PortalPatient2Action",
         // Read-scope gates — permit GET, only 405 truly unsupported methods.
         "io.github.carlos_emr.carlos.appointment.gate.ViewAppointment2Action",
         "io.github.carlos_emr.carlos.appointment.gate.ViewAppointmentWrite2Action",

--- a/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/PatientPortalAccountAndSecretCallsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/PatientPortalAccountAndSecretCallsUnitTest.java
@@ -145,6 +145,32 @@ class PatientPortalAccountAndSecretCallsUnitTest {
         }
 
         @Test
+        @DisplayName("should reject an unsafe account disable reason from the portal")
+        void shouldRejectAccountStatus_whenDisableReasonContainsFormattingControl() {
+            ScriptedExchange exchange =
+                    new ScriptedExchange()
+                            .reply(
+                                    200,
+                                    "{\"id\":5,\"clinic_id\":\"maplecreek\","
+                                            + "\"demographic_no\":123,\"status\":\"disabled\","
+                                            + "\"locked\":false,\"force_password_reset\":false,"
+                                            + "\"disabled_at\":\"2026-08-19T12:00:00Z\","
+                                            + "\"disabled_reason\":\"patient request\\u202Eapproved\"}");
+
+            assertThatThrownBy(
+                            () ->
+                                    service(exchange)
+                                            .findAccount(
+                                                    123,
+                                                    staff(
+                                                            PatientPortalStaffContext
+                                                                    .PERMISSION_ACCOUNT_MANAGE)))
+                    .isInstanceOf(PatientPortalException.class)
+                    .extracting(exception -> ((PatientPortalException) exception).kind())
+                    .isEqualTo(Kind.MALFORMED_RESPONSE);
+        }
+
+        @Test
         @DisplayName("should send the enabled flag and reason when access changes")
         void shouldSendEnabledAndReason_whenAccessIsChanged() throws Exception {
             ScriptedExchange exchange =

--- a/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalAccountAndPanelActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalAccountAndPanelActionUnitTest.java
@@ -228,6 +228,32 @@ class PortalAccountAndPanelActionUnitTest {
         }
 
         @Test
+        @DisplayName("should reject a disable reason longer than the portal accepts")
+        void shouldRefuseDisable_whenReasonIsTooLong() throws Exception {
+            request.setParameter("method", "access");
+            request.setParameter("enabled", "false");
+            request.setParameter("reason", "x".repeat(65));
+
+            accountAction().execute();
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+            verifyNoInteractions(patientPortalService);
+        }
+
+        @Test
+        @DisplayName("should reject formatting controls in a disable reason")
+        void shouldRefuseDisable_whenReasonContainsFormattingControl() throws Exception {
+            request.setParameter("method", "access");
+            request.setParameter("enabled", "false");
+            request.setParameter("reason", "patient request\u202Eapproved");
+
+            accountAction().execute();
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+            verifyNoInteractions(patientPortalService);
+        }
+
+        @Test
         @DisplayName("should disable with the supplied reason")
         void shouldDisableAccount_whenReasonIsGiven() throws Exception {
             request.setParameter("method", "access");

--- a/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalPatient2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalPatient2ActionUnitTest.java
@@ -159,9 +159,13 @@ class PortalPatient2ActionUnitTest {
         String script = Files.readString(
                 Path.of("src/main/webapp/share/javascript/patientPortalAccount.js"),
                 StandardCharsets.UTF_8);
+        String styles = Files.readString(
+                Path.of("src/main/webapp/demographic/patientPortalAccount.css"),
+                StandardCharsets.UTF_8);
 
         assertThat(jsp)
                 .contains("/WEB-INF/jspf/csrf-token.jspf")
+                .contains("patientPortalAccount.css")
                 .contains("patientPortalAccount.js")
                 .contains("requestScope.demographicNo")
                 .contains("forHtmlContent(requestScope.demographicNo)")
@@ -181,6 +185,11 @@ class PortalPatient2ActionUnitTest {
                 .contains("/demographic/portalAccount")
                 .doesNotContain("innerHTML")
                 .doesNotContain("outerHTML");
+        assertThat(styles)
+                .contains("--portal-primary: var(--carlos-primary, #337ab7)")
+                .contains(".portal-account-page [hidden]")
+                .contains(".portal-sidebar")
+                .contains(".portal-account__card h2");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalPatient2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/integration/patientportal/web/PortalPatient2ActionUnitTest.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.integration.patientportal.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.carlos_emr.carlos.integration.patientportal.PortalStaffContextResolver;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@Tag("unit")
+@Tag("patient-portal")
+@DisplayName("Portal patient view gate")
+class PortalPatient2ActionUnitTest {
+
+    private static final int DEMOGRAPHIC_NO = 123;
+
+    private SecurityInfoManager securityInfoManager;
+    private LoggedInInfo loggedInInfo;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockedStatic<LoggedInInfo> loggedInInfoStatic;
+    private MockedStatic<ServletActionContext> servletActionContextStatic;
+
+    @BeforeEach
+    void setUp() {
+        securityInfoManager = mock(SecurityInfoManager.class);
+        loggedInInfo = mock(LoggedInInfo.class);
+        request = new MockHttpServletRequest("GET", "/demographic/portalPatient");
+        request.setParameter("demographicNo", String.valueOf(DEMOGRAPHIC_NO));
+        response = new MockHttpServletResponse();
+
+        servletActionContextStatic = mockStatic(ServletActionContext.class);
+        servletActionContextStatic.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextStatic.when(ServletActionContext::getResponse).thenReturn(response);
+        loggedInInfoStatic = mockStatic(LoggedInInfo.class);
+        loggedInInfoStatic
+                .when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(loggedInInfo);
+    }
+
+    @AfterEach
+    void tearDown() {
+        loggedInInfoStatic.close();
+        servletActionContextStatic.close();
+    }
+
+    @Test
+    @DisplayName("should reject POST before consulting access controls")
+    void shouldRejectPost_beforeAuthorization() {
+        request.setMethod("POST");
+
+        String result = new PortalPatient2Action(securityInfoManager).execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        assertThat(response.getHeader("Allow")).isEqualTo("GET");
+        verifyNoInteractions(securityInfoManager);
+    }
+
+    @Test
+    @DisplayName("should reject a missing patient before consulting access controls")
+    void shouldRejectRequest_withoutPatientScope() {
+        request.removeParameter("demographicNo");
+
+        String result = new PortalPatient2Action(securityInfoManager).execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(securityInfoManager);
+    }
+
+    @Test
+    @DisplayName("should require both demographic and portal account read access")
+    void shouldRejectRequest_withoutPortalReadAccess() {
+        allowDemographicAccess();
+        when(securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        PortalStaffContextResolver.OBJECT_ACCOUNT,
+                        SecurityInfoManager.READ,
+                        String.valueOf(DEMOGRAPHIC_NO)))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> new PortalPatient2Action(securityInfoManager).execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("missing required sec object (_portal.account)");
+    }
+
+    @Test
+    @DisplayName("should expose only patient scope and capability flags to the view")
+    void shouldPrepareView_withAuthorizedCapabilities() {
+        allowDemographicAccess();
+        when(securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        PortalStaffContextResolver.OBJECT_ACCOUNT,
+                        SecurityInfoManager.READ,
+                        String.valueOf(DEMOGRAPHIC_NO)))
+                .thenReturn(true);
+        when(securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        PortalStaffContextResolver.OBJECT_ACCOUNT,
+                        SecurityInfoManager.WRITE,
+                        String.valueOf(DEMOGRAPHIC_NO)))
+                .thenReturn(true);
+        when(securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        PortalStaffContextResolver.OBJECT_ACCOUNT_UNLOCK,
+                        SecurityInfoManager.WRITE,
+                        String.valueOf(DEMOGRAPHIC_NO)))
+                .thenReturn(false);
+
+        String result = new PortalPatient2Action(securityInfoManager).execute();
+
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        assertThat(request.getAttribute("demographicNo")).isEqualTo("123");
+        assertThat(request.getAttribute("canManagePortalAccount")).isEqualTo(true);
+        assertThat(request.getAttribute("canUnlockPortalAccount")).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("should keep browser mutations behind CSRF and text-only rendering")
+    void shouldProtectBrowserMutations_withCsrfAndSafeRendering() throws IOException {
+        String jsp = Files.readString(
+                Path.of("src/main/webapp/WEB-INF/jsp/demographic/portalPatient.jsp"),
+                StandardCharsets.UTF_8);
+        String script = Files.readString(
+                Path.of("src/main/webapp/share/javascript/patientPortalAccount.js"),
+                StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("/WEB-INF/jspf/csrf-token.jspf")
+                .contains("patientPortalAccount.js")
+                .contains("requestScope.demographicNo")
+                .contains("forHtmlContent(requestScope.demographicNo)")
+                .contains("portal-account-disabled-reason")
+                .contains("for=\"portal-account-disable-reason\"")
+                .contains("maxlength=\"64\"");
+        assertThat(script)
+                .contains("CSRF-TOKEN")
+                .contains("X-Requested-With")
+                .contains("textContent")
+                .contains("hideAccountControls()")
+                .contains("await loadAccount(payload.note")
+                .contains("refresh.addEventListener(\"click\", function ()")
+                .contains("disabledReasonValue.textContent")
+                .contains("disableReason.value = \"\"")
+                .contains("CARLOS patient \" + demographicNo")
+                .contains("/demographic/portalAccount")
+                .doesNotContain("innerHTML")
+                .doesNotContain("outerHTML");
+    }
+
+    @Test
+    @DisplayName("should expose the protected direct route without adding navigation")
+    void shouldKeepViewUnreachable_fromNormalNavigation() throws IOException {
+        String routes = Files.readString(
+                Path.of("src/main/webapp/WEB-INF/classes/struts-demographic.xml"),
+                StandardCharsets.UTF_8);
+        String demographic = Files.readString(
+                Path.of("src/main/webapp/WEB-INF/jsp/demographic/edit.jsp"),
+                StandardCharsets.UTF_8);
+
+        assertThat(routes)
+                .contains("demographic/portalPatient")
+                .contains("PortalPatient2Action")
+                .contains("/WEB-INF/jsp/demographic/portalPatient.jsp");
+        assertThat(demographic).doesNotContain("/demographic/portalPatient");
+    }
+
+    private void allowDemographicAccess() {
+        when(securityInfoManager.hasPrivilege(
+                        loggedInInfo,
+                        "_demographic",
+                        SecurityInfoManager.READ,
+                        String.valueOf(DEMOGRAPHIC_NO)))
+                .thenReturn(true);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, DEMOGRAPHIC_NO))
+                .thenReturn(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add a CARLOS staff page for reading portal account status and clearing lockouts or disabling/re-enabling access
- align the screen with the demographic UI: patient banner, patient navigation, gray workspace, demographic-style panels, and responsive controls
- base the UI directly on #3478 and preserve the complete portal client underneath
- keep the page out of normal inbound navigation for now; use the protected direct route `/demographic/portalPatient?demographicNo=...`
- validate disable reasons before portal submission and reject unsafe or malformed returned audit text
- protect reads and mutations with patient-scoped privileges, repeated server-side authorization, CSRF, and text-only rendering

## Depends on
- base branch: `feature/3475-portal-client` (#3478)
- merge #3478 first, followed by this PR
- no invitation create or resend UI; email remains gated

## Security objects
- `_portal.account`: read status and enable or disable an account
- `_portal.account.unlock`: clear a lockout and force a password reset

## Validation
- portal patient view unit suite passes (6/6)
- desktop and mobile browser smoke tests pass against the local CARLOS server and mock portal
- verified account loading, Refresh, hidden-control behavior, responsive layout, and demographic return target
- Maven Checkstyle passes as part of the targeted Maven run

## Notes
- supersedes #3631; this replacement preserves its intended two-commit diff on top of #3478
- draft PR
- no dependency, migration, or deployment-policy changes introduced

## Summary by Sourcery

Add a protected demographic-style patient portal account screen with secure status, lockout, and access controls.

New Features:
- Add a protected, patient-scoped staff page for viewing and managing patient portal account status, lockouts, and access.

Bug Fixes:
- Reject unsafe or malformed portal disable reasons and validate staff-supplied reasons before submission.

Enhancements:
- Align the portal account screen with the demographic interface and responsive patient navigation.
- Enforce repeated patient-scoped authorization, CSRF protection, and text-only rendering for account operations.

Tests:
- Add unit coverage for view authorization, HTTP method handling, reason validation, safe rendering, and direct-route behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a staff-facing portal account screen where staff can view a patient's portal status, clear lockouts, and disable or re-enable access, styled to match the demographic UI. Builds on the portal client in #3478; merge that first.

- New protected route `/demographic/portalPatient` requires demographic read plus `_portal.account` read and write or `_portal.account.unlock` privileges, and stays out of normal navigation.
- Disable reasons are limited to 64 characters and rejected when they contain control or formatting characters; audit text returned by the portal is validated the same way before rendering.
- Reads and mutations repeat authorization server-side, mutations are CSRF-protected, and all portal text renders as text only.

<sup>Written for commit db0190b220c0342c4a32028395f40b947fac9b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

