### PR TITLE
fix(rx): stop the previous-instructions (*) modal rendering nothing (retargets #955)

### DIFF
--- a/docs/ui-tests/deb-install-validation.md
+++ b/docs/ui-tests/deb-install-validation.md
@@ -569,6 +569,14 @@ Notes on the contract:
   drugless script renders no preview and the check times out. Script 45 has
   drugs; verify with
   `SELECT p.script_no FROM prescription p JOIN drugs d ON d.script_no=p.script_no`.
+- **`rx-med-history-playwright-checks.js` needs a patient with an existing
+  prescription, not a script id.** It reads `RX_MED_HISTORY_DEMOGRAPHIC_NO`,
+  falling back to `PRESCRIPTION_DEMOGRAPHIC_NO` and then `1`, and stages
+  whichever drug the profile lists first by ticking its ReRx box — so the
+  "Rx Examples" window it opens is asked for a drug that HAS history. A
+  patient with no drug profile fails the check at staging rather than
+  silently measuring the empty state. It stages in memory only: nothing is
+  saved, so it seeds and cleans up nothing.
 - **`CONSULT_UNSIGNED_REQUEST_ID` is consumed.** The stamp-update scenario
   signs that consultation, so a second back-to-back run needs the fixture
   reset: `UPDATE consultationRequests SET signature_img=NULL WHERE requestId=3;`

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "test:flowsheet-admin-playwright": "node scripts/flowsheet-admin-playwright-checks.js",
     "test:select-forms-panel-playwright": "node scripts/select-forms-panel-playwright-checks.js",
     "test:flu-billing-report-playwright": "node scripts/flu-billing-report-playwright-checks.js",
-    "test:billing-on-third-party-playwright": "node scripts/billing-on-third-party-playwright-checks.js"
+    "test:billing-on-third-party-playwright": "node scripts/billing-on-third-party-playwright-checks.js",
+    "test:rx-med-history-playwright": "node scripts/rx-med-history-playwright-checks.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/rx-med-history-playwright-checks.js
+++ b/scripts/rx-med-history-playwright-checks.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression check for the Rx previous-instructions ("*") modal — the
+ * red asterisk beside the Instructions field on a staged prescription, which
+ * opens a small "<drug> Rx Examples" window listing the instructions that drug
+ * was last written with so the prescriber can click one instead of retyping it.
+ *
+ * The reported defect (#955) was that the asterisk did "nada": the window
+ * either never opened or opened empty. Both halves are pinned here, because
+ * they are two different failures with the same symptom:
+ *
+ *   1. The POST behind the asterisk (WriteScript?parameterValue=
+ *      listPreviousInstructions) must answer 2xx. The modal is opened from the
+ *      request's onSuccess callback ONLY (SearchDrug3.jsp), so any 4xx/5xx
+ *      means no window appears at all and the click looks inert. This is what
+ *      an unresolvable stash item used to do: getPreviousInstructions(null)
+ *      threw an NPE straight out of the action.
+ *   2. The iframe the modal loads (rx/ViewDisplayMedHistory) must RENDER
+ *      something. displayMedHistory.jsp wraps its whole body in a
+ *      try/catch that logs and swallows, so a null prescription used to
+ *      produce a 200 with an empty body — a blank white box, indistinguishable
+ *      to the user from nothing happening.
+ *
+ * Reaching the modal the way a prescriber does matters as much as asserting on
+ * it. The asterisk only exists on a STAGED prescription, so this check stages
+ * one from the patient's own drug profile (tick ReRx, "Stage medication") and
+ * then clicks the rendered anchor. A check that navigated straight to
+ * rx/ViewDisplayMedHistory would exercise neither the action nor the callback
+ * that decides whether the window is shown, and a check that staged a fresh
+ * CUSTOM drug would assert against a drug with no history by construction —
+ * the empty state would pass while real lookups stayed broken.
+ *
+ * Requires the deb-install env contract (docs/ui-tests/deb-install-validation.md §6):
+ *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN
+ * Optional: RX_MED_HISTORY_DEMOGRAPHIC_NO (default PRESCRIPTION_DEMOGRAPHIC_NO,
+ *   then 1), CHROME_PATH, RX_MED_HISTORY_SCREENSHOT_DIR (default /tmp),
+ *   RESET_PASSWORD (forced-reset completion; see the runbook).
+ */
+
+const { chromium } = require('playwright');
+const {
+  assert,
+  assertNoPageErrors,
+  assertNotErrorPage,
+  buildFailureDetails,
+  createRecorder,
+  getLaunchOptions,
+  gotoApp,
+  login,
+  screenshot,
+  validateBaseUrl,
+  wirePage,
+} = require('./eform-local-playwright-utils');
+
+const config = {
+  baseUrl: validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos'),
+  chromePath: process.env.CHROME_PATH || '',
+  testUser: process.env.TEST_USER || 'carlosdoc',
+  testPassword: process.env.TEST_PASSWORD || 'carlos2026',
+  testPin: process.env.TEST_PIN || '2026',
+  resetPassword: process.env.RESET_PASSWORD || '',
+  screenshotDir: process.env.RX_MED_HISTORY_SCREENSHOT_DIR || '/tmp',
+};
+const demographicNo = process.env.RX_MED_HISTORY_DEMOGRAPHIC_NO
+  || process.env.PRESCRIPTION_DEMOGRAPHIC_NO
+  || '1';
+assert(/^\d+$/.test(demographicNo), `RX_MED_HISTORY_DEMOGRAPHIC_NO must be numeric, got ${demographicNo}`);
+
+const LIST_PREVIOUS_INSTRUCTIONS = 'parameterValue=listPreviousInstructions';
+
+/** The modal iframe's document, once the window has been opened. */
+function modalFrame(page) {
+  return page.frameLocator('#xmaskframe');
+}
+
+/**
+ * Stage one of the patient's EXISTING prescriptions, the operator way: tick its
+ * ReRx box in the drug profile and confirm with "Stage medication".
+ *
+ * Returns the staged prescription's randomId, which is what every id on the
+ * staged pane — and the asterisk's onclick — is keyed by.
+ */
+async function stageExistingPrescription(page) {
+  const checkbox = page.locator("[id^='reRxCheckBox_']").first();
+  assert(
+    await checkbox.count(),
+    `Patient ${demographicNo} lists no re-prescribable drug, so no prescription can be staged. `
+      + 'The demo dataset seeds this patient with prescriptions; check the drug profile rendered '
+      + '(docs/ui-tests/deb-install-validation.md §4).',
+  );
+  await checkbox.check();
+
+  const stageButton = page.locator('#reRxConfirmBox input[name="stage"]');
+  await stageButton.waitFor({ state: 'visible', timeout: 20000 });
+  await stageButton.click();
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+  const instructions = page.locator("[id^='instructions_']").first();
+  await instructions.waitFor({ state: 'visible', timeout: 30000 });
+  const instructionsId = await instructions.getAttribute('id');
+  const randomId = (instructionsId || '').split('_')[1];
+  assert(/^\d+$/.test(randomId), `Staged prescription exposed no usable randomId (id="${instructionsId}")`);
+  return randomId;
+}
+
+/**
+ * Click the asterisk for a staged prescription and wait for BOTH halves of the
+ * interaction: the action POST and the iframe navigation it triggers.
+ */
+async function openPreviousInstructions(page, randomId) {
+  const star = page.locator(`a[onclick*="displayMedHistory('${randomId}')"]`).first();
+  await star.waitFor({ state: 'visible', timeout: 20000 });
+
+  const [postResponse] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes(LIST_PREVIOUS_INSTRUCTIONS) && r.request().method() === 'POST',
+      { timeout: 30000 },
+    ),
+    star.click(),
+  ]);
+  return postResponse;
+}
+
+(async () => {
+  const recorder = createRecorder();
+  const browser = await chromium.launch(getLaunchOptions(config.chromePath));
+  try {
+    if (config.baseUrl.protocol !== 'https:') {
+      console.log(
+        '[warn] BASE_URL is not HTTPS, so this run does NOT go through nginx and the WAF; the '
+        + 'modal POST is not being measured against the front door an operator uses.',
+      );
+    }
+
+    const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1000 } });
+    const landing = await login(context, config, recorder);
+    await landing.close();
+
+    const rxPage = await context.newPage();
+    wirePage(rxPage, 'rx-med-history', recorder);
+    await gotoApp(rxPage, config.baseUrl, `/rx/choosePatient?demographicNo=${demographicNo}`);
+    await rxPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await assertNotErrorPage(rxPage, 'rx module');
+
+    const randomId = await stageExistingPrescription(rxPage);
+
+    // --- 1. the real lookup -------------------------------------------------
+    const postResponse = await openPreviousInstructions(rxPage, randomId);
+    const postStatus = postResponse.status();
+    assert(
+      postStatus < 400,
+      `The previous-instructions POST returned HTTP ${postStatus}. SearchDrug3.jsp opens the modal `
+        + 'from onSuccess only, so on this status the asterisk does nothing at all — the original '
+        + `"nada" report. Check catalina.out for a stack trace out of listPreviousInstructions.`,
+    );
+
+    const iframe = rxPage.locator('#xmaskframe');
+    await iframe.waitFor({ state: 'visible', timeout: 20000 });
+    await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
+
+    // The whole defect is "the window is empty", so measure the rendered text,
+    // not the presence of the frame.
+    const modalText = (await modalFrame(rxPage).locator('body').innerText()).replace(/\s+/g, ' ').trim();
+    assert(
+      modalText.length > 0,
+      'The previous-instructions modal opened with a completely empty body. displayMedHistory.jsp '
+        + 'swallows its own exceptions, so an empty body means the page threw while rendering '
+        + '(check catalina.out) — this is the blank box users reported.',
+    );
+    assert(
+      /Rx\s*Examples/i.test(modalText),
+      `The modal rendered "${modalText.slice(0, 200)}" instead of the "<drug> Rx Examples" table. `
+        + 'A staged prescription that IS in the session stash must render its history table, not '
+        + 'the "Medication history is unavailable" fallback — that fallback appearing here means '
+        + 'the stash lookup failed for a prescription the page itself just staged.',
+    );
+
+    // A table with a header and no rows is still "nothing" to a prescriber: the
+    // whole point of the control is to offer instructions to click.
+    const instructionRows = modalFrame(rxPage).locator("a[id^='mhInst_'], a[id^='mhSpecInst_']");
+    const rowCount = await instructionRows.count();
+    assert(
+      rowCount > 0,
+      'The modal rendered its header but listed no previous instruction to choose. The staged drug '
+        + 'was re-prescribed from this patient\'s own record, so at least its own prior '
+        + 'instruction must come back from RxUtil.getPreviousInstructions '
+        + '(DrugDaoImpl.findByParameter binds the value — an unbound query used to fail outright '
+        + 'on any drug name containing an apostrophe).',
+    );
+
+    await screenshot(rxPage, config.screenshotDir, 'rx-med-history-modal');
+
+    // Choosing an entry must write it back into the prescription, which is the
+    // only reason the window exists.
+    const chosen = (await instructionRows.first().innerText()).trim();
+    await instructionRows.first().click();
+    const instructionsInput = rxPage.locator(`#instructions_${randomId}`);
+    await instructionsInput.waitFor({ state: 'visible', timeout: 10000 });
+    const applied = (await instructionsInput.inputValue()).trim();
+    assert(
+      applied.length > 0,
+      `Clicking "${chosen}" in the modal left the Instructions field empty; the modal renders but `
+        + 'cannot hand its selection back to the prescription.',
+    );
+
+    // --- 2. the hardened unresolvable path ---------------------------------
+    // A randomId the session stash does not know (a stale modal, a second tab
+    // whose prescription was removed, a hand-edited request) used to throw an
+    // NPE out of the action — 500, no modal, "nada". It must now answer 2xx and
+    // the iframe must SAY the history is unavailable rather than render blank.
+    const strayId = String(Number(randomId) + 7654321);
+    const [strayResponse] = await Promise.all([
+      rxPage.waitForResponse(
+        (r) => r.url().includes(LIST_PREVIOUS_INSTRUCTIONS) && r.request().method() === 'POST',
+        { timeout: 30000 },
+      ),
+      // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the id is passed as an argument, never interpolated into the page script, and is derived from a numeric id this script generated
+      rxPage.evaluate((id) => window.displayMedHistory(id), strayId),
+    ]);
+    const strayStatus = strayResponse.status();
+    assert(
+      strayStatus < 400,
+      `An unresolvable randomId returned HTTP ${strayStatus} from listPreviousInstructions. It must `
+        + 'answer 2xx with an empty history: the modal is opened from onSuccess, so an error status '
+        + 'leaves the user clicking an asterisk that never responds.',
+    );
+
+    await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
+    await rxPage.waitForFunction(
+      // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed predicate over the page's own DOM, no interpolation
+      () => {
+        const frame = document.getElementById('xmaskframe');
+        const body = frame && frame.contentDocument && frame.contentDocument.body;
+        return !!body && body.innerText.trim().length > 0;
+      },
+      null,
+      { timeout: 20000 },
+    ).catch(() => {});
+    const strayText = (await modalFrame(rxPage).locator('body').innerText()).replace(/\s+/g, ' ').trim();
+    assert(
+      /Medication history is unavailable/i.test(strayText),
+      `An unresolvable randomId rendered "${strayText.slice(0, 200)}" instead of the explicit `
+        + '"Medication history is unavailable" empty state. A blank body here is the exact defect '
+        + 'this check exists for: the user sees a white box and cannot tell it from a dead button.',
+    );
+
+    await screenshot(rxPage, config.screenshotDir, 'rx-med-history-unavailable');
+    await rxPage.close();
+
+    assertNoPageErrors(recorder);
+    await context.close();
+
+    console.log(
+      `PASS rx med history: staged prescription ${randomId} for demographic ${demographicNo}, `
+      + `asterisk answered HTTP ${postStatus} and listed ${rowCount} previous instruction(s), `
+      + `selection applied to the prescription, unresolvable id answered HTTP ${strayStatus} `
+      + 'with the explicit empty state',
+    );
+  } catch (error) {
+    console.error('FAIL rx med history Playwright check');
+    console.error(error.stack || error.message);
+    console.error(JSON.stringify(buildFailureDetails(recorder), null, 2));
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();

--- a/scripts/rx-med-history-playwright-checks.js
+++ b/scripts/rx-med-history-playwright-checks.js
@@ -96,6 +96,28 @@ function modalFrame(page) {
 }
 
 /**
+ * The text a prescriber can actually READ in the modal.
+ *
+ * Not `body.innerText`: the response-rewriting filters inject their own
+ * <script> into every HTML response, and its source comes back in the body
+ * text. A modal that rendered nothing at all therefore measures as several
+ * hundred non-empty characters, so "the body is not empty" is exactly the
+ * hollow assertion this defect would slip through. Strip script and style
+ * before measuring.
+ */
+async function modalVisibleText(page) {
+  const text = await page.evaluate(() => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed function over the page's own DOM, nothing interpolated
+    const frame = document.getElementById('xmaskframe');
+    const body = frame && frame.contentDocument && frame.contentDocument.body;
+    if (!body) return '';
+    const clone = body.cloneNode(true);
+    clone.querySelectorAll('script, style').forEach((node) => node.remove());
+    return clone.textContent || '';
+  });
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Stage one of the patient's EXISTING prescriptions, the operator way: tick its
  * ReRx box in the drug profile and confirm with "Stage medication".
  *
@@ -182,7 +204,7 @@ async function openPreviousInstructions(page, randomId) {
 
     // The whole defect is "the window is empty", so measure the rendered text,
     // not the presence of the frame.
-    const modalText = (await modalFrame(rxPage).locator('body').innerText()).replace(/\s+/g, ' ').trim();
+    const modalText = await modalVisibleText(rxPage);
     assert(
       modalText.length > 0,
       'The previous-instructions modal opened with a completely empty body. displayMedHistory.jsp '
@@ -253,12 +275,15 @@ async function openPreviousInstructions(page, randomId) {
       () => {
         const frame = document.getElementById('xmaskframe');
         const body = frame && frame.contentDocument && frame.contentDocument.body;
-        return !!body && body.innerText.trim().length > 0;
+        if (!body) return false;
+        const clone = body.cloneNode(true);
+        clone.querySelectorAll('script, style').forEach((node) => node.remove());
+        return (clone.textContent || '').trim().length > 0;
       },
       null,
       { timeout: 20000 },
     ).catch(() => {});
-    const strayText = (await modalFrame(rxPage).locator('body').innerText()).replace(/\s+/g, ' ').trim();
+    const strayText = await modalVisibleText(rxPage);
     assert(
       /Medication history is unavailable/i.test(strayText),
       `An unresolvable randomId rendered "${strayText.slice(0, 200)}" instead of the explicit `

--- a/scripts/rx-med-history-playwright-checks.js
+++ b/scripts/rx-med-history-playwright-checks.js
@@ -100,45 +100,54 @@ function modalFrame(page) {
 }
 
 /**
- * The text a prescriber can actually READ in the modal.
+ * The text a prescriber can actually READ in the modal opened for `randomId`.
  *
- * Not `body.innerText`: the response-rewriting filters inject their own
- * <script> into every HTML response, and its source comes back in the body
- * text. A modal that rendered nothing at all therefore measures as several
- * hundred non-empty characters, so "the body is not empty" is exactly the
- * hollow assertion this defect would slip through. Strip script and style
- * before measuring.
+ * Two traps, both of which make a blank modal look fine:
+ *
+ *   - Not `body.innerText`: the response-rewriting filters inject their own
+ *     <script> into every HTML response, and its source comes back in the body
+ *     text, so a window that rendered nothing still measures as several hundred
+ *     non-empty characters. Strip script and style before measuring.
+ *   - The page REUSES one #xmaskframe for every modal. After the first one has
+ *     rendered, a read taken before the next navigation commits returns the
+ *     PREVIOUS drug's document — so a later assertion could pass, or fail, on
+ *     text that has nothing to do with what it just asked for. Every read is
+ *     therefore pinned to the document whose URL carries the requested id;
+ *     anything else reads as empty, which is what the assertions report.
  */
-async function modalVisibleText(page) {
-  const text = await page.evaluate(() => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed function over the page's own DOM, nothing interpolated
+async function modalVisibleText(page, randomId) {
+  const text = await page.evaluate((id) => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the id is passed as an argument, never interpolated into the page script
     const frame = document.getElementById('xmaskframe');
-    const body = frame && frame.contentDocument && frame.contentDocument.body;
-    if (!body) return '';
-    const clone = body.cloneNode(true);
+    const doc = frame && frame.contentDocument;
+    if (!doc || !(doc.URL || '').includes(`randomId=${id}`) || !doc.body) return '';
+    const clone = doc.body.cloneNode(true);
     clone.querySelectorAll('script, style').forEach((node) => node.remove());
     return clone.textContent || '';
-  });
+  }, String(randomId));
   return text.replace(/\s+/g, ' ').trim();
 }
 
 /**
- * Wait for the modal to put something readable on screen.
+ * Wait for the modal to finish loading the document for `randomId` and put
+ * something readable in it.
  *
- * Tolerant on purpose: a modal that stays blank is a finding for the assertion
- * that follows to report in full, not a bare timeout here.
+ * Tolerant on purpose: a modal that stays blank, or never navigates, is a
+ * finding for the assertion that follows to report in full, not a bare timeout
+ * here.
  */
-async function waitForModalText(page) {
+async function waitForModalDocument(page, randomId) {
   await page.waitForFunction(
-    // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed predicate over the page's own DOM, no interpolation
-    () => {
+    // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the id is passed as an argument, never interpolated into the page script
+    (id) => {
       const frame = document.getElementById('xmaskframe');
-      const body = frame && frame.contentDocument && frame.contentDocument.body;
-      if (!body) return false;
-      const clone = body.cloneNode(true);
+      const doc = frame && frame.contentDocument;
+      if (!doc || doc.readyState !== 'complete') return false;
+      if (!(doc.URL || '').includes(`randomId=${id}`) || !doc.body) return false;
+      const clone = doc.body.cloneNode(true);
       clone.querySelectorAll('script, style').forEach((node) => node.remove());
       return (clone.textContent || '').trim().length > 0;
     },
-    null,
+    String(randomId),
     { timeout: 20000 },
   ).catch(() => {});
 }
@@ -269,11 +278,11 @@ async function openPreviousInstructions(page, randomId) {
     const iframe = rxPage.locator('#xmaskframe');
     await iframe.waitFor({ state: 'visible', timeout: 20000 });
     await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
-    await waitForModalText(rxPage);
+    await waitForModalDocument(rxPage, randomId);
 
     // The whole defect is "the window is empty", so measure the rendered text,
     // not the presence of the frame.
-    const modalText = await modalVisibleText(rxPage);
+    const modalText = await modalVisibleText(rxPage, randomId);
     assert(
       modalText.length > 0,
       'The previous-instructions modal opened with a completely empty body. displayMedHistory.jsp '
@@ -305,14 +314,57 @@ async function openPreviousInstructions(page, randomId) {
 
     // Choosing an entry must write it back into the prescription, which is the
     // only reason the window exists.
-    const chosen = (await instructionRows.first().innerText()).trim();
-    await instructionRows.first().click();
-    const instructionsInput = rxPage.locator(`#instructions_${randomId}`);
-    await instructionsInput.waitFor({ state: 'visible', timeout: 10000 });
-    const applied = (await instructionsInput.inputValue()).trim();
+    //
+    // Two things this has to get right, and neither is obvious:
+    //
+    //   - The two column links go to DIFFERENT fields. mhInst_* calls
+    //     addInstruction (-> #instructions_<id>) and mhSpecInst_* calls
+    //     addSpecialInstruction (-> #siInput_<id>), so clicking whichever link
+    //     happens to be first and then asserting on the Instructions field
+    //     fails on a history entry that only carries a special instruction,
+    //     even though the handoff worked. Pick the link that matches the field
+    //     being asserted.
+    //   - A ReRx-staged prescription arrives with its existing text ALREADY in
+    //     the field (prescribe.jsp seeds it from rx.getSpecial()), so "the
+    //     field is non-empty afterwards" is true before the click and measures
+    //     nothing. Clear it first.
+    //
+    // The assertion is "non-empty after clearing" rather than an equality
+    // against the link text on purpose: addInstruction runs the value through
+    // parseIntr, which rewrites it (it lifts quantity and repeats out of the
+    // sig), so an exact match would fail on a working handoff.
+    const plainRows = modalFrame(rxPage).locator("a[id^='mhInst_']");
+    const specialRows = modalFrame(rxPage).locator("a[id^='mhSpecInst_']");
+    const usePlainRow = (await plainRows.count()) > 0;
+    const chosenRow = usePlainRow ? plainRows.first() : specialRows.first();
+    const targetSelector = usePlainRow ? `#instructions_${randomId}` : `#siInput_${randomId}`;
+    const targetField = usePlainRow ? 'Instructions' : 'Special Instructions';
+
+    const chosen = (await chosenRow.innerText()).trim();
+    const appliedInput = rxPage.locator(targetSelector);
+    await appliedInput.waitFor({ state: 'attached', timeout: 10000 });
+    await appliedInput.fill('');
+    assert(
+      (await appliedInput.inputValue()).trim() === '',
+      `Could not clear the ${targetField} field before testing the modal's handoff, so the `
+        + 'assertion that follows would not measure the click.',
+    );
+
+    await chosenRow.click();
+    await rxPage.waitForFunction(
+      // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the selector is passed as an argument, never interpolated into the page script
+      (selector) => {
+        const el = document.querySelector(selector);
+        return !!el && el.value.trim().length > 0;
+      },
+      targetSelector,
+      { timeout: 10000 },
+    ).catch(() => {});
+    const applied = (await appliedInput.inputValue()).trim();
     assert(
       applied.length > 0,
-      `Clicking "${chosen}" in the modal left the Instructions field empty; the modal renders but `
+      `Clicking "${chosen}" in the modal left the ${targetField} field empty (it was cleared `
+        + 'first, so this is the click being measured, not leftover text). The modal renders but '
         + 'cannot hand its selection back to the prescription.',
     );
 
@@ -330,8 +382,8 @@ async function openPreviousInstructions(page, randomId) {
     );
 
     await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
-    await waitForModalText(rxPage);
-    const customText = await modalVisibleText(rxPage);
+    await waitForModalDocument(rxPage, customRandomId);
+    const customText = await modalVisibleText(rxPage, customRandomId);
     assert(
       /Rx\s*Examples/i.test(customText),
       `A history-less drug rendered "${customText.slice(0, 200)}" instead of its Rx Examples table. `
@@ -374,8 +426,8 @@ async function openPreviousInstructions(page, randomId) {
     );
 
     await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
-    await waitForModalText(rxPage);
-    const strayText = await modalVisibleText(rxPage);
+    await waitForModalDocument(rxPage, strayId);
+    const strayText = await modalVisibleText(rxPage, strayId);
     assert(
       /Medication history is unavailable/i.test(strayText),
       `An unresolvable randomId rendered "${strayText.slice(0, 200)}" instead of the explicit `

--- a/scripts/rx-med-history-playwright-checks.js
+++ b/scripts/rx-med-history-playwright-checks.js
@@ -114,12 +114,18 @@ function modalFrame(page) {
  *     text that has nothing to do with what it just asked for. Every read is
  *     therefore pinned to the document whose URL carries the requested id;
  *     anything else reads as empty, which is what the assertions report.
+ *
+ * The id is compared as a parsed query PARAMETER, not as a substring of the
+ * URL: the custom drug's id comes from Math.random() and can be short, so
+ * "randomId=4" would otherwise match a frame still showing randomId=42 and
+ * reintroduce the staleness this guard exists to remove.
  */
 async function modalVisibleText(page, randomId) {
   const text = await page.evaluate((id) => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the id is passed as an argument, never interpolated into the page script
     const frame = document.getElementById('xmaskframe');
     const doc = frame && frame.contentDocument;
-    if (!doc || !(doc.URL || '').includes(`randomId=${id}`) || !doc.body) return '';
+    if (!doc || !doc.body) return '';
+    if (new URL(doc.URL).searchParams.get('randomId') !== id) return '';
     const clone = doc.body.cloneNode(true);
     clone.querySelectorAll('script, style').forEach((node) => node.remove());
     return clone.textContent || '';
@@ -141,8 +147,8 @@ async function waitForModalDocument(page, randomId) {
     (id) => {
       const frame = document.getElementById('xmaskframe');
       const doc = frame && frame.contentDocument;
-      if (!doc || doc.readyState !== 'complete') return false;
-      if (!(doc.URL || '').includes(`randomId=${id}`) || !doc.body) return false;
+      if (!doc || doc.readyState !== 'complete' || !doc.body) return false;
+      if (new URL(doc.URL).searchParams.get('randomId') !== id) return false;
       const clone = doc.body.cloneNode(true);
       clone.querySelectorAll('script, style').forEach((node) => node.remove());
       return (clone.textContent || '').trim().length > 0;

--- a/scripts/rx-med-history-playwright-checks.js
+++ b/scripts/rx-med-history-playwright-checks.js
@@ -28,8 +28,8 @@
  * was last written with so the prescriber can click one instead of retyping it.
  *
  * The reported defect (#955) was that the asterisk did "nada": the window
- * either never opened or opened empty. Both halves are pinned here, because
- * they are two different failures with the same symptom:
+ * either never opened or opened empty. All three shapes are pinned here,
+ * because they are different failures wearing the same symptom:
  *
  *   1. The POST behind the asterisk (WriteScript?parameterValue=
  *      listPreviousInstructions) must answer 2xx. The modal is opened from the
@@ -42,15 +42,19 @@
  *      try/catch that logs and swallows, so a null prescription used to
  *      produce a 200 with an empty body — a blank white box, indistinguishable
  *      to the user from nothing happening.
+ *   3. A drug with no prescribing history must SAY so. The table rendered its
+ *      header and then stopped, leaving two column titles over nothing, which
+ *      reads as a broken control rather than an empty result.
  *
  * Reaching the modal the way a prescriber does matters as much as asserting on
  * it. The asterisk only exists on a STAGED prescription, so this check stages
  * one from the patient's own drug profile (tick ReRx, "Stage medication") and
  * then clicks the rendered anchor. A check that navigated straight to
  * rx/ViewDisplayMedHistory would exercise neither the action nor the callback
- * that decides whether the window is shown, and a check that staged a fresh
- * CUSTOM drug would assert against a drug with no history by construction —
- * the empty state would pass while real lookups stayed broken.
+ * that decides whether the window is shown. The custom drug this check also
+ * stages is for case 3 ONLY, and must not be the drug case 1 asserts against:
+ * a freshly-invented name has no history by construction, so an empty result
+ * would satisfy the main path while real lookups stayed broken.
  *
  * Requires the deb-install env contract (docs/ui-tests/deb-install-validation.md §6):
  *   BASE_URL, TEST_USER, TEST_PASSWORD, TEST_PIN
@@ -118,6 +122,28 @@ async function modalVisibleText(page) {
 }
 
 /**
+ * Wait for the modal to put something readable on screen.
+ *
+ * Tolerant on purpose: a modal that stays blank is a finding for the assertion
+ * that follows to report in full, not a bare timeout here.
+ */
+async function waitForModalText(page) {
+  await page.waitForFunction(
+    // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed predicate over the page's own DOM, no interpolation
+    () => {
+      const frame = document.getElementById('xmaskframe');
+      const body = frame && frame.contentDocument && frame.contentDocument.body;
+      if (!body) return false;
+      const clone = body.cloneNode(true);
+      clone.querySelectorAll('script, style').forEach((node) => node.remove());
+      return (clone.textContent || '').trim().length > 0;
+    },
+    null,
+    { timeout: 20000 },
+  ).catch(() => {});
+}
+
+/**
  * Stage one of the patient's EXISTING prescriptions, the operator way: tick its
  * ReRx box in the drug profile and confirm with "Stage medication".
  *
@@ -145,6 +171,48 @@ async function stageExistingPrescription(page) {
   const randomId = (instructionsId || '').split('_')[1];
   assert(/^\d+$/.test(randomId), `Staged prescription exposed no usable randomId (id="${instructionsId}")`);
   return randomId;
+}
+
+/** The randomIds of everything currently staged on the prescription pane. */
+async function stagedRandomIds(page) {
+  return page.evaluate(() => Array.from(document.querySelectorAll("[id^='instructions_']")) // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed function over the page's own DOM, nothing interpolated
+    .map((el) => el.id.split('_')[1])
+    .filter((id) => /^\d+$/.test(id)));
+}
+
+/**
+ * Stage a CUSTOM drug under a name nothing has ever been prescribed as, so its
+ * history lookup is legitimately empty — the one remaining shape of "the modal
+ * shows nothing", where the prescription resolves fine but has no instructions
+ * to offer.
+ *
+ * Driven through the CustomDrug button rather than the endpoint behind it, so
+ * the check keeps measuring the path a prescriber takes. That button confirms
+ * first, and wirePage's recorder DISMISSES every dialog — which would silently
+ * cancel the staging and leave this section asserting against the previous
+ * prescription. Swap the handler for the duration.
+ */
+async function stageUnprescribedCustomDrug(page, recorder, drugName) {
+  const before = new Set(await stagedRandomIds(page));
+
+  page.removeAllListeners('dialog');
+  page.on('dialog', async (dialog) => {
+    recorder.dialogs.push({ label: 'rx-med-history', type: dialog.type(), text: dialog.message() });
+    await dialog.accept().catch(() => {});
+  });
+
+  await page.locator('#searchString').fill(drugName);
+  await page.locator('#customDrug').click();
+  await page.waitForFunction(
+    // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the count is passed as an argument, never interpolated into the page script
+    (previousCount) => document.querySelectorAll("[id^='instructions_']").length > previousCount,
+    before.size,
+    { timeout: 30000 },
+  );
+
+  const added = (await stagedRandomIds(page)).filter((id) => !before.has(id));
+  assert(added.length === 1, `Staging a custom drug added ${added.length} prescriptions, expected 1`);
+  return added[0];
 }
 
 /**
@@ -201,6 +269,7 @@ async function openPreviousInstructions(page, randomId) {
     const iframe = rxPage.locator('#xmaskframe');
     await iframe.waitFor({ state: 'visible', timeout: 20000 });
     await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
+    await waitForModalText(rxPage);
 
     // The whole defect is "the window is empty", so measure the rendered text,
     // not the presence of the frame.
@@ -247,7 +316,42 @@ async function openPreviousInstructions(page, randomId) {
         + 'cannot hand its selection back to the prescription.',
     );
 
-    // --- 2. the hardened unresolvable path ---------------------------------
+    // --- 2. a prescription with no history ---------------------------------
+    // The lookup succeeds and the prescription resolves; there is simply
+    // nothing to offer. The table used to render its header and then stop, so
+    // the prescriber got a box with two column titles and no content — the
+    // same "nothing happened" as a blank window.
+    const customDrugName = `ZZ Check Drug ${Date.now()}`;
+    const customRandomId = await stageUnprescribedCustomDrug(rxPage, recorder, customDrugName);
+    const customResponse = await openPreviousInstructions(rxPage, customRandomId);
+    assert(
+      customResponse.status() < 400,
+      `The previous-instructions POST for a history-less drug returned HTTP ${customResponse.status()}.`,
+    );
+
+    await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
+    await waitForModalText(rxPage);
+    const customText = await modalVisibleText(rxPage);
+    assert(
+      /Rx\s*Examples/i.test(customText),
+      `A history-less drug rendered "${customText.slice(0, 200)}" instead of its Rx Examples table. `
+        + 'The prescription is in the stash, so the table — not the unavailable fallback — belongs here.',
+    );
+    assert(
+      /No previous instructions recorded/i.test(customText),
+      `A drug with no prescribing history rendered "${customText.slice(0, 200)}" — a header with no `
+        + 'row under it and no explanation. It must say so in words, or the prescriber cannot tell '
+        + 'an empty history from a broken control.',
+    );
+    assert(
+      (await modalFrame(rxPage).locator("a[id^='mhInst_'], a[id^='mhSpecInst_']").count()) === 0,
+      'A drug with no prescribing history offered instructions to click; the empty-state row is '
+        + 'being rendered alongside real content, which means the row counter is wrong.',
+    );
+
+    await screenshot(rxPage, config.screenshotDir, 'rx-med-history-no-history');
+
+    // --- 3. the hardened unresolvable path ---------------------------------
     // A randomId the session stash does not know (a stale modal, a second tab
     // whose prescription was removed, a hand-edited request) used to throw an
     // NPE out of the action — 500, no modal, "nada". It must now answer 2xx and
@@ -270,19 +374,7 @@ async function openPreviousInstructions(page, randomId) {
     );
 
     await modalFrame(rxPage).locator('body').waitFor({ state: 'attached', timeout: 20000 });
-    await rxPage.waitForFunction(
-      // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed predicate over the page's own DOM, no interpolation
-      () => {
-        const frame = document.getElementById('xmaskframe');
-        const body = frame && frame.contentDocument && frame.contentDocument.body;
-        if (!body) return false;
-        const clone = body.cloneNode(true);
-        clone.querySelectorAll('script, style').forEach((node) => node.remove());
-        return (clone.textContent || '').trim().length > 0;
-      },
-      null,
-      { timeout: 20000 },
-    ).catch(() => {});
+    await waitForModalText(rxPage);
     const strayText = await modalVisibleText(rxPage);
     assert(
       /Medication history is unavailable/i.test(strayText),
@@ -300,8 +392,8 @@ async function openPreviousInstructions(page, randomId) {
     console.log(
       `PASS rx med history: staged prescription ${randomId} for demographic ${demographicNo}, `
       + `asterisk answered HTTP ${postStatus} and listed ${rowCount} previous instruction(s), `
-      + `selection applied to the prescription, unresolvable id answered HTTP ${strayStatus} `
-      + 'with the explicit empty state',
+      + 'selection applied to the prescription; a drug with no history said so in words; '
+      + `unresolvable id answered HTTP ${strayStatus} with the explicit empty state`,
     );
   } catch (error) {
     console.error('FAIL rx med history Playwright check');

--- a/scripts/rx-med-history-playwright-checks.js
+++ b/scripts/rx-med-history-playwright-checks.js
@@ -188,6 +188,23 @@ async function stageExistingPrescription(page) {
   return randomId;
 }
 
+/**
+ * The special-instruction box starts collapsed on a prescription that has none
+ * (prescribe.jsp renders #siAutoComplete_<id> display:none), and
+ * addSpecialInstruction is responsible for opening it as it writes. A value
+ * dropped into a still-hidden box is invisible to the prescriber.
+ */
+async function assertSpecialInstructionsRevealed(page, randomId) {
+  const container = page.locator(`#siAutoComplete_${randomId}`);
+  await container.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+  assert(
+    await container.isVisible(),
+    `The modal wrote a special instruction into #siInput_${randomId} but left `
+      + `#siAutoComplete_${randomId} collapsed, so the prescriber cannot see or edit what was `
+      + 'applied.',
+  );
+}
+
 /** The randomIds of everything currently staged on the prescription pane. */
 async function stagedRandomIds(page) {
   return page.evaluate(() => Array.from(document.querySelectorAll("[id^='instructions_']")) // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- fixed function over the page's own DOM, nothing interpolated
@@ -349,7 +366,21 @@ async function openPreviousInstructions(page, randomId) {
     const chosen = (await chosenRow.innerText()).trim();
     const appliedInput = rxPage.locator(targetSelector);
     await appliedInput.waitFor({ state: 'attached', timeout: 10000 });
-    await appliedInput.fill('');
+
+    // Cleared through the DOM rather than with fill(): on the special-instruction
+    // branch the field lives inside #siAutoComplete_<id>, which prescribe.jsp renders
+    // display:none unless the prescription already has a special instruction, and
+    // fill() would fail its actionability check on a hidden input. Clearing is test
+    // setup, not the behaviour under test, so reaching past the UI for it costs
+    // nothing — the CLICK that follows is still the real control.
+    await rxPage.evaluate(
+      // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-injection.playwright-evaluate-injection -- the selector is passed as an argument, never interpolated into the page script
+      (selector) => {
+        const el = document.querySelector(selector);
+        if (el) el.value = '';
+      },
+      targetSelector,
+    );
     assert(
       (await appliedInput.inputValue()).trim() === '',
       `Could not clear the ${targetField} field before testing the modal's handoff, so the `
@@ -373,6 +404,12 @@ async function openPreviousInstructions(page, randomId) {
         + 'first, so this is the click being measured, not leftover text). The modal renders but '
         + 'cannot hand its selection back to the prescription.',
     );
+
+    // addSpecialInstruction also has to REVEAL the collapsed section it writes into,
+    // or the prescriber is left with a value they cannot see or correct.
+    if (!usePlainRow) {
+      await assertSpecialInstructionsRevealed(rxPage, randomId);
+    }
 
     // --- 2. a prescription with no history ---------------------------------
     // The lookup succeeds and the prescription resolves; there is simply

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxSessionBean.java
@@ -176,12 +176,17 @@ public class RxSessionBean implements java.io.Serializable {
      * The staged prescription carrying this random id, or {@code null} when the stash
      * does not hold one.
      *
-     * <p>The null element check is defensive rather than a reproduced defect: no caller
-     * puts a null in the stash today. It is here because every caller of this method
-     * treats a missing item as "no history to show", and a NullPointerException raised
-     * while scanning would instead surface as a 500 on an AJAX lookup whose modal only
-     * opens from the success callback — the failure this whole path was hardened
-     * against.</p>
+     * <p>What a miss means is the caller's business, and callers differ: the
+     * previous-instructions lookup renders its empty modal, {@code saveCustomName} logs
+     * and abandons the rename, {@code normalDrugSetCustom} skips its conversion. This
+     * method reports the miss and nothing more.</p>
+     *
+     * <p>The null ELEMENT check inside the scan is defensive rather than a reproduced
+     * defect: no caller puts a null in the stash today. It is here because a
+     * NullPointerException raised while scanning would escape as a 500 rather than as
+     * the null this method contracts to return — and on the AJAX history lookup, whose
+     * modal only opens from the success callback, a 500 is a control that does nothing
+     * at all.</p>
      */
     public RxPrescriptionData.Prescription getStashItem2(int randomId) {
         RxPrescriptionData.Prescription psp = null;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxSessionBean.java
@@ -172,11 +172,21 @@ public class RxSessionBean implements java.io.Serializable {
         return stash.get(index);
     }
 
-    //return prescript from its random id
+    /**
+     * The staged prescription carrying this random id, or {@code null} when the stash
+     * does not hold one.
+     *
+     * <p>The null element check is defensive rather than a reproduced defect: no caller
+     * puts a null in the stash today. It is here because every caller of this method
+     * treats a missing item as "no history to show", and a NullPointerException raised
+     * while scanning would instead surface as a 500 on an AJAX lookup whose modal only
+     * opens from the success callback — the failure this whole path was hardened
+     * against.</p>
+     */
     public RxPrescriptionData.Prescription getStashItem2(int randomId) {
         RxPrescriptionData.Prescription psp = null;
         for (RxPrescriptionData.Prescription rx : stash) {
-            if (rx.getRandomId() == randomId) {
+            if (rx != null && rx.getRandomId() == randomId) {
                 psp = rx;
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
@@ -438,7 +438,6 @@ public final class RxWriteScript2Action extends ActionSupport {
 
         logger.debug("=============Start listPreviousInstructions RxWriteScript2Action.java===============");
         String randomId = request.getParameter("randomId");
-        randomId = randomId.trim();
         // get prescript from randomId.
         // if prescript is normal drug, if din is not null, use din to find it
         // if din is null, use BN to find it
@@ -449,8 +448,29 @@ public final class RxWriteScript2Action extends ActionSupport {
             response.sendRedirect("error.html");
             return null;
         }
+        randomId = randomId != null ? randomId.trim() : null;
+        if (randomId == null || !randomId.matches("\\d+")) {
+            logger.warn("listPreviousInstructions: invalid randomId");
+            bean.setListMedHistory(new ArrayList<>());
+            return null;
+        }
+
+        final int randomIdInt;
+        try {
+            randomIdInt = Integer.parseInt(randomId);
+        } catch (NumberFormatException e) {
+            logger.warn("listPreviousInstructions: randomId is out of range");
+            bean.setListMedHistory(new ArrayList<>());
+            return null;
+        }
+
         // create Prescription
-        RxPrescriptionData.Prescription rx = bean.getStashItem2(Integer.parseInt(randomId));
+        RxPrescriptionData.Prescription rx = bean.getStashItem2(randomIdInt);
+        if (rx == null) {
+            logger.warn("listPreviousInstructions: no stash item found");
+            bean.setListMedHistory(new ArrayList<>());
+            return null;
+        }
         List<HashMap<String, String>> retList = new ArrayList();
         retList = RxUtil.getPreviousInstructions(rx);
 

--- a/src/main/webapp/WEB-INF/jsp/rx/displayMedHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/displayMedHistory.jsp
@@ -69,16 +69,21 @@
     try {
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
         String randomId = request.getParameter("randomId");
-        if (randomId != null) {
-            RxPrescriptionData.Prescription rx = bean.getStashItem2(Integer.parseInt(randomId));
-            String drugName = rx.getBrandName();
-            if (drugName == null || drugName.equalsIgnoreCase("null") || drugName.trim().length() == 0)
-                drugName = rx.getCustomName();
-            List<HashMap<String, String>> listMedHistory = (List<HashMap<String, String>>) bean.getListMedHistory();
+        randomId = randomId != null ? randomId.trim() : null;
+        boolean renderedHistory = false;
+        if (bean != null && randomId != null && randomId.matches("\\d+")) {
+            try {
+                RxPrescriptionData.Prescription rx = bean.getStashItem2(Integer.parseInt(randomId));
+                if (rx != null) {
+                    renderedHistory = true;
+                    String drugName = rx.getBrandName();
+                    if (drugName == null || drugName.equalsIgnoreCase("null") || drugName.trim().length() == 0)
+                        drugName = rx.getCustomName();
+                    List<HashMap<String, String>> listMedHistory = (List<HashMap<String, String>>) bean.getListMedHistory();
 %>
 
-<a onmouseover="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
-        src="${carlos:forHtmlAttribute(ctx)}/images/close.png" border="0" TITLE="Close"
+<a onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
+        src="${carlos:forHtmlAttribute(ctx)}/images/close.png" border="0" alt="Close" TITLE="Close"
         style="position: absolute; top: 0.5em; right: 0.5em; "></a>
 <br/><br/>
 <table class="mhTable">
@@ -133,12 +138,29 @@
     <%
                     i++;
                 }
+    %>
+</table>
+    <%
+                } // end if (rx != null)
+            } catch (NumberFormatException ignored) {
+                // Out-of-range digit strings render the empty state below.
             }
+        } // end if (bean != null && randomId != null && randomId.matches("\\d+"))
 
+        if (!renderedHistory) {
+    %>
+<a onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
+        src="${carlos:forHtmlAttribute(ctx)}/images/close.png" border="0" alt="Close" TITLE="Close"
+        style="position: absolute; top: 0.5em; right: 0.5em; "></a>
+<br/><br/>
+<div class="mhTable" style="font-style:normal;font-family:sans-serif;font-size:80%;padding:1em;">
+    Medication history is unavailable.
+</div>
+    <%
+        }
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
         }
     %>
-</table>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/rx/displayMedHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/displayMedHistory.jsp
@@ -80,6 +80,12 @@
                     if (drugName == null || drugName.equalsIgnoreCase("null") || drugName.trim().length() == 0)
                         drugName = rx.getCustomName();
                     List<HashMap<String, String>> listMedHistory = (List<HashMap<String, String>>) bean.getListMedHistory();
+                    // The action always sets a list, but a null here would throw out of the
+                    // loop below and be swallowed by the catch at the foot of the page --
+                    // rendering the blank window this page exists to stop rendering.
+                    if (listMedHistory == null) {
+                        listMedHistory = new ArrayList<HashMap<String, String>>();
+                    }
 %>
 
 <a onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
@@ -99,6 +105,11 @@
     </tr>
     <%
         int i = 0;
+        // Rows rendered, NOT entries iterated: an entry whose instruction and special
+        // instruction are both blank renders no row at all, so a list of those would
+        // leave a header with nothing under it -- which is "the modal shows nothing"
+        // from where the prescriber sits.
+        int renderedRows = 0;
         for (HashMap<String, String> hm : listMedHistory) {
             String ins = hm.get("instruction");
             String specIns = hm.get("special_instruction");
@@ -136,7 +147,20 @@
     </tr>
     <%}%>
     <%
+                    if (instructionExist || specialInstructionExist) {
+                        renderedRows++;
+                    }
                     i++;
+                }
+                if (renderedRows == 0) {
+    %>
+    <tr>
+        <td colspan="2" align="center"
+            style="font-style:normal;font-family:sans-serif;font-size:80%;padding:0.75em;">
+            No previous instructions recorded for this medication.
+        </td>
+    </tr>
+    <%
                 }
     %>
 </table>

--- a/src/main/webapp/WEB-INF/jsp/rx/displayMedHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/displayMedHistory.jsp
@@ -88,7 +88,11 @@
                     }
 %>
 
-<a onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
+<%-- href plus onclick, not a bare onMouseDown: without an href the anchor takes no
+     focus and no keyboard activation, so the only way to dismiss this window was the
+     mouse. onclick covers both pointer and Enter. --%>
+<a href="javascript:void(0);" onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';"
+   onclick="parent.mb.hide();"><img
         src="${carlos:forHtmlAttribute(ctx)}/images/close.png" border="0" alt="Close" TITLE="Close"
         style="position: absolute; top: 0.5em; right: 0.5em; "></a>
 <br/><br/>
@@ -173,7 +177,11 @@
 
         if (!renderedHistory) {
     %>
-<a onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
+<%-- href plus onclick, not a bare onMouseDown: without an href the anchor takes no
+     focus and no keyboard activation, so the only way to dismiss this window was the
+     mouse. onclick covers both pointer and Enter. --%>
+<a href="javascript:void(0);" onmouseover="this.style.cursor='pointer';" onfocus="this.style.cursor='pointer';"
+   onclick="parent.mb.hide();"><img
         src="${carlos:forHtmlAttribute(ctx)}/images/close.png" border="0" alt="Close" TITLE="Close"
         style="position: absolute; top: 0.5em; right: 0.5em; "></a>
 <br/><br/>

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2ActionListPreviousInstructionsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2ActionListPreviousInstructionsTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -137,7 +138,10 @@ class RxWriteScript2ActionListPreviousInstructionsTest extends CarlosUnitTestBas
         }
     }
 
+    // @NullSource covers the parameter being absent altogether, which is the shape the
+    // unguarded randomId.trim() used to throw on before the session-bean check even ran.
     @ParameterizedTest
+    @NullSource
     @ValueSource(strings = {"12\r\ninvalid", "999999999999999999999", "42"})
     @DisplayName("should clear history without sending an error for an invalid or missing randomId")
     void shouldClearHistory_whenRandomIdIsInvalidOrMissing(String randomId) throws Exception {

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2ActionListPreviousInstructionsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2ActionListPreviousInstructionsTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.prescript.pageUtil;
+
+import io.github.carlos_emr.carlos.commn.dao.PartialDateDao;
+import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.PrescriptionSignatureStampService;
+import io.github.carlos_emr.carlos.managers.RxManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData;
+import io.github.carlos_emr.carlos.prescript.util.RxUtil;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("RxWriteScript2Action listPreviousInstructions")
+@Tag("unit")
+@Tag("prescript")
+class RxWriteScript2ActionListPreviousInstructionsTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockedStatic<LoggedInInfo> loggedInInfoMock;
+    private AutoCloseable mocks;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+    @Mock
+    private UserPropertyDAO mockUserPropertyDAO;
+    @Mock
+    private PartialDateDao mockPartialDateDao;
+    @Mock
+    private DemographicManager mockDemographicManager;
+    @Mock
+    private RxManager mockRxManager;
+    @Mock
+    private PrescriptionSignatureStampService mockSignatureStampService;
+    @Mock
+    private LoggedInInfo mockLoggedInInfo;
+    @Mock
+    private HttpServletRequest mockRequest;
+    @Mock
+    private HttpServletResponse mockResponse;
+    @Mock
+    private HttpSession mockSession;
+
+    private RxSessionBean bean;
+    private RxWriteScript2Action action;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
+        registerMock(UserPropertyDAO.class, mockUserPropertyDAO);
+        registerMock(PartialDateDao.class, mockPartialDateDao);
+        registerMock(DemographicManager.class, mockDemographicManager);
+        registerMock(RxManager.class, mockRxManager);
+
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(mockResponse);
+
+        loggedInInfoMock = mockStatic(LoggedInInfo.class);
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(mockLoggedInInfo);
+
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_rx"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockRequest.getSession()).thenReturn(mockSession);
+
+        bean = new RxSessionBean();
+        bean.setListMedHistory(new ArrayList<>(List.of(historyEntry("take once daily"))));
+        when(mockSession.getAttribute("RxSessionBean")).thenReturn(bean);
+
+        // The package-private constructor, not the Struts no-arg one: the latter resolves the
+        // signature-stamp service from the Spring context, which a unit test has no business
+        // standing up for a read-only history lookup.
+        action = new RxWriteScript2Action(mockSignatureStampService);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (loggedInInfoMock != null) {
+            loggedInInfoMock.close();
+        }
+        if (servletActionContextMock != null) {
+            servletActionContextMock.close();
+        }
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"12\r\ninvalid", "999999999999999999999", "42"})
+    @DisplayName("should clear history without sending an error for an invalid or missing randomId")
+    void shouldClearHistory_whenRandomIdIsInvalidOrMissing(String randomId) throws Exception {
+        when(mockRequest.getParameter("randomId")).thenReturn(randomId);
+
+        String result = action.listPreviousInstructions();
+
+        assertThat(result).isNull();
+        assertThat(bean.getListMedHistory()).isEmpty();
+        verify(mockResponse, never()).sendError(anyInt(), any(String.class));
+    }
+
+    @Test
+    @DisplayName("should populate previous instructions when randomId has surrounding whitespace")
+    void shouldPopulatePreviousInstructions_whenRandomIdHasWhitespace() throws Exception {
+        RxPrescriptionData.Prescription prescription = new RxPrescriptionData.Prescription(0, "999998", 123);
+        prescription.setRandomId(42);
+        bean.getStashList().add(prescription);
+        List<HashMap<String, String>> history = new ArrayList<>(List.of(historyEntry("take twice daily")));
+        when(mockRequest.getParameter("randomId")).thenReturn(" 42 ");
+
+        try (MockedStatic<RxUtil> rxUtilMock = mockStatic(RxUtil.class)) {
+            rxUtilMock.when(() -> RxUtil.getPreviousInstructions(prescription)).thenReturn(history);
+
+            String result = action.listPreviousInstructions();
+
+            assertThat(result).isNull();
+            assertThat(bean.getListMedHistory()).containsExactlyElementsOf(history);
+            verify(mockResponse, never()).sendError(anyInt(), any(String.class));
+        }
+    }
+
+    private HashMap<String, String> historyEntry(String instruction) {
+        HashMap<String, String> entry = new HashMap<>();
+        entry.put("instruction", instruction);
+        return entry;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2ActionListPreviousInstructionsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2ActionListPreviousInstructionsUnitTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 @DisplayName("RxWriteScript2Action listPreviousInstructions")
 @Tag("unit")
 @Tag("prescript")
-class RxWriteScript2ActionListPreviousInstructionsTest extends CarlosUnitTestBase {
+class RxWriteScript2ActionListPreviousInstructionsUnitTest extends CarlosUnitTestBase {
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private MockedStatic<LoggedInInfo> loggedInInfoMock;


### PR DESCRIPTION
## Description

Clicking the red asterisk beside a staged prescription's **Instructions** field opened an empty window, or no window at all — the "nada" in #955.

Three independent failures produce the same symptom, and all three are fixed:

1. **`listPreviousInstructions` threw out of the action.** It called `randomId.trim()` before the session-bean guard, and handed whatever `bean.getStashItem2(...)` returned — `null` for any id the stash no longer holds — straight to `RxUtil.getPreviousInstructions`. `SearchDrug3.jsp` opens the modal from the request's `onSuccess` callback **only**, so an error status means the asterisk does nothing at all. The id is now digits-validated, parsed defensively, and an unresolvable stash item clears the history and returns normally.
2. **`displayMedHistory.jsp` rendered a blank body.** It dereferenced the same prescription inside a `try/catch` that logs and swallows, so a `null` left the response empty but for a stray `</table>` — a white box the user cannot tell from a dead button. The lookup is now guarded and an explicit *"Medication history is unavailable."* empty state renders with its own close control.
3. **A drug with no prescribing history said nothing.** With everything resolving normally and the lookup succeeding, a drug nothing has been written as before rendered the *"&lt;drug&gt; Rx Examples"* heading, the two column titles, and then stopped — headers over nothing, which from where the prescriber sits is indistinguishable from a broken control. The table now carries an explicit *"No previous instructions recorded for this medication."* row.

That third row counts **rows rendered**, not list entries: an entry whose instruction and special instruction are both blank renders no row at all, so a list made only of those would slip past an `isEmpty()` test and leave the same empty box. A null history list is coalesced on the way in for the same reason the rest of the page is guarded — it would throw out of the row loop into the catch at the foot of the page and produce the blank window again, with only a log line to explain it.

### Relationship to #955

This is a **retarget of #955** (which targeted `develop`, and is now closed) onto `release/2026.08`, carrying only the Rx change. The third part of #955's original fix — binding the value in `DrugDaoImpl.findByParameter`, which used to fail outright on any drug name containing an apostrophe — is **already on this branch**, so nothing of it is duplicated here, and nothing else from `develop` comes with it.

Shape 3 above is **not** from #955; it was found while validating this branch on a packaged install and is the last remaining way the control can still show a prescriber nothing.

One adjustment was needed for this branch: the unit test constructs the action through its package-private constructor rather than the Struts no-arg one, which here resolves a `PrescriptionSignatureStampService` from the Spring context that a read-only history lookup has no business standing up.

The browser check from #955 was replaced. The original navigated to `/rx/searchDrug` (which maps to `RxSearchDrug2Action` → `ChooseDrug.jsp`, not the staging pane) and needed a hand-provisioned `RX_MED_HISTORY_SCRIPT_ID` fixture. The new one reaches the control the way a prescriber does: stage one of the patient's own prescriptions from the drug profile (tick ReRx → "Stage medication"), click the rendered asterisk, and assert the modal lists **selectable** previous instructions and that choosing one writes it back into the prescription. It then stages a custom drug under a name nothing has been prescribed as and requires the modal to name its emptiness in words, and finally drives the unresolvable-id path and requires 2xx plus the explicit unavailable state.

## Related Issues

Retargets #955 (closed in favour of this PR). Related to #2633 (the broader Rx `*`-control confusion that made this hard to verify by hand).

## Target Branch

`release/2026.08` — a supported-release fix, per `docs/release-process.md`. The defect is present on that branch, and #955's own head could not simply be rebased onto it: it carried several `develop` merges, so retargeting it in place would have dragged unrelated `develop` code into the release line. This branch is cut from `release/2026.08` and carries the Rx change only. No version or SCM metadata is touched, and no Flyway migration is modified.

## How Was This Tested?

**Unit** — `mvn test -Dtest=RxWriteScript2ActionListPreviousInstructionsTest`: 4/4 pass.

**Lint** — `scripts/lint/check-encoder-null-safety.sh` PASS, `check-bdd-test-naming.py` PASS (270 files), `check-security-exception-message-convention.sh` PASS.

**Packaged install** — the `.deb` packages were built from this branch and installed on Ubuntu 26.04 (`carlos-emr` + `carlos-emr-drugref`, preseeded with the demo dataset), and every check below ran through the real front door at `:443` (nginx + ModSecurity/CRS blocking), per `docs/ui-tests/deb-install-validation.md`. `carlos-ctl check` is clean apart from three `systemctl`-status lines: the validation host was a container rather than the runbook's LXD VM (this sandbox's kernel offers only cgroup v1, which systemd 259 no longer supports), so MariaDB, nginx and Tomcat were started directly instead of by their units. Everything functional — WAF blocking a probe SQLi with 403, the live DrugRef lookup, 19 Flyway migrations — reports OK.

The check was run against four builds on that install, replacing the deployed JSP and action class to un-fix each shape in turn:

| deployed build | result |
|---|---|
| pre-fix action + pre-fix JSP | **FAIL** — `listPreviousInstructions` answers HTTP 500, no modal opens at all |
| fixed action + pre-fix JSP | **FAIL** — HTTP 200, but the modal body renders nothing readable |
| both fixed, no empty-history row | **FAIL** — a history-less drug renders `ZZ Check Drug … Rx Examples Instruction Special Instruction` and nothing more |
| everything in this PR | **PASS** — 2 previous instructions listed, selection applied, history-less drug says so in words, unresolvable id answers 200 with the unavailable state |

The second run also corrected the check itself: asserting "the modal body is not empty" passes on a modal that rendered nothing, because the response-rewriting filters inject their logout-broadcast `<script>` into every HTML response. The check now strips script and style before measuring.

Adjacent Rx surfaces on the same install: `drug-search` PASS (47 results), `allergy-rx-alert` PASS, `prescription-signature` PASS, `application-health` PASS.

**Note for reviewers:** on a healthy install the everyday path already worked — the staged-prescription lookup passed even on the fully un-fixed build. What remained broken were the unresolvable-stash case (a stale Rx window, a prescription removed in another tab, a session whose stash was cleared), which answered 500, and the history-less drug, which rendered an empty table. This matches the report on #955 that the defect was there but hard to reproduce by hand.

## Screenshots

Captured by the check on the packaged install:

- `rx-med-history-modal.png` — the "Test2 Rx Examples" window listing two clickable previous instructions, with the chosen one written back into the Instructions field.
- `rx-med-history-no-history.png` — a drug with no prescribing history now reading "No previous instructions recorded for this medication." instead of an empty table.
- `rx-med-history-unavailable.png` — the unresolvable-id path showing "Medication history is unavailable." with its close control, where the old build showed a blank white box.

## Checklist

- [ ] **My commits are signed off for the [DCO](https://developercertificate.org/)** — they are **not**; none of the three commits carries a `Signed-off-by` trailer, so the DCO check will fail. Adding it means rewriting and force-pushing this branch, which the repository's Claude guardrails block, so it needs a maintainer decision: either authorise that rewrite, or post the documented confirmation comment (`Confirming DCO sign off for all commits at 39c616da5005039256b689ac7a340c9e5ccd08ea`), which `.github/workflows/dco-check.yml` accepts from an OWNER/MEMBER/COLLABORATOR.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
- [x] I preserved the target branch version/SCM metadata
- [x] I did not modify a Flyway migration that exists in a published release tag

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENQTPcn5MRSJdBM7dGGxbc

## Summary by Sourcery

Fix the Rx previous-instructions modal so stale or empty prescription history requests provide reliable, actionable feedback instead of rendering nothing.

Bug Fixes:
- Prevent the previous-instructions action from failing on missing, invalid, or stale prescription identifiers and return an explicit unavailable state instead.
- Show clear empty states when medication history is unavailable or no previous instructions are recorded, preventing blank Rx history modals.
- Restore and verify selection of previous instructions from the modal into staged prescriptions.

Enhancements:
- Make the medication-history modal close control keyboard-accessible and improve handling of empty or malformed history data.

Documentation:
- Document the requirement that the Rx medication-history browser check use a patient with an existing prescription.

Tests:
- Add unit coverage for invalid, missing, whitespace-padded, and valid prescription identifiers.
- Add a Playwright regression check covering existing history, history-less drugs, instruction selection, and unresolvable prescriptions.